### PR TITLE
Adjust date displays to Pacific time

### DIFF
--- a/server/src/services/AnthropicService.ts
+++ b/server/src/services/AnthropicService.ts
@@ -552,9 +552,21 @@ export class AnthropicService {
             recentEventsSection += '**This Week:**\n';
             thisWeekEvents.forEach(e => {
               const date = new Date(e.start);
-              const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
-              const dateStr = date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' });
-              const timeStr = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: false });
+              const dayName = date.toLocaleDateString('en-US', { 
+                timeZone: 'America/Los_Angeles',
+                weekday: 'short' 
+              });
+              const dateStr = date.toLocaleDateString('en-US', { 
+                timeZone: 'America/Los_Angeles',
+                month: 'numeric', 
+                day: 'numeric' 
+              });
+              const timeStr = date.toLocaleTimeString('en-US', { 
+                timeZone: 'America/Los_Angeles',
+                hour: 'numeric', 
+                minute: '2-digit', 
+                hour12: false 
+              });
               const title = e.title || 'Untitled';
               recentEventsSection += `- ${dayName} ${dateStr}: ${timeStr} ${title}\n`;
             });
@@ -564,9 +576,21 @@ export class AnthropicService {
             recentEventsSection += '\n**Next Week:**\n';
             nextWeekEvents.forEach(e => {
               const date = new Date(e.start);
-              const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
-              const dateStr = date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' });
-              const timeStr = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: false });
+              const dayName = date.toLocaleDateString('en-US', { 
+                timeZone: 'America/Los_Angeles',
+                weekday: 'short' 
+              });
+              const dateStr = date.toLocaleDateString('en-US', { 
+                timeZone: 'America/Los_Angeles',
+                month: 'numeric', 
+                day: 'numeric' 
+              });
+              const timeStr = date.toLocaleTimeString('en-US', { 
+                timeZone: 'America/Los_Angeles',
+                hour: 'numeric', 
+                minute: '2-digit', 
+                hour12: false 
+              });
               const title = e.title || 'Untitled';
               recentEventsSection += `- ${dayName} ${dateStr}: ${timeStr} ${title}\n`;
             });
@@ -597,7 +621,9 @@ export class AnthropicService {
           if (upcoming.length > 0) {
             maintenanceSection += `**Next due:** ${upcoming.map((m: any) => {
               const clientName = m.clientName || 'Unknown';
-              const nextDue = m.nextDue ? new Date(m.nextDue).toLocaleDateString() : 'Unknown';
+              const nextDue = m.nextDue ? new Date(m.nextDue).toLocaleDateString('en-US', {
+                timeZone: 'America/Los_Angeles'
+              }) : 'Unknown';
               return `${clientName} (${nextDue})`;
             }).join(', ')}\n`;
           }
@@ -612,6 +638,7 @@ export class AnthropicService {
       }
 
       const currentDate = new Date().toLocaleDateString('en-US', { 
+        timeZone: 'America/Los_Angeles',
         weekday: 'long', 
         year: 'numeric', 
         month: 'long', 

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -323,7 +323,9 @@ export class InvoiceService extends DatabaseService {
   }
 
   private buildServiceDescription(workType: string, activities: any[]): string {
-    const dates = activities.map(a => new Date(a.date).toLocaleDateString()).join(', ');
+    const dates = activities.map(a => new Date(a.date).toLocaleDateString('en-US', {
+      timeZone: 'America/Los_Angeles'
+    })).join(', ');
     const totalHours = activities.reduce((sum, a) => sum + (a.billableHours || a.totalHours || 0), 0);
     
     return `${this.formatWorkType(workType)} - ${totalHours} hours (${dates})`;

--- a/server/src/services/SchedulingService.ts
+++ b/server/src/services/SchedulingService.ts
@@ -94,7 +94,10 @@ export class SchedulingService {
     const currentDate = new Date(start);
     
     while (currentDate <= end) {
-      const dayName = currentDate.toLocaleDateString('en-US', { weekday: 'long' });
+      const dayName = currentDate.toLocaleDateString('en-US', { 
+      timeZone: 'America/Los_Angeles',
+      weekday: 'long' 
+    });
       const isWorkday = helper.workdays.includes(dayName);
       
       if (isWorkday) {

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -45,6 +45,7 @@ import {
 } from '@mui/icons-material';
 import { WorkActivitiesTable } from './WorkActivitiesTable';
 import WorkActivityEditDialog from './WorkActivityEditDialog';
+import { formatDatePacific } from '../utils/dateUtils';
 
 interface Client {
   id: number;
@@ -235,10 +236,7 @@ const ClientDetail: React.FC = () => {
     }
   }, [id]);
 
-  const formatDate = (dateString: string | null | undefined) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString();
-  };
+
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
@@ -336,7 +334,7 @@ const ClientDetail: React.FC = () => {
   };
 
   const handleWorkActivityDelete = async (activity: WorkActivity) => {
-    if (window.confirm(`Are you sure you want to delete this ${activity.workType} activity from ${formatDate(activity.date)}?`)) {
+    if (window.confirm(`Are you sure you want to delete this ${activity.workType} activity from ${formatDatePacific(activity.date)}?`)) {
       try {
         const response = await fetch(`/api/work-activities/${activity.id}`, {
           method: 'DELETE',
@@ -366,11 +364,13 @@ const ClientDetail: React.FC = () => {
     const date = new Date(dateString);
     return {
       date: date.toLocaleDateString('en-US', { 
+        timeZone: 'America/Los_Angeles',
         weekday: 'short',
         month: 'short', 
         day: 'numeric' 
       }),
       time: date.toLocaleTimeString('en-US', { 
+        timeZone: 'America/Los_Angeles',
         hour: 'numeric',
         minute: '2-digit',
         hour12: true
@@ -603,13 +603,13 @@ const ClientDetail: React.FC = () => {
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <CalendarIcon color="action" />
                       <Typography variant="body2" color="text.secondary">Last Maintenance:</Typography>
-                      <Typography variant="body1">{formatDate(client.lastMaintenanceDate)}</Typography>
+                      <Typography variant="body1">{formatDatePacific(client.lastMaintenanceDate)}</Typography>
                     </Box>
                     
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <CalendarIcon color="action" />
                       <Typography variant="body2" color="text.secondary">Next Target:</Typography>
-                      <Typography variant="body1">{formatDate(client.nextMaintenanceTarget)}</Typography>
+                      <Typography variant="body1">{formatDatePacific(client.nextMaintenanceTarget)}</Typography>
                     </Box>
                   </>
                 )}
@@ -785,7 +785,7 @@ const ClientDetail: React.FC = () => {
                             />
                             {note.date && (
                               <Typography variant="body2" color="text.secondary">
-                                {formatDate(note.date)}
+                                {formatDatePacific(note.date)}
                               </Typography>
                             )}
                           </Box>
@@ -812,9 +812,9 @@ const ClientDetail: React.FC = () => {
                         {note.content}
                       </Typography>
                       <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                        Created: {formatDate(note.createdAt)}
+                        Created: {formatDatePacific(note.createdAt)}
                         {note.updatedAt !== note.createdAt && (
-                          <span> • Updated: {formatDate(note.updatedAt)}</span>
+                          <span> • Updated: {formatDatePacific(note.updatedAt)}</span>
                         )}
                       </Typography>
                     </Box>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ import {
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS } from '../config/api';
+import { formatDateBriefPacific } from '../utils/dateUtils';
 
 interface WorkActivityStats {
   totalActivities: number;
@@ -212,13 +213,7 @@ const Dashboard: React.FC = () => {
     }
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString([], {
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
+
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
@@ -515,7 +510,7 @@ const Dashboard: React.FC = () => {
                                 </Typography>
                               )}
                               <Typography component="span" variant="body2" color="text.secondary">
-                                • {formatDate(activity.date)} • {activity.totalHours}h
+                                • {formatDateBriefPacific(activity.date)} • {activity.totalHours}h
                               </Typography>
                             </Box>
                           }
@@ -625,7 +620,7 @@ const Dashboard: React.FC = () => {
                             secondary={
                               <Box>
                                 <Typography variant="caption" color="text.secondary">
-                                  {formatDate(activity.date)}
+                                  {formatDateBriefPacific(activity.date)}
                                 </Typography>
                                 {activity.clientName !== 'No Client' && (
                                   <Typography variant="caption" color="text.secondary">

--- a/src/components/EmployeeDetail.tsx
+++ b/src/components/EmployeeDetail.tsx
@@ -48,6 +48,7 @@ import {
   Edit as EditIcon,
   TrendingUp as TrendingUpIcon,
 } from '@mui/icons-material';
+import { formatDatePacific } from '../utils/dateUtils';
 
 interface Employee {
   id: number;
@@ -179,10 +180,7 @@ const EmployeeDetail: React.FC = () => {
     }
   }, [id]);
 
-  const formatDate = (dateString: string | null | undefined) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString();
-  };
+
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -462,7 +460,7 @@ const EmployeeDetail: React.FC = () => {
                   
                   <Box>
                     <Typography variant="body2" color="text.secondary">Last Activity</Typography>
-                    <Typography variant="body1">{formatDate(summary?.lastActivityDate)}</Typography>
+                    <Typography variant="body1">{formatDatePacific(summary?.lastActivityDate)}</Typography>
                   </Box>
                 </Stack>
               </AccordionDetails>
@@ -494,7 +492,7 @@ const EmployeeDetail: React.FC = () => {
                 
                 return (
                   <TableRow key={activity.id}>
-                    <TableCell>{formatDate(activity.date)}</TableCell>
+                    <TableCell>{formatDatePacific(activity.date)}</TableCell>
                     <TableCell>
                       <Chip label={activity.workType} size="small" />
                     </TableCell>

--- a/src/components/ProjectManagement.tsx
+++ b/src/components/ProjectManagement.tsx
@@ -33,6 +33,7 @@ import {
   Work as WorkIcon,
 } from '@mui/icons-material';
 import { Client } from '../services/api';
+import { formatDatePacific } from '../utils/dateUtils';
 
 interface Project {
   id: number;
@@ -183,9 +184,7 @@ const ProjectManagement: React.FC = () => {
     }
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString();
-  };
+
 
   if (loading) return <Typography>Loading projects...</Typography>;
 
@@ -257,7 +256,7 @@ const ProjectManagement: React.FC = () => {
                     {project.description || '-'}
                   </Typography>
                 </TableCell>
-                <TableCell>{formatDate(project.createdAt)}</TableCell>
+                <TableCell>{formatDatePacific(project.createdAt)}</TableCell>
                 <TableCell>
                   <IconButton onClick={() => handleEdit(project)} size="small">
                     <EditIcon />

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -101,7 +101,8 @@ const Schedule: React.FC = () => {
             <Card sx={{ mb: 2 }}>
               <CardContent>
                 <Typography variant="h6" gutterBottom>
-                  {new Date(date).toLocaleDateString([], {
+                  {new Date(date).toLocaleDateString('en-US', {
+                    timeZone: 'America/Los_Angeles',
                     weekday: 'long',
                     month: 'long',
                     day: 'numeric',
@@ -126,11 +127,13 @@ const Schedule: React.FC = () => {
                         secondary={
                           <Box>
                             <Typography variant="body2" color="text.secondary">
-                              {new Date(event.start).toLocaleTimeString([], {
+                              {new Date(event.start).toLocaleTimeString('en-US', {
+                                timeZone: 'America/Los_Angeles',
                                 hour: '2-digit',
                                 minute: '2-digit',
                               })} - {' '}
-                              {new Date(event.end).toLocaleTimeString([], {
+                              {new Date(event.end).toLocaleTimeString('en-US', {
+                                timeZone: 'America/Los_Angeles',
                                 hour: '2-digit',
                                 minute: '2-digit',
                               })}

--- a/src/components/WorkActivitiesTable.tsx
+++ b/src/components/WorkActivitiesTable.tsx
@@ -23,6 +23,7 @@ import {
   AccessTime as TimeIcon,
   Update as UpdateIcon,
 } from '@mui/icons-material';
+import { formatDateShortPacific, formatTimestampPacific } from '../utils/dateUtils';
 
 interface WorkActivity {
   id: number;
@@ -76,29 +77,7 @@ export const WorkActivitiesTable: React.FC<WorkActivitiesTableProps> = ({
   const [sortColumn, setSortColumn] = useState<SortColumn>('date');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      timeZone: 'America/Los_Angeles',
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
 
-  const formatTimestamp = (timestamp?: string) => {
-    if (!timestamp) return 'Never';
-    const date = new Date(timestamp);
-    return `${date.toLocaleDateString('en-US', {
-      timeZone: 'America/Los_Angeles',
-      month: 'short',
-      day: 'numeric',
-      year: '2-digit'
-    })} ${date.toLocaleTimeString('en-US', { 
-      timeZone: 'America/Los_Angeles',
-      hour: '2-digit', 
-      minute: '2-digit' 
-    })}`;
-  };
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -276,7 +255,7 @@ export const WorkActivitiesTable: React.FC<WorkActivitiesTableProps> = ({
           {sortedActivities.map((activity) => (
             <React.Fragment key={activity.id}>
               <TableRow sx={{ '&:nth-of-type(odd)': { backgroundColor: 'action.hover' } }}>
-                <TableCell>{formatDate(activity.date)}</TableCell>
+                <TableCell>{formatDateShortPacific(activity.date)}</TableCell>
                 <TableCell>
                   <Chip 
                     label={activity.workType.replace('_', ' ').toUpperCase()} 
@@ -360,7 +339,7 @@ export const WorkActivitiesTable: React.FC<WorkActivitiesTableProps> = ({
                     <UpdateIcon sx={{ fontSize: 14, color: 'text.secondary', mt: 0.1 }} />
                     <Box>
                       <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
-                        {formatTimestamp(activity.updatedAt)}
+                        {formatTimestampPacific(activity.updatedAt)}
                       </Typography>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
                         <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>

--- a/src/components/WorkActivityDetail.tsx
+++ b/src/components/WorkActivityDetail.tsx
@@ -51,6 +51,7 @@ import {
   Sync,
 } from '@mui/icons-material';
 import { API_ENDPOINTS } from '../config/api';
+import { formatDateLongPacific, formatDateTimePacific } from '../utils/dateUtils';
 
 interface WorkActivity {
   id: number;
@@ -120,24 +121,7 @@ const WorkActivityDetail: React.FC = () => {
     }
   }, [id]);
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-  };
 
-  const formatDateTime = (dateString: string) => {
-    return new Date(dateString).toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -252,7 +236,7 @@ const WorkActivityDetail: React.FC = () => {
           </Box>
         </Box>
         <Typography variant="subtitle1" color="text.secondary">
-          Activity #{activity.id} • {formatDate(activity.date)}
+          Activity #{activity.id} • {formatDateLongPacific(activity.date)}
         </Typography>
       </Box>
 
@@ -587,7 +571,7 @@ const WorkActivityDetail: React.FC = () => {
                     Created
                   </Typography>
                   <Typography variant="body1">
-                    {activity.createdAt ? formatDateTime(activity.createdAt) : 'Unknown'}
+                    {activity.createdAt ? formatDateTimePacific(activity.createdAt) : 'Unknown'}
                   </Typography>
                 </Box>
                 <Box>
@@ -595,7 +579,7 @@ const WorkActivityDetail: React.FC = () => {
                     Last Updated
                   </Typography>
                   <Typography variant="body1">
-                    {activity.updatedAt ? formatDateTime(activity.updatedAt) : 'Unknown'}
+                    {activity.updatedAt ? formatDateTimePacific(activity.updatedAt) : 'Unknown'}
                   </Typography>
                 </Box>
                 <Box>
@@ -620,9 +604,9 @@ const WorkActivityDetail: React.FC = () => {
                       </Typography>
                     </Box>
                     {activity.lastNotionSyncAt && (
-                      <Typography variant="caption" color="text.secondary">
-                        Last sync: {formatDateTime(activity.lastNotionSyncAt)}
-                      </Typography>
+                                          <Typography variant="caption" color="text.secondary">
+                      Last sync: {formatDateTimePacific(activity.lastNotionSyncAt)}
+                    </Typography>
                     )}
                   </Box>
                 )}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,165 @@
+/**
+ * Date utility functions for consistent Pacific Time handling
+ */
+
+const PACIFIC_TIMEZONE = 'America/Los_Angeles';
+
+/**
+ * Format a date string as Pacific Time in MM/DD/YYYY format
+ */
+export const formatDatePacific = (dateString: string | null | undefined): string => {
+  if (!dateString) return '-';
+  
+  // Handle ISO date strings (YYYY-MM-DD) by adding time component for proper timezone handling
+  const dateToFormat = dateString.includes('T') ? dateString : `${dateString}T00:00:00`;
+  
+  return new Date(dateToFormat).toLocaleDateString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    month: '2-digit',
+    day: '2-digit',
+    year: 'numeric'
+  });
+};
+
+/**
+ * Format a date string as Pacific Time in short format (MMM DD, YYYY)
+ */
+export const formatDateShortPacific = (dateString: string | null | undefined): string => {
+  if (!dateString) return '-';
+  
+  const dateToFormat = dateString.includes('T') ? dateString : `${dateString}T00:00:00`;
+  
+  return new Date(dateToFormat).toLocaleDateString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+};
+
+/**
+ * Format a date string as Pacific Time in long format (Weekday, Month DD, YYYY)
+ */
+export const formatDateLongPacific = (dateString: string | null | undefined): string => {
+  if (!dateString) return '-';
+  
+  const dateToFormat = dateString.includes('T') ? dateString : `${dateString}T00:00:00`;
+  
+  return new Date(dateToFormat).toLocaleDateString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+};
+
+/**
+ * Format a date string as Pacific Time in brief format (MMM DD)
+ */
+export const formatDateBriefPacific = (dateString: string | null | undefined): string => {
+  if (!dateString) return '-';
+  
+  const dateToFormat = dateString.includes('T') ? dateString : `${dateString}T00:00:00`;
+  
+  return new Date(dateToFormat).toLocaleDateString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    month: 'short',
+    day: 'numeric'
+  });
+};
+
+/**
+ * Format a date string as Pacific Time with weekday (e.g., "Mon, Dec 23")
+ */
+export const formatDateWithWeekdayPacific = (dateString: string | null | undefined): string => {
+  if (!dateString) return '-';
+  
+  const dateToFormat = dateString.includes('T') ? dateString : `${dateString}T00:00:00`;
+  
+  return new Date(dateToFormat).toLocaleDateString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  });
+};
+
+/**
+ * Format a timestamp as Pacific Time (date + time)
+ */
+export const formatTimestampPacific = (timestamp?: string | null): string => {
+  if (!timestamp) return 'Never';
+  
+  const date = new Date(timestamp);
+  return `${date.toLocaleDateString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    month: 'short',
+    day: 'numeric',
+    year: '2-digit'
+  })} ${date.toLocaleTimeString('en-US', { 
+    timeZone: PACIFIC_TIMEZONE,
+    hour: '2-digit', 
+    minute: '2-digit' 
+  })}`;
+};
+
+/**
+ * Format a datetime as Pacific Time (full date + time)
+ */
+export const formatDateTimePacific = (dateString: string): string => {
+  const date = new Date(dateString);
+  return date.toLocaleString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+/**
+ * Format time only as Pacific Time
+ */
+export const formatTimePacific = (dateString: string): string => {
+  return new Date(dateString).toLocaleTimeString('en-US', {
+    timeZone: PACIFIC_TIMEZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+/**
+ * Get current date in Pacific Time as YYYY-MM-DD string
+ */
+export const getCurrentDatePacific = (): string => {
+  const now = new Date();
+  return now.toLocaleDateString('en-CA', {
+    timeZone: PACIFIC_TIMEZONE
+  }); // en-CA gives YYYY-MM-DD format
+};
+
+/**
+ * Get current Pacific Time as a Date object
+ */
+export const getCurrentDateTimePacific = (): Date => {
+  const now = new Date();
+  // Get Pacific time as string and convert back to Date
+  const pacificTimeString = now.toLocaleString('en-US', {
+    timeZone: PACIFIC_TIMEZONE
+  });
+  return new Date(pacificTimeString);
+};
+
+/**
+ * Parse a date string and ensure it's interpreted in Pacific Time
+ */
+export const parseDateAsPacific = (dateString: string): Date => {
+  // If it's just a date (YYYY-MM-DD), treat it as midnight Pacific time
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+    return new Date(`${dateString}T00:00:00-08:00`); // PST offset
+  }
+  
+  return new Date(dateString);
+};


### PR DESCRIPTION


## Description
Ensures all date and time displays across the application are consistently interpreted and formatted in Pacific Time (`America/Los_Angeles`).
- Introduced `src/utils/dateUtils.ts` for centralized Pacific Time formatting.
- Updated all relevant frontend components to utilize these new date utilities.
- Applied explicit Pacific Timezone settings to date formatting in backend services (e.g., for AI prompts, invoice descriptions, scheduling).
This resolves inconsistencies where dates were previously displayed based on the user's local browser timezone. Date storage in the database remains unchanged (ISO strings).

