### PR TITLE
Auto-run DB migrations on docker-compose up

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,29 @@ services:
     networks:
       - blossom-network
 
+  # One-shot DB migration. Runs after postgres is healthy, exits on success.
+  # Backend waits for this to complete before starting.
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    container_name: blossom-migrate
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgresql://blossom_user:blossom_password@postgres:5432/blossom_and_bough
+    volumes:
+      - ./server:/app/server
+      - ./server/package.json:/app/server/package.json
+      - ./server/package-lock.json:/app/server/package-lock.json
+      - backend_node_modules:/app/server/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - blossom-network
+    restart: "no"
+    command: npm run db:migrate:prod
+
   # Backend API Server
   backend:
     build:
@@ -50,6 +73,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     networks:
       - blossom-network
     # Override command to watch for package.json changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,27 @@ services:
     networks:
       - blossom-network
 
+  # One-shot DB migration. Runs after postgres is healthy, exits on success.
+  # Backend waits for this to complete before starting.
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    container_name: blossom-migrate
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgresql://blossom_user:blossom_password@postgres:5432/blossom_and_bough
+    volumes:
+      - ./server:/app/server
+      - /app/server/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - blossom-network
+    restart: "no"
+    command: npm run db:migrate:prod
+
   # Backend API Server
   backend:
     build:
@@ -46,6 +67,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     networks:
       - blossom-network
     command: npm run dev


### PR DESCRIPTION
## Summary
- Adds a one-shot `migrate` service to both `docker-compose.yml` and `docker-compose.dev.yml`
- Runs `npm run db:migrate:prod` after Postgres is healthy, exits cleanly, and gates `backend` startup via `service_completed_successfully`
- Removes the need to manually run `docker-compose exec backend npm run db:migrate` on a fresh stack

## Why a separate service (vs. `&&`-ing into backend's command)
- Backend restarts during dev don't re-run migrations
- Migration failures surface as their own service rather than a crash-looping backend
- Mirrors how migrations typically run in prod/CI

## Test plan
- [ ] `docker-compose -f docker-compose.dev.yml down && docker-compose -f docker-compose.dev.yml up` — `blossom-migrate` runs, logs success, exits, then backend boots
- [ ] Same with `docker-compose.yml`
- [ ] `docker-compose -f docker-compose.dev.yml run --rm migrate` re-runs migrations on demand without restarting other services

🤖 Generated with [Claude Code](https://claude.com/claude-code)