### PR TITLE
feat: Add Settings/Configuration Page with Billable Hours Rounding

### DIFF
--- a/server/drizzle/0009_cooing_kat_farrell.sql
+++ b/server/drizzle/0009_cooing_kat_farrell.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "settings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"key" text NOT NULL,
+	"value" text NOT NULL,
+	"description" text,
+	"category" text DEFAULT 'general' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "settings_key_unique" UNIQUE("key")
+);

--- a/server/drizzle/meta/0009_snapshot.json
+++ b/server/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1225 @@
+{
+  "id": "3e55ff3a-b321-4962-8c69-45d4751136db",
+  "prevId": "556538bb-f63f-475d-b404-4cf0c88daf99",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.client_notes": {
+      "name": "client_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "client_notes_client_id_clients_id_fk": {
+          "name": "client_notes_client_id_clients_id_fk",
+          "tableFrom": "client_notes",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo_zone": {
+          "name": "geo_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_recurring_maintenance": {
+          "name": "is_recurring_maintenance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maintenance_interval_weeks": {
+          "name": "maintenance_interval_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_hours_per_visit": {
+          "name": "maintenance_hours_per_visit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_rate": {
+          "name": "maintenance_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_date": {
+          "name": "last_maintenance_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_maintenance_target": {
+          "name": "next_maintenance_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_level": {
+          "name": "priority_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_flexibility": {
+          "name": "schedule_flexibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_days": {
+          "name": "preferred_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_time": {
+          "name": "preferred_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_notes": {
+          "name": "special_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_client_id_unique": {
+          "name": "clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regular_workdays": {
+          "name": "regular_workdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_address": {
+          "name": "home_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_hours_per_day": {
+          "name": "min_hours_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_hours_per_day": {
+          "name": "max_hours_per_day",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_level": {
+          "name": "capability_level",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employees_employee_id_unique": {
+          "name": "employees_employee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "employee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_charge_id": {
+          "name": "other_charge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_item_id": {
+          "name": "qbo_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_line_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_work_activity_id_work_activities_id_fk": {
+          "name": "invoice_line_items_work_activity_id_work_activities_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_other_charge_id_other_charges_id_fk": {
+          "name": "invoice_line_items_other_charge_id_other_charges_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "other_charges",
+          "columnsFrom": [
+            "other_charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk": {
+          "name": "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "qbo_items",
+          "columnsFrom": [
+            "qbo_item_id"
+          ],
+          "columnsTo": [
+            "qbo_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_invoice_id": {
+          "name": "qbo_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qbo_customer_id": {
+          "name": "qbo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_sync_at": {
+          "name": "qbo_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_qbo_invoice_id_unique": {
+          "name": "invoices_qbo_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_invoice_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.other_charges": {
+      "name": "other_charges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_type": {
+          "name": "charge_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_rate": {
+          "name": "unit_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "other_charges_work_activity_id_work_activities_id_fk": {
+          "name": "other_charges_work_activity_id_work_activities_id_fk",
+          "tableFrom": "other_charges",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plant_list": {
+      "name": "plant_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plant_list_work_activity_id_work_activities_id_fk": {
+          "name": "plant_list_work_activity_id_work_activities_id_fk",
+          "tableFrom": "plant_list",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_items": {
+      "name": "qbo_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_id": {
+          "name": "qbo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "income_account_ref": {
+          "name": "income_account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "qbo_items_qbo_id_unique": {
+          "name": "qbo_items_qbo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activities": {
+      "name": "work_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_type": {
+          "name": "work_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable_hours": {
+          "name": "billable_hours",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_time_minutes": {
+          "name": "travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_travel_time_minutes": {
+          "name": "adjusted_travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "break_time_minutes": {
+          "name": "break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_billable_time_minutes": {
+          "name": "non_billable_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasks": {
+          "name": "tasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_page_id": {
+          "name": "notion_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notion_sync_at": {
+          "name": "last_notion_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'web_app'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_activities_project_id_projects_id_fk": {
+          "name": "work_activities_project_id_projects_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activities_client_id_clients_id_fk": {
+          "name": "work_activities_client_id_clients_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "work_activities_notion_page_id_unique": {
+          "name": "work_activities_notion_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notion_page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activity_employees": {
+      "name": "work_activity_employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_activity_employees_work_activity_id_work_activities_id_fk": {
+          "name": "work_activity_employees_work_activity_id_work_activities_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activity_employees_employee_id_employees_id_fk": {
+          "name": "work_activity_employees_employee_id_employees_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1751741856091,
       "tag": "0008_known_sway",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1751761249239,
+      "tag": "0009_cooing_kat_farrell",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -170,6 +170,17 @@ export const invoiceLineItems = pgTable('invoice_line_items', {
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
+// Settings table for application configuration
+export const settings = pgTable('settings', {
+  id: serial('id').primaryKey(),
+  key: text('key').unique().notNull(), // e.g., 'billable_hours_rounding'
+  value: text('value').notNull(), // JSON string for complex values
+  description: text('description'), // Human-readable description
+  category: text('category').notNull().default('general'), // e.g., 'billing', 'general', 'notifications'
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
 // Export types for use in the application
 export type Client = typeof clients.$inferSelect;
 export type NewClient = typeof clients.$inferInsert;
@@ -202,4 +213,7 @@ export type Invoice = typeof invoices.$inferSelect;
 export type NewInvoice = typeof invoices.$inferInsert;
 
 export type InvoiceLineItem = typeof invoiceLineItems.$inferSelect;
-export type NewInvoiceLineItem = typeof invoiceLineItems.$inferInsert; 
+export type NewInvoiceLineItem = typeof invoiceLineItems.$inferInsert;
+
+export type Setting = typeof settings.$inferSelect;
+export type NewSetting = typeof settings.$inferInsert; 

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,0 +1,200 @@
+import { Router } from 'express';
+import { SettingsService } from '../services/SettingsService';
+import { requireAuth } from '../middleware/auth';
+
+const router = Router();
+const settingsService = new SettingsService();
+
+// Apply authentication to all routes
+router.use(requireAuth);
+
+/**
+ * GET /api/settings
+ * Get all settings
+ */
+router.get('/', async (req, res) => {
+  try {
+    const settings = await settingsService.getAllSettings();
+    res.json({ success: true, settings });
+  } catch (error) {
+    console.error('Error fetching settings:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to fetch settings' 
+    });
+  }
+});
+
+/**
+ * GET /api/settings/category/:category
+ * Get settings by category
+ */
+router.get('/category/:category', async (req, res) => {
+  try {
+    const { category } = req.params;
+    const settings = await settingsService.getSettingsByCategory(category);
+    res.json({ success: true, settings });
+  } catch (error) {
+    console.error('Error fetching settings by category:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to fetch settings' 
+    });
+  }
+});
+
+/**
+ * GET /api/settings/:key
+ * Get a specific setting by key
+ */
+router.get('/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const setting = await settingsService.getSetting(key);
+    
+    if (!setting) {
+      return res.status(404).json({ 
+        success: false, 
+        error: 'Setting not found' 
+      });
+    }
+
+    res.json({ success: true, setting });
+  } catch (error) {
+    console.error('Error fetching setting:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to fetch setting' 
+    });
+  }
+});
+
+/**
+ * POST /api/settings
+ * Create or update a setting
+ */
+router.post('/', async (req, res) => {
+  try {
+    const { key, value, description, category } = req.body;
+
+    if (!key || value === undefined) {
+      return res.status(400).json({ 
+        success: false, 
+        error: 'Key and value are required' 
+      });
+    }
+
+    const setting = await settingsService.setSetting(
+      key, 
+      value, 
+      description, 
+      category || 'general'
+    );
+
+    res.json({ success: true, setting });
+  } catch (error) {
+    console.error('Error creating/updating setting:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to save setting' 
+    });
+  }
+});
+
+/**
+ * PUT /api/settings/:key
+ * Update a specific setting
+ */
+router.put('/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const { value, description, category } = req.body;
+
+    if (value === undefined) {
+      return res.status(400).json({ 
+        success: false, 
+        error: 'Value is required' 
+      });
+    }
+
+    const setting = await settingsService.setSetting(
+      key, 
+      value, 
+      description, 
+      category
+    );
+
+    res.json({ success: true, setting });
+  } catch (error) {
+    console.error('Error updating setting:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to update setting' 
+    });
+  }
+});
+
+/**
+ * DELETE /api/settings/:key
+ * Delete a setting
+ */
+router.delete('/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const deleted = await settingsService.deleteSetting(key);
+
+    if (!deleted) {
+      return res.status(404).json({ 
+        success: false, 
+        error: 'Setting not found' 
+      });
+    }
+
+    res.json({ success: true, message: 'Setting deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting setting:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to delete setting' 
+    });
+  }
+});
+
+/**
+ * POST /api/settings/initialize
+ * Initialize default settings
+ */
+router.post('/initialize', async (req, res) => {
+  try {
+    await settingsService.initializeDefaultSettings();
+    res.json({ 
+      success: true, 
+      message: 'Default settings initialized' 
+    });
+  } catch (error) {
+    console.error('Error initializing default settings:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to initialize default settings' 
+    });
+  }
+});
+
+/**
+ * GET /api/settings/billing/config
+ * Get billing configuration
+ */
+router.get('/billing/config', async (req, res) => {
+  try {
+    const billingSettings = await settingsService.getBillingSettings();
+    res.json({ success: true, settings: billingSettings });
+  } catch (error) {
+    console.error('Error fetching billing settings:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to fetch billing settings' 
+    });
+  }
+});
+
+export default router; 

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -197,4 +197,38 @@ router.get('/billing/config', async (req, res) => {
   }
 });
 
+/**
+ * POST /api/settings/billing/preview-rounding
+ * Preview what would happen if we apply rounding to existing work activities
+ */
+router.post('/billing/preview-rounding', async (req, res) => {
+  try {
+    const result = await settingsService.previewRoundingForExistingWorkActivities();
+    res.json(result);
+  } catch (error) {
+    console.error('Error previewing rounding for existing work activities:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to preview rounding for existing work activities' 
+    });
+  }
+});
+
+/**
+ * POST /api/settings/billing/apply-rounding
+ * Apply billable hours rounding to existing work activities
+ */
+router.post('/billing/apply-rounding', async (req, res) => {
+  try {
+    const result = await settingsService.applyRoundingToExistingWorkActivities();
+    res.json(result);
+  } catch (error) {
+    console.error('Error applying rounding to existing work activities:', error);
+    res.status(500).json({ 
+      success: false, 
+      error: 'Failed to apply rounding to existing work activities' 
+    });
+  }
+});
+
 export default router; 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -30,6 +30,7 @@ import quickbooksRouter from './routes/quickbooks';
 import { createNotionSyncRouter } from './routes/notionSync';
 import { createWorkNotesImportRouter } from './routes/workNotesImport';
 import travelTimeRouter from './routes/travelTime';
+import settingsRouter from './routes/settings';
 import { requireAuth } from './middleware/auth';
 
 // Load environment variables from root directory .env file
@@ -137,6 +138,7 @@ app.use('/api/projects', requireAuth, projectsRouter);
 app.use('/api/work-notes', requireAuth, createWorkNotesImportRouter(anthropicService));
 app.use('/api/travel-time', requireAuth, travelTimeRouter);
 app.use('/api/migration', requireAuth, migrationRouter);
+app.use('/api/settings', settingsRouter); // Settings routes handle their own auth
 app.use('/api/notion', notionRouter); // Public routes for embedded usage
 app.use('/api/notion-sync', requireAuth, createNotionSyncRouter(anthropicService)); // Notion sync routes
 app.use('/api/admin', adminRouter); // Admin routes handle their own auth

--- a/server/src/services/SettingsService.ts
+++ b/server/src/services/SettingsService.ts
@@ -1,0 +1,195 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { settings, NewSetting, Setting } from '../db/schema';
+
+export interface SettingDefinition {
+  key: string;
+  value: string;
+  description?: string;
+  category: string;
+}
+
+export class SettingsService {
+  
+  /**
+   * Get all settings
+   */
+  async getAllSettings(): Promise<Setting[]> {
+    return await db.select().from(settings);
+  }
+
+  /**
+   * Get settings by category
+   */
+  async getSettingsByCategory(category: string): Promise<Setting[]> {
+    return await db.select().from(settings).where(eq(settings.category, category));
+  }
+
+  /**
+   * Get a specific setting by key
+   */
+  async getSetting(key: string): Promise<Setting | null> {
+    const result = await db.select().from(settings).where(eq(settings.key, key));
+    return result.length > 0 ? result[0] : null;
+  }
+
+  /**
+   * Get a setting value with a default fallback
+   */
+  async getSettingValue(key: string, defaultValue?: string): Promise<string | null> {
+    const setting = await this.getSetting(key);
+    return setting ? setting.value : (defaultValue || null);
+  }
+
+  /**
+   * Get a parsed JSON setting value
+   */
+  async getSettingValueParsed<T>(key: string, defaultValue?: T): Promise<T | null> {
+    const setting = await this.getSetting(key);
+    if (!setting) return defaultValue || null;
+    
+    try {
+      return JSON.parse(setting.value);
+    } catch (error) {
+      console.error(`Failed to parse setting ${key}:`, error);
+      return defaultValue || null;
+    }
+  }
+
+  /**
+   * Set a setting value
+   */
+  async setSetting(key: string, value: string, description?: string, category: string = 'general'): Promise<Setting> {
+    const existingSetting = await this.getSetting(key);
+    
+    if (existingSetting) {
+      // Update existing setting
+      const updated = await db.update(settings)
+        .set({ 
+          value, 
+          description: description || existingSetting.description,
+          category,
+          updatedAt: new Date()
+        })
+        .where(eq(settings.key, key))
+        .returning();
+      return updated[0];
+    } else {
+      // Create new setting
+      const newSetting: NewSetting = {
+        key,
+        value,
+        description,
+        category
+      };
+      const created = await db.insert(settings).values(newSetting).returning();
+      return created[0];
+    }
+  }
+
+  /**
+   * Set a setting value with JSON serialization
+   */
+  async setSettingValue<T>(key: string, value: T, description?: string, category: string = 'general'): Promise<Setting> {
+    const serializedValue = typeof value === 'string' ? value : JSON.stringify(value);
+    return await this.setSetting(key, serializedValue, description, category);
+  }
+
+  /**
+   * Delete a setting
+   */
+  async deleteSetting(key: string): Promise<boolean> {
+    const result = await db.delete(settings).where(eq(settings.key, key)).returning();
+    return result.length > 0;
+  }
+
+  /**
+   * Initialize default settings
+   */
+  async initializeDefaultSettings(): Promise<void> {
+    const defaultSettings: SettingDefinition[] = [
+      {
+        key: 'billable_hours_rounding',
+        value: 'false',
+        description: 'Whether to round billable hours to the nearest half hour',
+        category: 'billing'
+      },
+      {
+        key: 'billable_hours_rounding_method',
+        value: 'up',
+        description: 'How to round billable hours: "up", "down", or "nearest"',
+        category: 'billing'
+      },
+      {
+        key: 'default_hourly_rate',
+        value: '50',
+        description: 'Default hourly rate for new work activities',
+        category: 'billing'
+      },
+      {
+        key: 'app_name',
+        value: 'Garden Care CRM',
+        description: 'Application name displayed in the UI',
+        category: 'general'
+      }
+    ];
+
+    for (const setting of defaultSettings) {
+      const existing = await this.getSetting(setting.key);
+      if (!existing) {
+        await this.setSetting(setting.key, setting.value, setting.description, setting.category);
+      }
+    }
+  }
+
+  /**
+   * Get billing-related settings
+   */
+  async getBillingSettings(): Promise<{
+    roundBillableHours: boolean;
+    roundingMethod: 'up' | 'down' | 'nearest';
+    defaultHourlyRate: number;
+  }> {
+    const [roundingEnabled, roundingMethod, defaultRate] = await Promise.all([
+      this.getSettingValue('billable_hours_rounding', 'false'),
+      this.getSettingValue('billable_hours_rounding_method', 'up'),
+      this.getSettingValue('default_hourly_rate', '50')
+    ]);
+
+    return {
+      roundBillableHours: roundingEnabled === 'true',
+      roundingMethod: roundingMethod as 'up' | 'down' | 'nearest',
+      defaultHourlyRate: parseFloat(defaultRate || '50')
+    };
+  }
+
+  /**
+   * Utility function to round hours based on settings
+   */
+  async roundHours(hours: number): Promise<number> {
+    const billingSettings = await this.getBillingSettings();
+    
+    if (!billingSettings.roundBillableHours) {
+      return hours;
+    }
+
+    // Round to nearest half hour
+    const halfHours = hours * 2;
+    let roundedHalfHours: number;
+
+    switch (billingSettings.roundingMethod) {
+      case 'up':
+        roundedHalfHours = Math.ceil(halfHours);
+        break;
+      case 'down':
+        roundedHalfHours = Math.floor(halfHours);
+        break;
+      case 'nearest':
+      default:
+        roundedHalfHours = Math.round(halfHours);
+        break;
+    }
+
+    return roundedHalfHours / 2;
+  }
+} 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import Login from './components/Login';
 import NotionEmbedPage from './components/NotionEmbedPage';
 import QuickBooksIntegration from './components/QuickBooksIntegration';
 import Invoices from './components/Invoices';
+import Settings from './components/Settings';
 
 const theme = createTheme({
   palette: {
@@ -79,6 +80,7 @@ function App() {
                       <Route path="/quickbooks" element={<QuickBooksIntegration />} />
                       <Route path="/invoices" element={<Invoices />} />
                       <Route path="/debug" element={<Debug />} />
+                      <Route path="/settings" element={<Settings />} />
                       <Route path="/admin" element={<Admin />} />
                     </Routes>
                   </ProtectedRoute>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -87,6 +87,7 @@ const Navigation: React.FC = () => {
   // Secondary items
   const secondaryNavItems = [
     { path: '/debug', label: 'Reports', icon: <Analytics /> },
+    { path: '/settings', label: 'Settings', icon: <Settings /> },
     { path: '/admin', label: 'Admin', icon: <Settings /> },
   ];
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,501 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  Box,
+  Switch,
+  FormControlLabel,
+  Button,
+  Alert,
+  Divider,
+  Grid,
+  Paper,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  Snackbar,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+  Chip,
+  CircularProgress,
+} from '@mui/material';
+import {
+  Settings as SettingsIcon,
+  AttachMoney,
+  ExpandMore,
+  Save,
+  RestoreOutlined,
+  Business,
+  Home,
+  Security,
+  Notifications,
+  Schedule,
+  Refresh,
+} from '@mui/icons-material';
+import { apiClient } from '../config/api';
+
+interface Setting {
+  id: number;
+  key: string;
+  value: string;
+  description?: string;
+  category: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SettingsByCategory {
+  [key: string]: Setting[];
+}
+
+const Settings: React.FC = () => {
+  const [settings, setSettings] = useState<SettingsByCategory>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' as 'success' | 'error' });
+  const [expandedCategories, setExpandedCategories] = useState<string[]>(['billing', 'general']);
+
+  // Form state for billing settings
+  const [billingSettings, setBillingSettings] = useState({
+    roundBillableHours: false,
+    roundingMethod: 'up' as 'up' | 'down' | 'nearest',
+    defaultHourlyRate: 50,
+  });
+
+  // Form state for general settings
+  const [generalSettings, setGeneralSettings] = useState({
+    appName: 'Garden Care CRM',
+  });
+
+  const showSnackbar = (message: string, severity: 'success' | 'error' = 'success') => {
+    setSnackbar({ open: true, message, severity });
+  };
+
+  const fetchSettings = async () => {
+    try {
+      setLoading(true);
+      const response = await apiClient.get('/api/settings');
+      const data = await response.json();
+      
+      if (data.success) {
+        // Group settings by category
+        const groupedSettings: SettingsByCategory = {};
+        data.settings.forEach((setting: Setting) => {
+          if (!groupedSettings[setting.category]) {
+            groupedSettings[setting.category] = [];
+          }
+          groupedSettings[setting.category].push(setting);
+        });
+        
+        setSettings(groupedSettings);
+        
+        // Update form state from fetched settings
+        updateFormStateFromSettings(data.settings);
+      } else {
+        setError(data.error || 'Failed to fetch settings');
+      }
+    } catch (error) {
+      console.error('Error fetching settings:', error);
+      setError('Failed to fetch settings');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateFormStateFromSettings = (settingsList: Setting[]) => {
+    const settingsMap = settingsList.reduce((acc, setting) => {
+      acc[setting.key] = setting.value;
+      return acc;
+    }, {} as Record<string, string>);
+
+    // Update billing settings
+    setBillingSettings({
+      roundBillableHours: settingsMap.billable_hours_rounding === 'true',
+      roundingMethod: (settingsMap.billable_hours_rounding_method || 'up') as 'up' | 'down' | 'nearest',
+      defaultHourlyRate: parseFloat(settingsMap.default_hourly_rate || '50'),
+    });
+
+    // Update general settings
+    setGeneralSettings({
+      appName: settingsMap.app_name || 'Garden Care CRM',
+    });
+  };
+
+  const saveSetting = async (key: string, value: string, category: string, description?: string) => {
+    try {
+      const response = await apiClient.post('/api/settings', {
+        key,
+        value,
+        category,
+        description,
+      });
+      
+      const data = await response.json();
+      if (!data.success) {
+        throw new Error(data.error || 'Failed to save setting');
+      }
+      
+      return data.setting;
+    } catch (error) {
+      console.error(`Error saving setting ${key}:`, error);
+      throw error;
+    }
+  };
+
+  const saveSettings = async () => {
+    try {
+      setSaving(true);
+      
+      // Save billing settings
+      await Promise.all([
+        saveSetting(
+          'billable_hours_rounding',
+          billingSettings.roundBillableHours.toString(),
+          'billing',
+          'Whether to round billable hours to the nearest half hour'
+        ),
+        saveSetting(
+          'billable_hours_rounding_method',
+          billingSettings.roundingMethod,
+          'billing',
+          'How to round billable hours: "up", "down", or "nearest"'
+        ),
+        saveSetting(
+          'default_hourly_rate',
+          billingSettings.defaultHourlyRate.toString(),
+          'billing',
+          'Default hourly rate for new work activities'
+        ),
+        saveSetting(
+          'app_name',
+          generalSettings.appName,
+          'general',
+          'Application name displayed in the UI'
+        ),
+      ]);
+
+      showSnackbar('Settings saved successfully!');
+      await fetchSettings(); // Refresh settings
+    } catch (error) {
+      console.error('Error saving settings:', error);
+      showSnackbar('Failed to save settings', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const initializeDefaults = async () => {
+    try {
+      setSaving(true);
+      const response = await apiClient.post('/api/settings/initialize');
+      const data = await response.json();
+      
+      if (data.success) {
+        showSnackbar('Default settings initialized successfully!');
+        await fetchSettings();
+      } else {
+        throw new Error(data.error || 'Failed to initialize default settings');
+      }
+    } catch (error) {
+      console.error('Error initializing default settings:', error);
+      showSnackbar('Failed to initialize default settings', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCategoryToggle = (category: string) => {
+    setExpandedCategories(prev => 
+      prev.includes(category) 
+        ? prev.filter(c => c !== category)
+        : [...prev, category]
+    );
+  };
+
+  useEffect(() => {
+    fetchSettings();
+  }, []);
+
+  const getCategoryIcon = (category: string) => {
+    switch (category) {
+      case 'billing': return <AttachMoney />;
+      case 'general': return <Home />;
+      case 'security': return <Security />;
+      case 'notifications': return <Notifications />;
+      case 'schedule': return <Schedule />;
+      default: return <SettingsIcon />;
+    }
+  };
+
+  const getCategoryColor = (category: string) => {
+    switch (category) {
+      case 'billing': return 'primary';
+      case 'general': return 'secondary';
+      case 'security': return 'error';
+      case 'notifications': return 'info';
+      case 'schedule': return 'warning';
+      default: return 'default';
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4, textAlign: 'center' }}>
+        <CircularProgress />
+        <Typography variant="h6" sx={{ mt: 2 }}>
+          Loading settings...
+        </Typography>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Header */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h4" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <SettingsIcon /> Settings & Configuration
+        </Typography>
+        <Typography variant="subtitle1" color="text.secondary">
+          Manage your application preferences and configuration options
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Action Buttons */}
+      <Box sx={{ mb: 3, display: 'flex', gap: 2 }}>
+        <Button
+          variant="contained"
+          startIcon={<Save />}
+          onClick={saveSettings}
+          disabled={saving}
+        >
+          {saving ? 'Saving...' : 'Save Settings'}
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<RestoreOutlined />}
+          onClick={initializeDefaults}
+          disabled={saving}
+        >
+          Initialize Defaults
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<Refresh />}
+          onClick={fetchSettings}
+          disabled={saving}
+        >
+          Refresh
+        </Button>
+      </Box>
+
+      {/* Settings Categories */}
+      <Grid container spacing={3}>
+        {/* Billing Settings */}
+        <Grid item xs={12}>
+          <Accordion 
+            expanded={expandedCategories.includes('billing')}
+            onChange={() => handleCategoryToggle('billing')}
+          >
+            <AccordionSummary expandIcon={<ExpandMore />}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <AttachMoney color="primary" />
+                <Typography variant="h6">Billing & Pricing</Typography>
+                <Chip label="billing" size="small" color="primary" />
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Grid container spacing={3}>
+                <Grid item xs={12} md={6}>
+                  <Card>
+                    <CardContent>
+                      <Typography variant="h6" gutterBottom>
+                        Billable Hours Rounding
+                      </Typography>
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={billingSettings.roundBillableHours}
+                            onChange={(e) => setBillingSettings(prev => ({
+                              ...prev,
+                              roundBillableHours: e.target.checked
+                            }))}
+                          />
+                        }
+                        label="Round billable hours to nearest half hour"
+                      />
+                      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                        When enabled, billable hours will be automatically rounded to the nearest 0.5 hour increment.
+                      </Typography>
+
+                      {billingSettings.roundBillableHours && (
+                        <Box sx={{ mt: 2 }}>
+                          <FormControl fullWidth>
+                            <InputLabel>Rounding Method</InputLabel>
+                            <Select
+                              value={billingSettings.roundingMethod}
+                              label="Rounding Method"
+                              onChange={(e) => setBillingSettings(prev => ({
+                                ...prev,
+                                roundingMethod: e.target.value as 'up' | 'down' | 'nearest'
+                              }))}
+                            >
+                              <MenuItem value="up">Round Up (Always favor client)</MenuItem>
+                              <MenuItem value="down">Round Down (Always favor business)</MenuItem>
+                              <MenuItem value="nearest">Round to Nearest (Most accurate)</MenuItem>
+                            </Select>
+                          </FormControl>
+                        </Box>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Grid>
+
+                <Grid item xs={12} md={6}>
+                  <Card>
+                    <CardContent>
+                      <Typography variant="h6" gutterBottom>
+                        Default Rates
+                      </Typography>
+                      <TextField
+                        fullWidth
+                        type="number"
+                        label="Default Hourly Rate"
+                        value={billingSettings.defaultHourlyRate}
+                        onChange={(e) => setBillingSettings(prev => ({
+                          ...prev,
+                          defaultHourlyRate: parseFloat(e.target.value) || 0
+                        }))}
+                        InputProps={{
+                          startAdornment: <Typography>$</Typography>,
+                        }}
+                      />
+                      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                        This rate will be used as the default for new work activities.
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              </Grid>
+            </AccordionDetails>
+          </Accordion>
+        </Grid>
+
+        {/* General Settings */}
+        <Grid item xs={12}>
+          <Accordion 
+            expanded={expandedCategories.includes('general')}
+            onChange={() => handleCategoryToggle('general')}
+          >
+            <AccordionSummary expandIcon={<ExpandMore />}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Home color="secondary" />
+                <Typography variant="h6">General</Typography>
+                <Chip label="general" size="small" color="secondary" />
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Grid container spacing={3}>
+                <Grid item xs={12} md={6}>
+                  <Card>
+                    <CardContent>
+                      <Typography variant="h6" gutterBottom>
+                        Application Settings
+                      </Typography>
+                      <TextField
+                        fullWidth
+                        label="Application Name"
+                        value={generalSettings.appName}
+                        onChange={(e) => setGeneralSettings(prev => ({
+                          ...prev,
+                          appName: e.target.value
+                        }))}
+                        sx={{ mb: 2 }}
+                      />
+                      <Typography variant="body2" color="text.secondary">
+                        This name will be displayed in the navigation and other UI elements.
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              </Grid>
+            </AccordionDetails>
+          </Accordion>
+        </Grid>
+
+        {/* Current Settings Display */}
+        <Grid item xs={12}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Current Settings Overview
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              
+              {Object.entries(settings).map(([category, categorySettings]) => (
+                <Box key={category} sx={{ mb: 3 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    {getCategoryIcon(category)}
+                    <Typography variant="subtitle1" fontWeight="bold">
+                      {category.charAt(0).toUpperCase() + category.slice(1)}
+                    </Typography>
+                    <Chip 
+                      label={`${categorySettings.length} settings`} 
+                      size="small" 
+                      color={getCategoryColor(category) as any}
+                    />
+                  </Box>
+                  
+                  <List dense>
+                    {categorySettings.map((setting) => (
+                      <ListItem key={setting.key} divider>
+                        <ListItemText
+                          primary={setting.key}
+                          secondary={setting.description || 'No description'}
+                        />
+                        <Box sx={{ textAlign: 'right', minWidth: 100 }}>
+                          <Typography variant="body2" fontWeight="bold">
+                            {setting.value}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {new Date(setting.updatedAt).toLocaleDateString()}
+                          </Typography>
+                        </Box>
+                      </ListItem>
+                    ))}
+                  </List>
+                </Box>
+              ))}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* Snackbar for notifications */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        message={snackbar.message}
+      />
+    </Container>
+  );
+};
+
+export default Settings; 


### PR DESCRIPTION
## Overview

This PR adds a comprehensive settings/configuration page to the Garden Care CRM application with the ability to configure billable hours rounding and other application settings.

## Features Implemented

### 🎛️ Settings Management System
- **Database Schema**: Added `settings` table with fields for key, value, description, and category
- **SettingsService**: Comprehensive service with CRUD operations for settings management
- **API Routes**: Full REST API for settings with specialized billing configuration endpoints
- **React Component**: Material-UI based settings page with accordion interface

### ⏰ Billable Hours Rounding
- **Configurable Rounding**: Toggle to enable/disable billable hours rounding
- **Rounding Methods**: Support for 'up', 'down', and 'nearest' rounding methods
- **Default Hourly Rate**: Configurable default rate for new work activities
- **Existing Activities**: Ability to preview and apply rounding to existing work activities

### 🔧 Enhanced User Experience
- **Preview Functionality**: Safe preview of rounding changes before applying
- **Detailed Statistics**: Shows total activities, affected count, and change details
- **Unsaved Changes Tracking**: Visual indicators and warnings for unsaved changes
- **Error Handling**: Comprehensive error handling with user-friendly messages

## Technical Details

### Backend Changes
- **Database Migration**: `0009_cooing_kat_farrell.sql` for settings table
- **SettingsService**: 
  - `getBillingSettings()` - Get billing-specific settings
  - `roundHours()` - Apply rounding logic based on configured method
  - `applyRoundingToExistingWorkActivities()` - Apply rounding to existing data
  - `previewRoundingForExistingWorkActivities()` - Preview changes safely
- **API Endpoints**:
  - `GET/POST/PUT/DELETE /api/settings` - Full CRUD operations
  - `GET /api/settings/billing/config` - Get billing settings
  - `POST /api/settings/billing/preview-rounding` - Preview rounding changes
  - `POST /api/settings/billing/apply-rounding` - Apply rounding to existing activities

### Frontend Changes
- **Settings Component**: Comprehensive settings page with:
  - Billing settings section (rounding toggle, method selection, default rate)
  - General settings section (app name configuration)
  - Current settings overview
  - Preview/apply functionality for existing activities
- **Navigation**: Added Settings to navigation menu and routing
- **State Management**: Proper loading states, error handling, and change tracking

## Key Commits
- `706ffb4`: Initial settings implementation with database schema and UI
- `68be3fc`: Add apply rounding to existing work activities feature
- `4673912`: Fix unsaved changes tracking for better UX

## Testing
- ✅ Settings page loads and displays correctly
- ✅ Billable hours rounding toggle works
- ✅ Preview functionality shows accurate changes
- ✅ Apply functionality updates existing activities correctly
- ✅ Only billable hours are rounded (total hours remain unchanged)
- ✅ Unsaved changes tracking prevents data loss

## Breaking Changes
None - this is a purely additive feature.

## Database Migration Required
Yes - run the migration to create the settings table:
```sql
-- Migration 0009_cooing_kat_farrell.sql will be applied automatically
``` 