### PR TITLE
Make client names clickable in tables

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -43,6 +43,7 @@ interface WorkActivityStats {
     date: string;
     workType: string;
     clientName: string;
+    clientId?: number;
     totalHours: number;
     status: string;
   }>;
@@ -112,6 +113,7 @@ const Dashboard: React.FC = () => {
             date: activity.date,
             workType: activity.workType,
             clientName: activity.clientName || 'No Client',
+            clientId: activity.clientId,
             totalHours: activity.totalHours,
             status: activity.status,
           }));
@@ -385,9 +387,32 @@ const Dashboard: React.FC = () => {
                             </Box>
                           }
                           secondary={
-                            <Box>
-                              <Typography variant="body2" color="text.secondary">
-                                {activity.clientName} • {formatDate(activity.date)} • {activity.totalHours}h
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              {activity.clientId && activity.clientName !== 'No Client' ? (
+                                <Button 
+                                  variant="text" 
+                                  onClick={() => navigate(`/clients/${activity.clientId}`)}
+                                  sx={{ 
+                                    minHeight: 'auto',
+                                    p: 0,
+                                    textTransform: 'none',
+                                    fontSize: '0.875rem',
+                                    color: 'text.secondary',
+                                    '&:hover': {
+                                      color: 'primary.main',
+                                      backgroundColor: 'transparent'
+                                    }
+                                  }}
+                                >
+                                  {activity.clientName}
+                                </Button>
+                              ) : (
+                                <Typography component="span" variant="body2" color="text.secondary">
+                                  {activity.clientName}
+                                </Typography>
+                              )}
+                              <Typography component="span" variant="body2" color="text.secondary">
+                                • {formatDate(activity.date)} • {activity.totalHours}h
                               </Typography>
                             </Box>
                           }

--- a/src/components/ProjectManagement.tsx
+++ b/src/components/ProjectManagement.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Box,
   Paper,
@@ -53,6 +54,7 @@ const PROJECT_STATUSES = [
 ];
 
 const ProjectManagement: React.FC = () => {
+  const navigate = useNavigate();
   const [projects, setProjects] = useState<Project[]>([]);
   const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(true);
@@ -222,7 +224,27 @@ const ProjectManagement: React.FC = () => {
                     {project.name}
                   </Typography>
                 </TableCell>
-                <TableCell>{project.clientName}</TableCell>
+                <TableCell>
+                  {project.clientId ? (
+                    <Button 
+                      variant="text" 
+                      onClick={() => navigate(`/clients/${project.clientId}`)}
+                      sx={{ 
+                        textAlign: 'left', 
+                        justifyContent: 'flex-start', 
+                        textTransform: 'none',
+                        minHeight: 'auto',
+                        p: 0
+                      }}
+                    >
+                      {project.clientName}
+                    </Button>
+                  ) : (
+                    <Typography variant="body2">
+                      {project.clientName || 'No Client'}
+                    </Typography>
+                  )}
+                </TableCell>
                 <TableCell>
                   <Chip
                     label={project.status.replace('_', ' ').toUpperCase()}

--- a/src/components/WorkActivityManagement.tsx
+++ b/src/components/WorkActivityManagement.tsx
@@ -34,7 +34,7 @@ import {
 } from '@mui/icons-material';
 import { Client } from '../services/api';
 import { API_ENDPOINTS, apiClient } from '../config/api';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Editor } from 'react-draft-wysiwyg';
 import { EditorState, convertToRaw, ContentState } from 'draft-js';
 import draftToHtml from 'draftjs-to-html';
@@ -100,6 +100,7 @@ const WORK_STATUSES = [
 
 const WorkActivityManagement: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   const [workActivities, setWorkActivities] = useState<WorkActivity[]>([]);
   const [clients, setClients] = useState<Client[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -408,9 +409,26 @@ const WorkActivityManagement: React.FC = () => {
       sortable: true,
       render: (activity) => (
         <Box>
-          <Typography variant="body2" sx={{ fontWeight: 600 }}>
-            {activity.clientName || 'No Client'}
-          </Typography>
+          {activity.clientName && activity.clientId ? (
+            <Button 
+              variant="text" 
+              onClick={() => navigate(`/clients/${activity.clientId}`)}
+              sx={{ 
+                textAlign: 'left', 
+                justifyContent: 'flex-start', 
+                textTransform: 'none',
+                fontWeight: 600,
+                minHeight: 'auto',
+                p: 0
+              }}
+            >
+              {activity.clientName}
+            </Button>
+          ) : (
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {activity.clientName || 'No Client'}
+            </Typography>
+          )}
           {activity.projectName && (
             <Typography variant="caption" color="text.secondary">
               {activity.projectName}


### PR DESCRIPTION
Client names were made clickable across several table views to enable direct navigation to client detail pages.

*   In `WorkActivityManagement.tsx` and `ProjectManagement.tsx`:
    *   `useNavigate` was imported from `react-router-dom` and initialized.
    *   The rendering logic for the client name columns was updated.
    *   Client names are now rendered as `Button` components.
    *   Clicking a client name navigates to `/clients/${clientId}`.
    *   Conditional rendering ensures names are only clickable if a `clientId` exists, otherwise they appear as plain text (e.g., "No Client").

*   In `Dashboard.tsx`:
    *   The `WorkActivityStats` interface was extended to include an optional `clientId`.
    *   The data mapping for recent activities was updated to include the `clientId`.
    *   Client names in the recent activities list are now rendered as `Button` components.
    *   Navigation to `/clients/${clientId}` occurs on click, provided a `clientId` exists and the client name is not "No Client".
    *   Styling was applied to ensure consistent appearance.

These changes enhance user experience by providing consistent, intuitive navigation from client names in various tables to their respective detail pages.