### PR TITLE
feat: Unify work activities table views with enhanced features

### DIFF
--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -7,12 +7,6 @@ import {
   Grid,
   Chip,
   Button,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Card,
   CardContent,
   Divider,
@@ -34,7 +28,6 @@ import {
   FormControl,
   InputLabel,
   Snackbar,
-  IconButton,
 } from '@mui/material';
 import {
   ArrowBack as ArrowBackIcon,
@@ -44,11 +37,11 @@ import {
   AttachMoney as MoneyIcon,
   ExpandMore as ExpandMoreIcon,
   Edit as EditIcon,
-  Delete as DeleteIcon,
   LocationOn as LocationIcon,
   Flag as PriorityIcon,
   CalendarToday as CalendarIcon,
 } from '@mui/icons-material';
+import { WorkActivitiesTable } from './WorkActivitiesTable';
 
 interface Client {
   id: number;
@@ -145,8 +138,7 @@ const ClientDetail: React.FC = () => {
   const [selectedWorkActivity, setSelectedWorkActivity] = useState<WorkActivity | null>(null);
   const [workActivityFormData, setWorkActivityFormData] = useState<Partial<WorkActivity>>({});
   
-  // Expanded rows state
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+
 
   useEffect(() => {
     const fetchClientData = async () => {
@@ -310,17 +302,7 @@ const ClientDetail: React.FC = () => {
     }
   };
 
-  const toggleRowExpansion = (activityId: number) => {
-    setExpandedRows(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(activityId)) {
-        newSet.delete(activityId);
-      } else {
-        newSet.add(activityId);
-      }
-      return newSet;
-    });
-  };
+
 
   if (loading) {
     return (
@@ -535,125 +517,13 @@ const ClientDetail: React.FC = () => {
             <Typography variant="h5" gutterBottom>Work Activities</Typography>
             <Divider sx={{ mb: 2 }} />
             
-            {workActivities.length === 0 ? (
-              <Alert severity="info">No work activities found for this client.</Alert>
-            ) : (
-              <TableContainer sx={{ overflowX: 'auto' }}>
-                <Table sx={{ minWidth: 800 }}>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell sx={{ width: '10%' }}>Date</TableCell>
-                      <TableCell sx={{ width: '10%' }}>Type</TableCell>
-                      <TableCell sx={{ width: '10%' }}>Status</TableCell>
-                      <TableCell sx={{ width: '12%' }}>Time</TableCell>
-                      <TableCell sx={{ width: '8%' }}>Hours</TableCell>
-                      <TableCell sx={{ width: '20%' }}>Employees</TableCell>
-                      <TableCell sx={{ width: '10%' }}>Charges</TableCell>
-                      <TableCell sx={{ width: '10%' }}>Notes/Tasks</TableCell>
-                      <TableCell sx={{ width: '10%', textAlign: 'center' }}>Actions</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {workActivities.map((activity) => (
-                      <React.Fragment key={activity.id}>
-                        <TableRow sx={{ '&:nth-of-type(odd)': { backgroundColor: 'action.hover' } }}>
-                          <TableCell>{formatDate(activity.date)}</TableCell>
-                          <TableCell>
-                            <Chip label={activity.workType} size="small" />
-                          </TableCell>
-                          <TableCell>
-                            <Chip 
-                              label={activity.status} 
-                              color={getStatusColor(activity.status) as any} 
-                              size="small" 
-                            />
-                          </TableCell>
-                          <TableCell>
-                            {activity.startTime && activity.endTime 
-                              ? `${activity.startTime} - ${activity.endTime}`
-                              : '-'
-                            }
-                          </TableCell>
-                          <TableCell sx={{ fontWeight: 600 }}>{activity.totalHours}h</TableCell>
-                          <TableCell>
-                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                              {activity.employeesList.map((emp, index) => (
-                                <Chip 
-                                  key={index}
-                                  label={emp.employeeName || 'Unknown'}
-                                  size="small"
-                                  variant="outlined"
-                                  sx={{ fontSize: '0.75rem', height: '24px' }}
-                                />
-                              ))}
-                            </Box>
-                          </TableCell>
-                          <TableCell>{formatCurrency(activity.totalCharges)}</TableCell>
-                          <TableCell>
-                            {(activity.notes || activity.tasks) ? (
-                              <Button 
-                                variant="text" 
-                                size="small" 
-                                onClick={() => toggleRowExpansion(activity.id)}
-                                sx={{ minWidth: 'auto', p: 0.5 }}
-                              >
-                                {expandedRows.has(activity.id) ? 'Hide' : 'View'}
-                              </Button>
-                            ) : (
-                              <Typography variant="body2" color="text.secondary">-</Typography>
-                            )}
-                          </TableCell>
-                          <TableCell sx={{ textAlign: 'center' }}>
-                            <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'center' }}>
-                              <IconButton onClick={() => handleWorkActivityEdit(activity)} size="small" color="primary">
-                                <EditIcon />
-                              </IconButton>
-                              <IconButton onClick={() => handleWorkActivityDelete(activity)} size="small" color="error">
-                                <DeleteIcon />
-                              </IconButton>
-                            </Box>
-                          </TableCell>
-                        </TableRow>
-                        {expandedRows.has(activity.id) && (activity.notes || activity.tasks) && (
-                          <TableRow>
-                            <TableCell colSpan={9} sx={{ p: 0, borderBottom: 'none' }}>
-                              <Box sx={{ p: 3, backgroundColor: 'grey.50', borderRadius: 1, m: 1 }}>
-                                <Grid container spacing={3}>
-                                  {activity.notes && (
-                                    <Grid item xs={12} md={6}>
-                                      <Box>
-                                        <Typography variant="h6" gutterBottom sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 1 }}>
-                                          📝 Notes
-                                        </Typography>
-                                        <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>
-                                          {activity.notes}
-                                        </Typography>
-                                      </Box>
-                                    </Grid>
-                                  )}
-                                  {activity.tasks && (
-                                    <Grid item xs={12} md={activity.notes ? 6 : 12}>
-                                      <Box>
-                                        <Typography variant="h6" gutterBottom sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 1 }}>
-                                          ✓ Tasks
-                                        </Typography>
-                                        <Typography variant="body1" component="pre" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>
-                                          {activity.tasks}
-                                        </Typography>
-                                      </Box>
-                                    </Grid>
-                                  )}
-                                </Grid>
-                              </Box>
-                            </TableCell>
-                          </TableRow>
-                        )}
-                      </React.Fragment>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            )}
+            <WorkActivitiesTable
+              activities={workActivities}
+              onEdit={handleWorkActivityEdit}
+              onDelete={handleWorkActivityDelete}
+              showClientColumn={false}
+              emptyMessage="No work activities found for this client."
+            />
           </Paper>
         </Grid>
       </Grid>

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -191,16 +191,6 @@ const ClientDetail: React.FC = () => {
     }
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'completed': return 'success';
-      case 'in_progress': return 'primary';
-      case 'planned': return 'warning';
-      case 'invoiced': return 'secondary';
-      default: return 'default';
-    }
-  };
-
   const handleEdit = () => {
     if (client) {
       setFormData(client);

--- a/src/components/WorkActivitiesTable.tsx
+++ b/src/components/WorkActivitiesTable.tsx
@@ -1,0 +1,352 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Chip,
+  IconButton,
+  Grid,
+  Paper,
+} from '@mui/material';
+import {
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  Person as PersonIcon,
+  AccessTime as TimeIcon,
+  Update as UpdateIcon,
+} from '@mui/icons-material';
+
+interface WorkActivity {
+  id: number;
+  workType: string;
+  date: string;
+  status: string;
+  startTime: string | null;
+  endTime: string | null;
+  billableHours: number | null;
+  totalHours: number;
+  hourlyRate: number | null;
+  projectId?: number;
+  clientId?: number;
+  travelTimeMinutes?: number;
+  breakTimeMinutes?: number;
+  notes: string | null;
+  tasks: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  notionPageId?: string;
+  lastNotionSyncAt?: string;
+  lastUpdatedBy?: 'web_app' | 'notion_sync';
+  clientName?: string | null;
+  projectName?: string | null;
+  employeesList: Array<{ employeeId: number; employeeName: string | null; hours: number }>;
+  chargesList: Array<any>;
+  totalCharges: number;
+}
+
+interface WorkActivitiesTableProps {
+  activities: WorkActivity[];
+  onEdit?: (activity: WorkActivity) => void;
+  onDelete?: (activity: WorkActivity) => void;
+  showClientColumn?: boolean;
+  emptyMessage?: string;
+}
+
+export const WorkActivitiesTable: React.FC<WorkActivitiesTableProps> = ({
+  activities,
+  onEdit,
+  onDelete,
+  showClientColumn = true,
+  emptyMessage = "No work activities found"
+}) => {
+  const navigate = useNavigate();
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      timeZone: 'America/Los_Angeles',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+  };
+
+  const formatTimestamp = (timestamp?: string) => {
+    if (!timestamp) return 'Never';
+    const date = new Date(timestamp);
+    return `${date.toLocaleDateString('en-US', {
+      timeZone: 'America/Los_Angeles',
+      month: 'short',
+      day: 'numeric',
+      year: '2-digit'
+    })} ${date.toLocaleTimeString('en-US', { 
+      timeZone: 'America/Los_Angeles',
+      hour: '2-digit', 
+      minute: '2-digit' 
+    })}`;
+  };
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount);
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'completed': return 'success';
+      case 'in_progress': return 'warning';
+      case 'planned': return 'info';
+      case 'invoiced': return 'primary';
+      case 'cancelled': return 'error';
+      default: return 'default';
+    }
+  };
+
+  const toggleRowExpansion = (activityId: number) => {
+    const newExpanded = new Set(expandedRows);
+    if (newExpanded.has(activityId)) {
+      newExpanded.delete(activityId);
+    } else {
+      newExpanded.add(activityId);
+    }
+    setExpandedRows(newExpanded);
+  };
+
+  if (activities.length === 0) {
+    return (
+      <Paper sx={{ p: 3, textAlign: 'center' }}>
+        <Typography variant="body1" color="text.secondary">
+          {emptyMessage}
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
+      <Table sx={{ minWidth: 800 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: '10%' }}>Date</TableCell>
+            <TableCell sx={{ width: '10%' }}>Type</TableCell>
+            <TableCell sx={{ width: '10%' }}>Status</TableCell>
+            {showClientColumn && (
+              <TableCell sx={{ width: '12%' }}>Client</TableCell>
+            )}
+            <TableCell sx={{ width: '12%' }}>Time</TableCell>
+            <TableCell sx={{ width: '8%' }}>Hours</TableCell>
+            <TableCell sx={{ width: '20%' }}>Employees</TableCell>
+            <TableCell sx={{ width: '10%' }}>Charges</TableCell>
+            <TableCell sx={{ width: '15%' }}>Last Updated</TableCell>
+            <TableCell sx={{ width: '10%' }}>Notes/Tasks</TableCell>
+            {(onEdit || onDelete) && (
+              <TableCell sx={{ width: '10%', textAlign: 'center' }}>Actions</TableCell>
+            )}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {activities.map((activity) => (
+            <React.Fragment key={activity.id}>
+              <TableRow sx={{ '&:nth-of-type(odd)': { backgroundColor: 'action.hover' } }}>
+                <TableCell>{formatDate(activity.date)}</TableCell>
+                <TableCell>
+                  <Chip 
+                    label={activity.workType.replace('_', ' ').toUpperCase()} 
+                    size="small" 
+                    variant="outlined"
+                  />
+                </TableCell>
+                <TableCell>
+                  <Chip 
+                    label={activity.status.replace('_', ' ').toUpperCase()} 
+                    color={getStatusColor(activity.status) as any} 
+                    size="small" 
+                  />
+                </TableCell>
+                {showClientColumn && (
+                  <TableCell>
+                    {activity.clientName && activity.clientId ? (
+                      <Button 
+                        variant="text" 
+                        onClick={() => navigate(`/clients/${activity.clientId}`)}
+                        sx={{ 
+                          textAlign: 'left', 
+                          justifyContent: 'flex-start', 
+                          textTransform: 'none',
+                          fontWeight: 600,
+                          minHeight: 'auto',
+                          p: 0,
+                          fontSize: '0.875rem'
+                        }}
+                      >
+                        {activity.clientName}
+                      </Button>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        No Client
+                      </Typography>
+                    )}
+                    {activity.projectName && (
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        {activity.projectName}
+                      </Typography>
+                    )}
+                  </TableCell>
+                )}
+                <TableCell>
+                  {activity.startTime && activity.endTime 
+                    ? `${activity.startTime} - ${activity.endTime}`
+                    : '-'
+                  }
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <TimeIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {activity.totalHours.toFixed(1)}h
+                    </Typography>
+                    {activity.billableHours && activity.billableHours !== activity.totalHours && (
+                      <Typography variant="caption" color="text.secondary">
+                        ({activity.billableHours.toFixed(1)}h bill)
+                      </Typography>
+                    )}
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                    {activity.employeesList.map((emp, index) => (
+                      <Chip 
+                        key={index}
+                        label={`${emp.employeeName || 'Unknown'} (${emp.hours.toFixed(1)}h)`}
+                        size="small"
+                        icon={<PersonIcon sx={{ fontSize: 14 }} />}
+                        variant="outlined"
+                        sx={{ fontSize: '0.75rem', height: '24px' }}
+                      />
+                    ))}
+                  </Box>
+                </TableCell>
+                <TableCell>{formatCurrency(activity.totalCharges)}</TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+                    <UpdateIcon sx={{ fontSize: 14, color: 'text.secondary', mt: 0.1 }} />
+                    <Box>
+                      <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
+                        {formatTimestamp(activity.updatedAt)}
+                      </Typography>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+                          by {activity.lastUpdatedBy === 'web_app' ? 'User' : 'Notion Sync'}
+                        </Typography>
+                        {activity.lastUpdatedBy === 'web_app' && (
+                          <Chip 
+                            label="🛡️" 
+                            size="small" 
+                            variant="outlined"
+                            sx={{ 
+                              fontSize: '0.6rem', 
+                              height: '16px',
+                              minWidth: '16px',
+                              '& .MuiChip-label': { px: 0.5 },
+                              color: 'warning.main',
+                              borderColor: 'warning.main'
+                            }}
+                          />
+                        )}
+                      </Box>
+                    </Box>
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  {(activity.notes || activity.tasks) ? (
+                    <Button 
+                      variant="text" 
+                      size="small" 
+                      onClick={() => toggleRowExpansion(activity.id)}
+                      sx={{ minWidth: 'auto', p: 0.5, fontSize: '0.75rem' }}
+                    >
+                      {expandedRows.has(activity.id) ? 'Hide' : 'View'}
+                    </Button>
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">-</Typography>
+                  )}
+                </TableCell>
+                {(onEdit || onDelete) && (
+                  <TableCell sx={{ textAlign: 'center' }}>
+                    <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'center' }}>
+                      {onEdit && (
+                        <IconButton onClick={() => onEdit(activity)} size="small" color="primary">
+                          <EditIcon sx={{ fontSize: 18 }} />
+                        </IconButton>
+                      )}
+                      {onDelete && (
+                        <IconButton onClick={() => onDelete(activity)} size="small" color="error">
+                          <DeleteIcon sx={{ fontSize: 18 }} />
+                        </IconButton>
+                      )}
+                    </Box>
+                  </TableCell>
+                )}
+              </TableRow>
+              {expandedRows.has(activity.id) && (activity.notes || activity.tasks) && (
+                <TableRow>
+                  <TableCell colSpan={showClientColumn ? (onEdit || onDelete ? 11 : 10) : (onEdit || onDelete ? 10 : 9)} sx={{ p: 0, borderBottom: 'none' }}>
+                    <Box sx={{ p: 3, backgroundColor: 'grey.50', borderRadius: 1, m: 1 }}>
+                      <Grid container spacing={3}>
+                        {activity.notes && (
+                          <Grid item xs={12} md={activity.tasks ? 6 : 12}>
+                            <Box>
+                              <Typography variant="h6" gutterBottom sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 1, fontSize: '1rem' }}>
+                                📝 Notes
+                              </Typography>
+                              <Typography 
+                                variant="body2" 
+                                sx={{ 
+                                  whiteSpace: 'pre-wrap', 
+                                  lineHeight: 1.6,
+                                  fontSize: '0.875rem'
+                                }}
+                                dangerouslySetInnerHTML={{ __html: activity.notes }}
+                              />
+                            </Box>
+                          </Grid>
+                        )}
+                        {activity.tasks && (
+                          <Grid item xs={12} md={activity.notes ? 6 : 12}>
+                            <Box>
+                              <Typography variant="h6" gutterBottom sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 1, fontSize: '1rem' }}>
+                                ✓ Tasks
+                              </Typography>
+                              <Typography 
+                                variant="body2" 
+                                sx={{ 
+                                  whiteSpace: 'pre-wrap', 
+                                  lineHeight: 1.6,
+                                  fontSize: '0.875rem'
+                                }}
+                                dangerouslySetInnerHTML={{ __html: activity.tasks }}
+                              />
+                            </Box>
+                          </Grid>
+                        )}
+                      </Grid>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              )}
+            </React.Fragment>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}; 

--- a/src/components/WorkActivityManagement.tsx
+++ b/src/components/WorkActivityManagement.tsx
@@ -473,44 +473,7 @@ const WorkActivityManagement: React.FC = () => {
     });
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'planned': return 'info';
-      case 'in_progress': return 'primary';
-      case 'completed': return 'success';
-      case 'invoiced': return 'secondary';
-      case 'cancelled': return 'error';
-      default: return 'default';
-    }
-  };
 
-  const formatDate = (dateString: string) => {
-    // Parse the date string as a local date to avoid timezone conversion
-    // dateString is in YYYY-MM-DD format from the database
-    const [year, month, day] = dateString.split('-').map(Number);
-    const date = new Date(year, month - 1, day); // month is 0-indexed
-    return date.toLocaleDateString('en-US', {
-      timeZone: 'America/Los_Angeles', // Force Pacific Time
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric'
-    });
-  };
-
-  const formatTimestamp = (timestamp?: string) => {
-    if (!timestamp) return 'Never';
-    const date = new Date(timestamp);
-    return `${date.toLocaleDateString('en-US', {
-      timeZone: 'America/Los_Angeles',
-      month: 'short',
-      day: 'numeric',
-      year: '2-digit'
-    })} ${date.toLocaleTimeString('en-US', { 
-      timeZone: 'America/Los_Angeles',
-      hour: '2-digit', 
-      minute: '2-digit' 
-    })}`;
-  };
 
 
 

--- a/src/components/WorkActivityManagement.tsx
+++ b/src/components/WorkActivityManagement.tsx
@@ -8,7 +8,7 @@ import {
   DialogContent,
   DialogActions,
   TextField,
-  Chip,
+
   IconButton,
   Alert,
   Snackbar,
@@ -22,45 +22,41 @@ import {
   ListItemText,
   ListItemSecondaryAction,
   Autocomplete,
+  Paper,
 } from '@mui/material';
 import {
-  Edit as EditIcon,
-  Delete as DeleteIcon,
   Add as AddIcon,
   Assignment as AssignmentIcon,
-  AccessTime as TimeIcon,
-  Person as PersonIcon,
   Remove as RemoveIcon,
-  Update as UpdateIcon,
 } from '@mui/icons-material';
 import { Client } from '../services/api';
 import { API_ENDPOINTS, apiClient } from '../config/api';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Editor } from 'react-draft-wysiwyg';
 import { EditorState, convertToRaw, ContentState } from 'draft-js';
 import draftToHtml from 'draftjs-to-html';
 import htmlToDraft from 'html-to-draftjs';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
-import FilterableTable, { FilterConfig, ColumnConfig } from './FilterableTable';
+import { WorkActivitiesTable } from './WorkActivitiesTable';
 
 interface WorkActivity {
   id: number;
   workType: string;
   date: string;
   status: string;
-  startTime?: string;
-  endTime?: string;
-  billableHours?: number;
+  startTime: string | null;
+  endTime: string | null;
+  billableHours: number | null;
   totalHours: number;
-  hourlyRate?: number;
+  hourlyRate: number | null;
   projectId?: number;
   clientId?: number;
   travelTimeMinutes?: number;
   breakTimeMinutes?: number;
-  notes?: string;
-  tasks?: string;
-  createdAt: string;
-  updatedAt: string;
+  notes: string | null;
+  tasks: string | null;
+  createdAt?: string;
+  updatedAt?: string;
   notionPageId?: string;
   lastNotionSyncAt?: string;
   lastUpdatedBy?: 'web_app' | 'notion_sync';
@@ -104,7 +100,6 @@ const WORK_STATUSES = [
 
 const WorkActivityManagement: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
   const [workActivities, setWorkActivities] = useState<WorkActivity[]>([]);
   const [clients, setClients] = useState<Client[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -415,240 +410,18 @@ const WorkActivityManagement: React.FC = () => {
     })}`;
   };
 
-  // Configure table columns
-  const columns: ColumnConfig<WorkActivity>[] = [
-    {
-      key: 'date',
-      label: 'Date',
-      sortable: true,
-      render: (activity) => formatDate(activity.date),
-    },
-    {
-      key: 'workType',
-      label: 'Type',
-      sortable: true,
-      render: (activity) => (
-        <Chip 
-          label={activity.workType.replace('_', ' ').toUpperCase()} 
-          size="small" 
-          variant="outlined"
-        />
-      ),
-    },
-    {
-      key: 'clientName',
-      label: 'Client/Project',
-      sortable: true,
-      render: (activity) => (
-        <Box>
-          {activity.clientName && activity.clientId ? (
-            <Button 
-              variant="text" 
-              onClick={() => navigate(`/clients/${activity.clientId}`)}
-              sx={{ 
-                textAlign: 'left', 
-                justifyContent: 'flex-start', 
-                textTransform: 'none',
-                fontWeight: 600,
-                minHeight: 'auto',
-                p: 0
-              }}
-            >
-              {activity.clientName}
-            </Button>
-          ) : (
-            <Typography variant="body2" sx={{ fontWeight: 600 }}>
-              {activity.clientName || 'No Client'}
-            </Typography>
-          )}
-          {activity.projectName && (
-            <Typography variant="caption" color="text.secondary">
-              {activity.projectName}
-            </Typography>
-          )}
-        </Box>
-      ),
-    },
-    {
-      key: 'employeesList',
-      label: 'Employees',
-      render: (activity) => (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-          {activity.employeesList.map((emp) => (
-            <Chip 
-              key={emp.employeeId}
-              label={`${emp.employeeName || 'Unknown'} (${emp.hours.toFixed(2)}h)`}
-              size="small"
-              icon={<PersonIcon />}
-            />
-          ))}
-        </Box>
-      ),
-    },
-    {
-      key: 'totalHours',
-      label: 'Hours',
-      sortable: true,
-      render: (activity) => (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <TimeIcon fontSize="small" />
-          <Typography variant="body2">
-            {activity.totalHours.toFixed(2)}h
-            {activity.billableHours && activity.billableHours !== activity.totalHours && (
-              <Typography component="span" variant="caption" color="text.secondary">
-                {' '}({activity.billableHours.toFixed(2)}h billable)
-              </Typography>
-            )}
-          </Typography>
-        </Box>
-      ),
-    },
-    {
-      key: 'updatedAt',
-      label: 'Last Updated',
-      sortable: true,
-      render: (activity) => (
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
-          <UpdateIcon sx={{ fontSize: '0.875rem', color: 'text.secondary', mt: 0.1 }} />
-          <Box>
-            <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-              {formatTimestamp(activity.updatedAt)}
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
-              <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-                by {activity.lastUpdatedBy === 'web_app' ? 'User' : 'Notion Sync'}
-              </Typography>
-              {activity.lastUpdatedBy === 'web_app' && (
-                <Chip 
-                  label="🛡️ Protected" 
-                  size="small" 
-                  variant="outlined"
-                  sx={{ 
-                    fontSize: '0.6rem', 
-                    height: '16px',
-                    '& .MuiChip-label': { px: 0.5 },
-                    color: 'warning.main',
-                    borderColor: 'warning.main'
-                  }}
-                />
-              )}
-            </Box>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-              Created: {formatTimestamp(activity.createdAt)}
-            </Typography>
-          </Box>
-        </Box>
-      ),
-    },
-    {
-      key: 'status',
-      label: 'Status',
-      sortable: true,
-      render: (activity) => (
-        <Chip
-          label={activity.status.replace('_', ' ').toUpperCase()}
-          color={getStatusColor(activity.status) as any}
-          size="small"
-        />
-      ),
-    },
-  ];
 
-  // Configure filters
-  const filters: FilterConfig[] = [
-    {
-      key: 'date',
-      label: 'Date Range',
-      type: 'daterange',
-    },
-    {
-      key: 'clientName',
-      label: 'Client',
-      type: 'autocomplete',
-      options: clients.map(client => ({ value: client.name, label: client.name })),
-      getOptionLabel: (option) => option || 'No Client',
-    },
-    {
-      key: 'status',
-      label: 'Status',
-      type: 'multiselect',
-      options: WORK_STATUSES.map(status => ({
-        value: status,
-        label: status.replace('_', ' ').toUpperCase()
-      })),
-    },
-    {
-      key: 'employeesList',
-      label: 'Employees',
-      type: 'autocomplete',
-      options: employees.map(emp => ({ value: { employeeName: emp.name, employeeId: emp.id }, label: emp.name })),
-      getOptionLabel: (option) => option?.employeeName || 'Unknown',
-    },
-    {
-      key: 'workType',
-      label: 'Work Type',
-      type: 'multiselect',
-      options: WORK_TYPES.map(type => ({
-        value: type,
-        label: type.replace('_', ' ').toUpperCase()
-      })),
-    },
-    {
-      key: 'notionPageId',
-      label: 'Notion Page ID',
-      type: 'text',
-    },
-  ];
-
-  // Handle table actions
-  const handleRowAction = (action: string, activity: WorkActivity) => {
-    switch (action) {
-      case 'edit':
-        handleEdit(activity);
-        break;
-      case 'delete':
-        handleDelete(activity);
-        break;
-      default:
-        break;
-    }
-  };
-
-  const tableActions = [
-    {
-      key: 'edit',
-      label: 'Edit',
-      icon: <EditIcon />,
-      color: 'default' as const,
-    },
-    {
-      key: 'delete',
-      label: 'Delete',
-      icon: <DeleteIcon />,
-      color: 'error' as const,
-    },
-  ];
 
   if (loading) return <Typography>Loading work activities...</Typography>;
 
   return (
     <Box sx={{ p: 3 }}>
-      <FilterableTable
-        data={workActivities}
-        columns={columns}
-        filters={filters}
-        onRowAction={handleRowAction}
-        actions={tableActions}
-        initialSortBy="date"
-        initialSortOrder="desc"
-        rowKeyField="id"
-        emptyMessage="No work activities found"
-        title={
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      {/* Header */}
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h4" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <AssignmentIcon /> Work Activity Management
-          </Box>
-        }
-        headerActions={
+          </Typography>
           <Button
             variant="contained"
             startIcon={<AddIcon />}
@@ -656,7 +429,16 @@ const WorkActivityManagement: React.FC = () => {
           >
             Log Work Activity
           </Button>
-        }
+        </Box>
+      </Paper>
+
+      {/* Work Activities Table */}
+      <WorkActivitiesTable
+        activities={workActivities}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        showClientColumn={true}
+        emptyMessage="No work activities found"
       />
 
       {/* Edit/Create Dialog */}


### PR DESCRIPTION
- Create reusable WorkActivitiesTable component that combines best features from both global and client views
- Display employee names with individual hours (e.g., 'Andrea Wilson (3.5h)')
- Add view/hide toggle for expandable notes/tasks with clean UI
- Show last updated timestamp and source (User vs Notion Sync)
- Remove created date from display as requested
- Support flexible client column visibility based on context
- Replace FilterableTable usage in WorkActivityManagement with new unified component
- Update ClientDetail to use new table component
- Maintain all existing functionality (edit, delete, navigation)
- Ensure consistent Material-UI styling across all views

This provides a unified, professional work activities display across the application with enhanced readability and consistent user experience.
