### PR TITLE
Disable claude's PR review functionality

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,75 +1,76 @@
-name: Claude Code Review
+# DISABLED - Claude PR review functionality disabled by user request
+# name: Claude Code Review
 
-on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+# on:
+#   pull_request:
+#     types: [opened, synchronize]
+#     # Optional: Only run on specific file changes
+#     # paths:
+#     #   - "src/**/*.ts"
+#     #   - "src/**/*.tsx"
+#     #   - "src/**/*.js"
+#     #   - "src/**/*.jsx"
 
-jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+# jobs:
+#   claude-review:
+#     # Optional: Filter by PR author
+#     # if: |
+#     #   github.event.pull_request.user.login == 'external-contributor' ||
+#     #   github.event.pull_request.user.login == 'new-developer' ||
+#     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+#     
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       pull-requests: read
+#       issues: read
+#       id-token: write
+#     
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+#       - name: Run Claude Code Review
+#         id: claude-review
+#         uses: anthropics/claude-code-action@beta
+#         with:
+#           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+#           
+#           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+#           # model: "claude-opus-4-20250514"
+#           
+#           # Direct prompt for automated review (no @claude mention needed)
+#           direct_prompt: |
+#             Please review this pull request and provide feedback on:
+#             - Code quality and best practices
+#             - Potential bugs or issues
+#             - Performance considerations
+#             - Security concerns
+#             - Test coverage
+#             
+#             Be constructive and helpful in your feedback.
+#           
+#           # Optional: Customize review based on file types
+#           # direct_prompt: |
+#           #   Review this PR focusing on:
+#           #   - For TypeScript files: Type safety and proper interface usage
+#           #   - For API endpoints: Security, input validation, and error handling
+#           #   - For React components: Performance, accessibility, and best practices
+#           #   - For tests: Coverage, edge cases, and test quality
+#           
+#           # Optional: Different prompts for different authors
+#           # direct_prompt: |
+#           #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+#           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
+#           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
+#           
+#           # Optional: Add specific tools for running tests or linting
+#           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+#           
+#           # Optional: Skip review for certain conditions
+#           # if: |
+#           #   !contains(github.event.pull_request.title, '[skip-review]') &&
+#           #   !contains(github.event.pull_request.title, '[WIP]')
 


### PR DESCRIPTION
## Description
This PR disables the automatic Claude PR review functionality.

The `.github/workflows/claude-code-review.yml` workflow, responsible for automatic PR reviews, has been entirely commented out. This prevents Claude from automatically reviewing new or updated pull requests. The workflow file is preserved and commented out to allow for easy re-enablement in the future if desired.

The manual `@claude` mention functionality in `.github/workflows/claude.yml` remains active.
