### PR TITLE
Hide quickbooks nav item in production

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -73,7 +73,7 @@ const Navigation: React.FC = () => {
     { path: '/employees', label: 'Employees', icon: <People /> },
     { path: '/projects', label: 'Projects', icon: <Assignment /> },
     { path: '/invoices', label: 'Invoices', icon: <Receipt /> },
-    { path: '/quickbooks', label: 'QuickBooks', icon: <AccountBalance /> },
+    ...(process.env.NODE_ENV !== 'production' ? [{ path: '/quickbooks', label: 'QuickBooks', icon: <AccountBalance /> }] : []),
     { path: '/schedule', label: 'Schedule', icon: <Schedule /> },
     { path: '/notion-sync', label: 'Notion Sync', icon: <Assignment /> },
     // { path: '/chat', label: 'AI Assistant', icon: <Chat /> }, // Hidden for now


### PR DESCRIPTION
```
%23%23 What Changed

Conditionally hides the QuickBooks navigation item in production environments. The item will only be visible when `process.env.NODE_ENV` is not set to 'production'.

%23%23 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature  
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update

%23%23 Testing

- [x] Tests pass locally
- [ ] Added tests for new functionality (if applicable)
- [x] Manually tested the changes

%23%23 Related Issues

Closes %23
Fixes %23

%23%23 Notes

The QuickBooks navigation item is now hidden in production while remaining visible in development and other environments.
```