### PR TITLE
Fix Notion sync inflating per-employee hours when team members are unmatched

### DIFF
--- a/docs/features/notification-center.md
+++ b/docs/features/notification-center.md
@@ -1,0 +1,71 @@
+# Notification Center (Follow-Up)
+
+Status: **Proposed — not yet built.**
+
+## Motivation
+
+Several background processes (Notion sync, cron jobs, future imports) produce
+events that the user needs to *eventually* act on but that shouldn't block the
+operation that produced them. Today these events are surfaced inconsistently:
+
+- Some are returned as `warnings: string[]` on a sync response and shown only
+  on the page that triggered the sync.
+- Some only land in server logs.
+- None of them persist — close the tab and the signal is gone.
+
+This makes it easy to miss things that genuinely need a human, e.g. an
+auto-created employee record from a Notion typo (see
+[`NotionSyncService.resolveTeamMembers`](../../server/src/services/NotionSyncService.ts)).
+
+## What needs to exist
+
+A central, persistent place where the app records "something happened that you
+should probably review" — and a UI surface that makes those events visible
+across the app, not just on the page that produced them.
+
+### Triggering cases (initial)
+
+1. **Auto-created employees from Notion sync.** Currently surfaced as an
+   in-line warning on the sync result. The new employee has
+   `notes: 'Auto-created from Notion sync - please review and update'`. The
+   notification should link directly to the employee detail page and the
+   originating Notion page.
+2. **Ambiguous employee matches.** When a Notion team-member name matches
+   multiple DB employees (e.g. two "Anne"s), `findEmployeeMatch` now refuses
+   the match and auto-creates instead. The notification should explain the
+   ambiguity so the user can merge.
+3. **Auto-created clients** (`ensureClientExists`) — same pattern.
+4. **Failed cron runs** (Notion maintenance cron, etc.).
+5. **Hours adjustments that couldn't be parsed.**
+
+### Suggested shape
+
+- New table `notifications` with: `id`, `type` (enum), `severity`
+  (info/warn/error), `title`, `body`, `link`, `entity_type`, `entity_id`,
+  `created_at`, `read_at`, `dismissed_at`.
+- A `NotificationService` with `create()` / `list()` / `markRead()` /
+  `dismiss()`.
+- A bell-icon in the app chrome that shows the unread count and opens a panel.
+- A dedicated `/notifications` page for the full history with filters.
+
+### Migration of existing call sites
+
+- Replace `warnings: string[]` on sync responses with notification records.
+  Keep the in-line warning on the immediate sync result (still useful), but
+  also write a notification so it persists.
+- Audit `debugLog.warn` calls that represent user-actionable events and
+  promote them to notifications.
+
+## Non-goals
+
+- Real-time push / websockets. Polling on app load is fine for v1.
+- Email/SMS delivery.
+- Per-user routing. Single-tenant for now.
+
+## Tracking
+
+This doc exists so the auto-create warnings added in commit `6a3fd4e` aren't
+the last we hear of this need. When this is built, the relevant code paths
+in `NotionSyncService` (`resolveTeamMembers`, `ensureClientExists`,
+hours-adjustment parsing) should switch from `warnings: string[]` to writing
+notification records.

--- a/server/src/__tests__/notionSync.resolveTeamMembers.test.ts
+++ b/server/src/__tests__/notionSync.resolveTeamMembers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { NotionSyncService } from '../services/NotionSyncService';
+import type { Employee, NewEmployee } from '../db/schema';
+
+type ResolveResult = { employeeIds: number[]; warnings: string[] };
+
+function makeEmployee(overrides: Partial<Employee> & { id: number; name: string }): Employee {
+  return {
+    employeeId: `emp-${overrides.id}`,
+    regularWorkdays: '',
+    homeAddress: '',
+    minHoursPerDay: 0,
+    maxHoursPerDay: 8,
+    capabilityLevel: 1,
+    hourlyRate: null,
+    notes: null,
+    activeStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides
+  } as Employee;
+}
+
+describe('NotionSyncService.resolveTeamMembers', () => {
+  let service: NotionSyncService;
+  let getAllEmployees: jest.Mock<() => Promise<Employee[]>>;
+  let createEmployee: jest.Mock<(data: NewEmployee) => Promise<Employee>>;
+  let resolveTeamMembers: (names: string[]) => Promise<ResolveResult>;
+  let nextEmployeeId: number;
+
+  beforeEach(() => {
+    service = new NotionSyncService();
+    nextEmployeeId = 100;
+
+    getAllEmployees = jest.fn<() => Promise<Employee[]>>();
+    createEmployee = jest.fn<(data: NewEmployee) => Promise<Employee>>(async (data) => {
+      return makeEmployee({ id: nextEmployeeId++, name: data.name });
+    });
+
+    (service as any).employeeService = {
+      getAllEmployees,
+      createEmployee
+    };
+
+    resolveTeamMembers = (service as any).resolveTeamMembers.bind(service);
+  });
+
+  it('returns existing employee IDs without warnings when every name matches', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Andrea Wilson' }),
+      makeEmployee({ id: 2, name: 'Anne McGary' })
+    ]);
+
+    const result = await resolveTeamMembers(['Andrea', 'Anne']);
+
+    expect(result.employeeIds).toEqual([1, 2]);
+    expect(result.warnings).toEqual([]);
+    expect(createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('auto-creates an unmatched team member and emits a warning', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Andrea Wilson' }),
+      makeEmployee({ id: 2, name: 'Anne McGary' })
+    ]);
+
+    const result = await resolveTeamMembers(['Andrea', 'Syd', 'Anne']);
+
+    expect(result.employeeIds).toEqual([1, 100, 2]);
+    expect(result.warnings).toEqual([
+      'Auto-created employee "Syd" from Notion - please review their details'
+    ]);
+    expect(createEmployee).toHaveBeenCalledTimes(1);
+
+    const created = createEmployee.mock.calls[0][0];
+    expect(created.name).toBe('Syd');
+    expect(created.activeStatus).toBe('active');
+    expect(created.notes).toMatch(/Auto-created from Notion/i);
+    expect(created.employeeId).toMatch(/^notion-/);
+  });
+
+  it('does NOT treat nickname variants as a match (e.g., "Andy" is not "Andrea")', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Andrea Wilson' })
+    ]);
+
+    const result = await resolveTeamMembers(['Andy']);
+
+    expect(result.employeeIds).toEqual([100]);
+    expect(result.warnings).toEqual([
+      'Auto-created employee "Andy" from Notion - please review their details'
+    ]);
+    expect(createEmployee).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches a first name in Notion against a full name in the DB (e.g., "Anne" → "Anne McGary")', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 2, name: 'Anne McGary' })
+    ]);
+
+    const result = await resolveTeamMembers(['Anne']);
+
+    expect(result.employeeIds).toEqual([2]);
+    expect(result.warnings).toEqual([]);
+    expect(createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('skips blank and whitespace-only names', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Andrea Wilson' })
+    ]);
+
+    const result = await resolveTeamMembers(['', '   ', 'Andrea']);
+
+    expect(result.employeeIds).toEqual([1]);
+    expect(result.warnings).toEqual([]);
+    expect(createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('does not double-create when the same unmatched name appears twice', async () => {
+    getAllEmployees.mockResolvedValue([]);
+
+    const result = await resolveTeamMembers(['Syd', 'Syd']);
+
+    expect(result.employeeIds).toEqual([100, 100]);
+    expect(result.warnings).toHaveLength(1);
+    expect(createEmployee).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty result for an empty input list', async () => {
+    getAllEmployees.mockResolvedValue([]);
+
+    const result = await resolveTeamMembers([]);
+
+    expect(result.employeeIds).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('preserves input order so per-employee hour splits stay aligned with team members', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 2, name: 'Anne McGary' })
+    ]);
+
+    const result = await resolveTeamMembers(['Syd', 'Anne', 'NewPerson']);
+
+    expect(result.employeeIds).toEqual([100, 2, 101]);
+    expect(result.employeeIds).toHaveLength(3);
+  });
+});

--- a/server/src/__tests__/notionSync.resolveTeamMembers.test.ts
+++ b/server/src/__tests__/notionSync.resolveTeamMembers.test.ts
@@ -147,4 +147,70 @@ describe('NotionSyncService.resolveTeamMembers', () => {
     expect(result.employeeIds).toEqual([100, 2, 101]);
     expect(result.employeeIds).toHaveLength(3);
   });
+
+  it('rejects arbitrary substring matches that are not whole tokens (e.g., "An" is not "Anne McGary")', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Anne McGary' }),
+      makeEmployee({ id: 2, name: 'Andrea Wilson' })
+    ]);
+
+    const result = await resolveTeamMembers(['An']);
+
+    expect(result.employeeIds).toEqual([100]);
+    expect(result.warnings).toEqual([
+      'Auto-created employee "An" from Notion - please review their details'
+    ]);
+  });
+
+  it('auto-creates when a first name is ambiguous across multiple employees', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Anne McGary' }),
+      makeEmployee({ id: 2, name: 'Anne Patterson' })
+    ]);
+
+    const result = await resolveTeamMembers(['Anne']);
+
+    // Two valid candidates → ambiguous → auto-create rather than silently pick one
+    expect(result.employeeIds).toEqual([100]);
+    expect(result.warnings).toEqual([
+      'Auto-created employee "Anne" from Notion - please review their details'
+    ]);
+  });
+
+  it('matches a multi-token Notion name against a single-token DB record (e.g., "Anne McGary" → "Anne")', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 2, name: 'Anne' })
+    ]);
+
+    const result = await resolveTeamMembers(['Anne McGary']);
+
+    expect(result.employeeIds).toEqual([2]);
+    expect(result.warnings).toEqual([]);
+    expect(createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('matches across hyphenated last names (e.g., "Smith" → "Anna Smith-Jones")', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 5, name: 'Anna Smith-Jones' })
+    ]);
+
+    const result = await resolveTeamMembers(['Smith']);
+
+    expect(result.employeeIds).toEqual([5]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('prefers an exact match over a token match when both exist', async () => {
+    getAllEmployees.mockResolvedValue([
+      makeEmployee({ id: 1, name: 'Anne McGary' }),
+      makeEmployee({ id: 2, name: 'Anne' })
+    ]);
+
+    const result = await resolveTeamMembers(['Anne']);
+
+    // Exact match wins; ambiguity check never fires
+    expect(result.employeeIds).toEqual([2]);
+    expect(result.warnings).toEqual([]);
+    expect(createEmployee).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/services/NotionSyncService.ts
+++ b/server/src/services/NotionSyncService.ts
@@ -4,7 +4,7 @@ import { ClientService } from './ClientService';
 import { EmployeeService } from './EmployeeService';
 import { AnthropicService } from './AnthropicService';
 import { debugLog } from '../utils/logger';
-import { NewWorkActivity, otherCharges, workActivityEmployees } from '../db/schema';
+import { Employee, NewWorkActivity, otherCharges, workActivityEmployees } from '../db/schema';
 import { eq } from 'drizzle-orm';
 
 const notion = new Client({
@@ -12,6 +12,12 @@ const notion = new Client({
 });
 
 const DATABASE_ID = process.env.NOTION_DATABASE_ID!;
+
+// Split a name into lowercase tokens on whitespace and hyphens, dropping blanks.
+// Used for whole-token name matching (see findEmployeeMatch).
+function tokenize(name: string): string[] {
+  return name.toLowerCase().split(/[\s-]+/).filter(Boolean);
+}
 
 export interface NotionWorkActivityData {
   notionPageId: string;
@@ -706,13 +712,23 @@ export class NotionSyncService {
   }
 
   /**
-   * Find an employee by name. Matches exact full name (case-insensitive) or
-   * a substring containment in either direction (so "Anne" matches "Anne McGary"
-   * and vice versa). Does NOT do nickname/variant matching - "Andy" will not
-   * match "Andrea", since they are usually different people.
+   * Find an employee by name. Matches in this order:
+   *   1. Exact full name (case-insensitive).
+   *   2. Whole-token match: every token of the shorter name appears as a complete
+   *      token of the longer name. So "Anne" matches "Anne McGary" (because "anne"
+   *      is a token of "Anne McGary"), but "An" does NOT match "Anne McGary"
+   *      (because "an" is not a token of "Anne McGary"), and "Andy" does NOT
+   *      match "Andrea Wilson" (no shared tokens).
+   *
+   * If more than one candidate matches at the token level the result is treated
+   * as ambiguous: returns null so the caller auto-creates with a visible warning
+   * rather than silently picking the wrong person.
+   *
+   * Does NOT do nickname/variant matching - "Andy" will not match "Andrea".
    */
-  private findEmployeeMatch(searchName: string, employees: any[]): any | null {
+  private findEmployeeMatch(searchName: string, employees: Employee[]): Employee | null {
     const search = searchName.toLowerCase().trim();
+    if (!search) return null;
 
     const exact = employees.find(emp => emp.name.toLowerCase().trim() === search);
     if (exact) {
@@ -720,13 +736,29 @@ export class NotionSyncService {
       return exact;
     }
 
-    const contains = employees.find(emp => {
-      const name = emp.name.toLowerCase().trim();
-      return name.includes(search) || search.includes(name);
+    const searchTokens = tokenize(search);
+    if (searchTokens.length === 0) return null;
+
+    const tokenMatches = employees.filter(emp => {
+      const empTokens = tokenize(emp.name);
+      if (empTokens.length === 0) return false;
+      const [shorter, longer] =
+        searchTokens.length <= empTokens.length
+          ? [searchTokens, empTokens]
+          : [empTokens, searchTokens];
+      return shorter.every(t => longer.includes(t));
     });
-    if (contains) {
-      debugLog.info(`   📍 Found contains match: "${searchName}" ~ "${contains.name}"`);
-      return contains;
+
+    if (tokenMatches.length === 1) {
+      const match = tokenMatches[0];
+      debugLog.info(`   📍 Found token match: "${searchName}" ~ "${match.name}"`);
+      return match;
+    }
+
+    if (tokenMatches.length > 1) {
+      const names = tokenMatches.map(e => e.name).join(', ');
+      debugLog.warn(`   ⚠️ Ambiguous match for "${searchName}" - candidates: ${names}. Treating as unmatched.`);
+      return null;
     }
 
     debugLog.info(`   ❌ No match found for "${searchName}"`);
@@ -1177,7 +1209,7 @@ export class NotionSyncService {
       }
 
       const created = await this.employeeService.createEmployee({
-        employeeId: `notion-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        employeeId: `notion-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
         name,
         regularWorkdays: '',
         homeAddress: '',

--- a/server/src/services/NotionSyncService.ts
+++ b/server/src/services/NotionSyncService.ts
@@ -304,35 +304,41 @@ export class NotionSyncService {
 
       if (existingActivity) {
         // We already know we should sync (checked above)
-        await this.updateWorkActivityFromParsedData(existingActivity.id, activityWithNotionId, page.properties);
+        const updateResult = await this.updateWorkActivityFromParsedData(existingActivity.id, activityWithNotionId, page.properties);
         debugLog.info(`Updated work activity ${existingActivity.id} from Notion page ${page.id}`);
         if (onProgress) {
           onProgress(`✅ Updated: ${activityWithNotionId.clientName} (${activityWithNotionId.date})`);
         }
-        
+
+        // Surface employee auto-creation warnings with a page reference
+        warnings.push(...updateResult.warnings.map(w => `${this.createPageReference(page, existingActivity.id)}: ${w}`));
+
         // Log any AI warnings
         if (aiResult.warnings && aiResult.warnings.length > 0) {
           warnings.push(...aiResult.warnings.map(w => `${this.createPageReference(page, existingActivity.id)}: ${w}`));
         }
-        
+
         return { action: 'updated', warnings: warnings.length > 0 ? warnings : undefined };
       } else {
         // Create new work activity using the validated workflow
         const clientProgressCallback = onProgress ? (message: string) => {
           onProgress(message);
         } : undefined;
-        
-        await this.createWorkActivityFromParsedData(activityWithNotionId, page.properties, clientProgressCallback);
+
+        const createResult = await this.createWorkActivityFromParsedData(activityWithNotionId, page.properties, clientProgressCallback);
         debugLog.info(`Created new work activity from Notion page ${page.id}`);
         if (onProgress) {
           onProgress(`✨ Created: ${activityWithNotionId.clientName} (${activityWithNotionId.date})`);
         }
-        
+
+        // Surface employee auto-creation warnings with a page reference
+        warnings.push(...createResult.warnings.map(w => `${this.createPageReference(page)}: ${w}`));
+
         // Log any AI warnings
         if (aiResult.warnings && aiResult.warnings.length > 0) {
           warnings.push(...aiResult.warnings.map(w => `${this.createPageReference(page)}: ${w}`));
         }
-        
+
         return { action: 'created', warnings: warnings.length > 0 ? warnings : undefined };
       }
 
@@ -700,68 +706,30 @@ export class NotionSyncService {
   }
 
   /**
-   * Find employee match with flexible name matching
+   * Find an employee by name. Matches exact full name (case-insensitive) or
+   * a substring containment in either direction (so "Anne" matches "Anne McGary"
+   * and vice versa). Does NOT do nickname/variant matching - "Andy" will not
+   * match "Andrea", since they are usually different people.
    */
   private findEmployeeMatch(searchName: string, employees: any[]): any | null {
     const search = searchName.toLowerCase().trim();
-    
-    // Define name mappings for AI-generated names to common first names
-    const nameVariants: Record<string, string[]> = {
-      'andrea': ['andrea', 'andy'],
-      'virginia': ['virginia', 'ginny', 'ginger'],
-      'rebecca': ['rebecca', 'becca', 'becky'],
-      'anne': ['anne', 'anna', 'annie'],
-      'megan': ['megan', 'meg', 'meghan'],
-      'jessica': ['jessica', 'jess', 'jessie'],
-      'sarah': ['sarah', 'sara'],
-      'michael': ['michael', 'mike', 'mick'],
-      'carlos': ['carlos', 'carl'],
-    };
-    
-    // Strategy 1: Exact match
-    let match = employees.find(emp => emp.name.toLowerCase() === search);
-    if (match) {
-      debugLog.info(`   📍 Found exact match: "${searchName}" = "${match.name}"`);
-      return match;
+
+    const exact = employees.find(emp => emp.name.toLowerCase().trim() === search);
+    if (exact) {
+      debugLog.info(`   📍 Found exact match: "${searchName}" = "${exact.name}"`);
+      return exact;
     }
-    
-    // Strategy 2: Contains match (original logic)
-    match = employees.find(emp => 
-      emp.name.toLowerCase().includes(search) ||
-      search.includes(emp.name.toLowerCase())
-    );
-    if (match) {
-      debugLog.info(`   📍 Found contains match: "${searchName}" ~ "${match.name}"`);
-      return match;
-    }
-    
-    // Strategy 3: First name matching with variants
-    const searchFirstName = search.split(' ')[0];
-    for (const [baseName, variants] of Object.entries(nameVariants)) {
-      if (variants.includes(searchFirstName)) {
-        // Look for employees whose first name matches any variant of this base name
-        match = employees.find(emp => {
-          const empFirstName = emp.name.toLowerCase().split(' ')[0];
-          return variants.includes(empFirstName) || empFirstName === baseName;
-        });
-        if (match) {
-          debugLog.info(`   📍 Found variant match: "${searchName}" (${searchFirstName}) -> "${match.name}" via ${baseName}`);
-          return match;
-        }
-      }
-    }
-    
-    // Strategy 4: Partial first name match (for common nicknames)
-    match = employees.find(emp => {
-      const empFirstName = emp.name.toLowerCase().split(' ')[0];
-      return empFirstName.startsWith(searchFirstName) || searchFirstName.startsWith(empFirstName);
+
+    const contains = employees.find(emp => {
+      const name = emp.name.toLowerCase().trim();
+      return name.includes(search) || search.includes(name);
     });
-    if (match) {
-      debugLog.info(`   📍 Found partial first name match: "${searchName}" ~ "${match.name}"`);
-      return match;
+    if (contains) {
+      debugLog.info(`   📍 Found contains match: "${searchName}" ~ "${contains.name}"`);
+      return contains;
     }
-    
-    debugLog.info(`   ❌ No match found for "${searchName}" using any strategy`);
+
+    debugLog.info(`   ❌ No match found for "${searchName}"`);
     return null;
   }
 
@@ -832,28 +800,13 @@ export class NotionSyncService {
         throw new Error(`Could not find client "${clientName}" after creation`);
       }
 
-      // Match employees
-      const allEmployees = await this.employeeService.getAllEmployees();
-      const employeeIds: number[] = [];
-      
-      debugLog.info(`🔍 Matching employees for ${clientName}:`);
-      debugLog.info(`   Team members from Notion: ${JSON.stringify(teamMembers)}`);
-      debugLog.info(`   Available employees: ${allEmployees.map(emp => `${emp.name} (ID: ${emp.id})`).join(', ')}`);
-      
-      for (const memberName of teamMembers) {
-        const matchedEmployee = this.findEmployeeMatch(memberName, allEmployees);
-        if (matchedEmployee) {
-          employeeIds.push(matchedEmployee.id);
-          debugLog.info(`   ✅ Matched "${memberName}" to "${matchedEmployee.name}" (ID: ${matchedEmployee.id})`);
-        } else {
-          debugLog.info(`   ❌ No match found for "${memberName}"`);
-        }
-      }
-
+      // Match team members → employees (auto-creates unmatched names)
+      debugLog.info(`🔍 Resolving team members for ${clientName}: ${JSON.stringify(teamMembers)}`);
+      const { employeeIds } = await this.resolveTeamMembers(teamMembers);
       debugLog.info(`   Final employee IDs: ${employeeIds.join(', ')}`);
-      
+
       if (employeeIds.length === 0) {
-        debugLog.warn(`⚠️ No employees matched - work activity will have no employee assignments!`);
+        debugLog.warn(`⚠️ No team members found - work activity will have no employee assignments!`);
       }
 
       // Calculate billable hours
@@ -933,10 +886,11 @@ export class NotionSyncService {
    * Create a new work activity from AI-parsed data (legacy method)
    */
   private async createWorkActivityFromParsedData(
-    parsedActivity: any, 
+    parsedActivity: any,
     notionPageProperties?: any,
     onProgress?: (message: string) => void
-  ): Promise<void> {
+  ): Promise<{ warnings: string[] }> {
+    const warnings: string[] = [];
     try {
       // Parse travel time and break time directly from Notion properties if available
       let travelTime = 0;
@@ -992,34 +946,16 @@ export class NotionSyncService {
         throw new Error(`Could not find client "${parsedActivity.clientName}" after creation`);
       }
 
-      // Get all employees for employee matching
-      const allEmployees = await this.employeeService.getAllEmployees();
-      const employeeIds: number[] = [];
-      
-      // Match employees from parsed activity with improved matching logic
-      debugLog.info(`🔍 Matching employees for ${parsedActivity.clientName}:`);
-      debugLog.info(`   Parsed employees: ${JSON.stringify(parsedActivity.employees)}`);
-      debugLog.info(`   Available employees: ${allEmployees.map(emp => `${emp.name} (ID: ${emp.id})`).join(', ')}`);
-      
-      if (parsedActivity.employees && parsedActivity.employees.length > 0) {
-        for (const empName of parsedActivity.employees) {
-          debugLog.info(`   Looking for match for: "${empName}"`);
-          const matchedEmployee = this.findEmployeeMatch(empName, allEmployees);
-          if (matchedEmployee) {
-            employeeIds.push(matchedEmployee.id);
-            debugLog.info(`   ✅ Matched "${empName}" to "${matchedEmployee.name}" (ID: ${matchedEmployee.id})`);
-          } else {
-            debugLog.info(`   ❌ No match found for "${empName}"`);
-          }
-        }
-      }
-      
-      debugLog.info(`   Final employee IDs: ${employeeIds.join(', ')}`);
-      debugLog.info(`   Employee count: ${employeeIds.length}`);
-      
-      // If no employees matched, log this as a warning but don't default to anyone
+      // Resolve team members → employees (auto-creates unmatched names)
+      debugLog.info(`🔍 Resolving team members for ${parsedActivity.clientName}: ${JSON.stringify(parsedActivity.employees)}`);
+      const { employeeIds, warnings: employeeWarnings } = await this.resolveTeamMembers(
+        parsedActivity.employees || []
+      );
+      warnings.push(...employeeWarnings);
+      debugLog.info(`   Final employee IDs: ${employeeIds.join(', ')} (count: ${employeeIds.length})`);
+
       if (employeeIds.length === 0) {
-        debugLog.warn(`⚠️  No employees matched for ${parsedActivity.clientName} - work activity will have no employee assignments!`);
+        debugLog.warn(`⚠️  No team members found for ${parsedActivity.clientName} - work activity will have no employee assignments!`);
       }
 
       // Calculate billable hours - do NOT subtract raw travel time, only adjusted travel time
@@ -1092,6 +1028,7 @@ export class NotionSyncService {
       await this.workActivityService.createWorkActivity(createData);
       debugLog.info(`✅ Created work activity from Notion with correct lastUpdatedBy: 'notion_sync'`);
 
+      return { warnings };
     } catch (error) {
       debugLog.error('Error creating work activity from parsed data:', error);
       throw error;
@@ -1213,9 +1150,58 @@ export class NotionSyncService {
   }
 
   /**
+   * Resolve a list of team member names (from Notion) to employee IDs.
+   * Auto-creates any employee that doesn't match an existing record, and
+   * returns warnings for each auto-created employee so the caller can surface them.
+   *
+   * Ensures the returned employeeIds.length === input names.length (minus blanks),
+   * which prevents per-employee hour inflation when totalHours was computed as
+   * duration × team_member_count.
+   */
+  private async resolveTeamMembers(
+    memberNames: string[]
+  ): Promise<{ employeeIds: number[]; warnings: string[] }> {
+    const warnings: string[] = [];
+    const employeeIds: number[] = [];
+    const allEmployees = await this.employeeService.getAllEmployees();
+
+    for (const rawName of memberNames) {
+      const name = (rawName || '').trim();
+      if (!name) continue;
+
+      const matched = this.findEmployeeMatch(name, allEmployees);
+      if (matched) {
+        employeeIds.push(matched.id);
+        debugLog.info(`   ✅ Matched "${name}" to "${matched.name}" (ID: ${matched.id})`);
+        continue;
+      }
+
+      const created = await this.employeeService.createEmployee({
+        employeeId: `notion-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        name,
+        regularWorkdays: '',
+        homeAddress: '',
+        minHoursPerDay: 0,
+        maxHoursPerDay: 8,
+        capabilityLevel: 1,
+        notes: 'Auto-created from Notion sync - please review and update',
+        activeStatus: 'active'
+      });
+      allEmployees.push(created);
+      employeeIds.push(created.id);
+      const warning = `Auto-created employee "${name}" from Notion - please review their details`;
+      warnings.push(warning);
+      debugLog.warn(`✨ ${warning} (ID: ${created.id})`);
+    }
+
+    return { employeeIds, warnings };
+  }
+
+  /**
    * Update an existing work activity from AI-parsed data
    */
-  private async updateWorkActivityFromParsedData(workActivityId: number, parsedActivity: any, notionPageProperties?: any): Promise<void> {
+  private async updateWorkActivityFromParsedData(workActivityId: number, parsedActivity: any, notionPageProperties?: any): Promise<{ warnings: string[] }> {
+    const warnings: string[] = [];
     try {
       // Parse travel time and break time directly from Notion properties if available
       let travelTime = 0;
@@ -1324,30 +1310,14 @@ export class NotionSyncService {
       // Handle employee assignments update - delete existing assignments and recreate them
       if (parsedActivity.employees && parsedActivity.employees.length > 0) {
         debugLog.info(`👥 Updating employee assignments for work activity ${workActivityId}`);
-        
-        // Get all employees for matching
-        const allEmployees = await this.employeeService.getAllEmployees();
-        const employeeIds: number[] = [];
-        
-        // Match employees from parsed activity with improved matching logic
-        debugLog.info(`🔍 Matching employees for update ${workActivityId}:`);
-        debugLog.info(`   Parsed employees: ${JSON.stringify(parsedActivity.employees)}`);
-        debugLog.info(`   Available employees: ${allEmployees.map(emp => `${emp.name} (ID: ${emp.id})`).join(', ')}`);
-        
-        for (const empName of parsedActivity.employees) {
-          debugLog.info(`   Looking for match for: "${empName}"`);
-          const matchedEmployee = this.findEmployeeMatch(empName, allEmployees);
-          if (matchedEmployee) {
-            employeeIds.push(matchedEmployee.id);
-            debugLog.info(`   ✅ Matched "${empName}" to "${matchedEmployee.name}" (ID: ${matchedEmployee.id})`);
-          } else {
-            debugLog.info(`   ❌ No match found for "${empName}"`);
-          }
-        }
-        
-        debugLog.info(`   Final employee IDs for update: ${employeeIds.join(', ')}`);
-        debugLog.info(`   Employee count: ${employeeIds.length}`);
-        
+
+        debugLog.info(`🔍 Resolving team members for update ${workActivityId}: ${JSON.stringify(parsedActivity.employees)}`);
+        const { employeeIds, warnings: employeeWarnings } = await this.resolveTeamMembers(
+          parsedActivity.employees
+        );
+        warnings.push(...employeeWarnings);
+        debugLog.info(`   Final employee IDs for update: ${employeeIds.join(', ')} (count: ${employeeIds.length})`);
+
         if (employeeIds.length > 0) {
           // Delete existing employee assignments
           await this.workActivityService.db.delete(workActivityEmployees)
@@ -1378,6 +1348,7 @@ export class NotionSyncService {
       
       debugLog.info(`Updated work activity ${workActivityId} with AI-parsed data, charges, and employee assignments`);
 
+      return { warnings };
     } catch (error) {
       debugLog.error(`Error updating work activity ${workActivityId}:`, error);
       throw error;


### PR DESCRIPTION
## Summary

A user reported a record where the elapsed time (9:05 → 10:35 = 1.5h) and the per-employee hours (2.5h × 2 employees) didn't reconcile. Root cause: when a Notion page lists team members who don't match a DB employee record, the sync silently drops them — but `totalHours` was already computed as `duration × teamMembers.length`. Dividing that by the smaller `employeeIds.length` inflated every remaining employee's hours.

In the reported case, Notion listed 3 team members (Andrea, Syd, Anne) but only 2 matched DB records (Syd was missing), so each remaining employee was credited with 1.5× the real time.

## Changes

- **Auto-create unmatched team members** with sensible defaults, mirroring the existing `ensureClientExists` pattern. Each auto-create emits a warning (`"Auto-created employee 'X' from Notion - please review their details"`) that's plumbed through the existing sync warnings channel so it appears in the UI alongside other warnings.
- **Refactor** the three duplicated employee-matching loops (`createWorkActivityFromStructuredData`, `createWorkActivityFromParsedData`, `updateWorkActivityFromParsedData`) into a single `resolveTeamMembers` helper.
- **Side-effect fix for the arithmetic bug**: because every team member now resolves to an employee, `teamMembers.length === employeeIds.length` always holds, so `totalHours / employeeIds.length` returns the real duration.
- **Strip nickname/variant matching from `findEmployeeMatch`** — removed the `andrea/andy`, `sarah/sara`, `michael/mike` etc. variants dict and the prefix-`startsWith` fallback. "Andy" should not silently route hours to "Andrea".

## Code-review follow-ups (commit 15d4023)

- **Whole-token name matching + ambiguity detection.** Replaced bidirectional substring containment in `findEmployeeMatch` with token-based matching (whitespace + hyphen split). "Anne" still matches "Anne McGary" and "Smith" still matches "Anna Smith-Jones", but `"An"` no longer matches "Anne McGary". When more than one candidate matches at the token level (e.g. two `Anne`s in the DB), the function now returns `null` and the caller auto-creates with a visible warning — eliminates the silent first-match-wins behavior.
- **`substr` → `slice`** for the generated `employee_id` suffix (deprecation cleanup).
- **Tightened `findEmployeeMatch` signature** from `any[]` to `Employee[]`.
- **`docs/features/notification-center.md`** — design doc for a persistent in-app notification center to replace transient sync warnings (auto-created employees, ambiguous matches, auto-created clients, failed crons, parse failures). Tracks this as explicit follow-up work.

## Not addressed in this PR

- **Existing inconsistent records**: re-syncing the affected Notion pages should now produce correct numbers. Happy to add a one-off audit script in a follow-up if needed.
- **Web-app edit-time drift**: editing `startTime`/`endTime` in the UI still doesn't recompute per-employee hours. Separate issue.
- **Notification center itself**: design captured in `docs/features/notification-center.md`; not implemented here.

## Test plan

- [x] `npm run type-check` (server) passes
- [x] New unit tests (`notionSync.resolveTeamMembers.test.ts`) — **13 passing**, covering: exact match, token match (first-name → full-name), nickname rejection, blank skipping, dedupe of repeated unmatched names, input-order preservation, empty input, auto-create warning content, substring-but-not-token rejection (`"An"` vs `"Anne McGary"`), ambiguity → auto-create, multi-token Notion → single-token DB, hyphenated last names, and exact-match preferred over token-match
- [ ] Manual: re-sync the Stassi (4/9) Notion page and verify Syd is auto-created, hours rebalance to ~1.83h per person, and a warning appears in the sync UI
- [ ] Manual: review any newly auto-created employees and either fill in their details or merge into existing records

🤖 Generated with [Claude Code](https://claude.com/claude-code)