### PR TITLE
Preview-and-edit invoice flow with AI-assisted line items

### DIFF
--- a/server/src/__tests__/aiInvoiceRebuild.test.ts
+++ b/server/src/__tests__/aiInvoiceRebuild.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+// AnthropicService is auto-mocked in setup.ts. We need the real exports for
+// the pure-helper tests below, so unmock just this module.
+jest.unmock('../services/AnthropicService');
+
+import {
+  rebuildLineItemsFromAIResponse,
+  normalizeSuggestedAdditions
+} from '../services/AnthropicService';
+
+describe('rebuildLineItemsFromAIResponse', () => {
+  const basic = [
+    {
+      workActivityId: 1,
+      qboItemId: 'qbo-labor',
+      description: 'original labor desc',
+      quantity: 4,
+      rate: 55,
+      amount: 220
+    },
+    {
+      otherChargeId: 99,
+      qboItemId: 'qbo-materials',
+      description: 'original materials desc',
+      quantity: 1,
+      rate: 30,
+      amount: 30
+    }
+  ];
+
+  it('replaces only the description; preserves identity fields and money', () => {
+    const result = rebuildLineItemsFromAIResponse(
+      [
+        { description: 'Rewritten labor.' },
+        { description: 'Rewritten materials.' }
+      ],
+      basic
+    );
+
+    expect(result).toEqual([
+      { ...basic[0], description: 'Rewritten labor.' },
+      { ...basic[1], description: 'Rewritten materials.' }
+    ]);
+  });
+
+  it('preserves otherChargeId — the bug fix for FK linkage being dropped', () => {
+    const result = rebuildLineItemsFromAIResponse(
+      [{ description: 'A.' }, { description: 'B.' }],
+      basic
+    );
+    expect(result[0].workActivityId).toBe(1);
+    expect(result[1].otherChargeId).toBe(99);
+  });
+
+  it('backfills original descriptions when AI returns fewer lines than provided', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = rebuildLineItemsFromAIResponse(
+      [{ description: 'Rewritten labor.' }], // only 1 of 2 returned
+      basic
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].description).toBe('Rewritten labor.');
+    expect(result[1].description).toBe('original materials desc');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('ignores extra AI lines that have no corresponding original (no extras leak in)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = rebuildLineItemsFromAIResponse(
+      [
+        { description: 'A.' },
+        { description: 'B.' },
+        { description: 'C (extra).' }
+      ],
+      basic
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.description)).toEqual(['A.', 'B.']);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('keeps original description when the AI description is empty or whitespace', () => {
+    const result = rebuildLineItemsFromAIResponse(
+      [{ description: '   ' }, { description: '' }],
+      basic
+    );
+    expect(result[0].description).toBe('original labor desc');
+    expect(result[1].description).toBe('original materials desc');
+  });
+
+  it('keeps original description when the AI description is missing or non-string', () => {
+    const result = rebuildLineItemsFromAIResponse(
+      [{}, { description: 42 as unknown as string }],
+      basic
+    );
+    expect(result[0].description).toBe('original labor desc');
+    expect(result[1].description).toBe('original materials desc');
+  });
+
+  it('does not let the AI alter quantity, rate, amount, or qboItemId', () => {
+    const result = rebuildLineItemsFromAIResponse(
+      [
+        {
+          description: 'A.',
+          quantity: 9999,
+          rate: 9999,
+          amount: 9999,
+          qboItemId: 'attacker-controlled',
+          workActivityId: 6666
+        },
+        { description: 'B.' }
+      ],
+      basic
+    );
+
+    expect(result[0].quantity).toBe(4);
+    expect(result[0].rate).toBe(55);
+    expect(result[0].amount).toBe(220);
+    expect(result[0].qboItemId).toBe('qbo-labor');
+    expect(result[0].workActivityId).toBe(1);
+  });
+
+  it('returns an empty array when there are no basic line items', () => {
+    expect(rebuildLineItemsFromAIResponse([{ description: 'noise' }], [])).toEqual([]);
+  });
+});
+
+describe('normalizeSuggestedAdditions', () => {
+  it('keeps plants and materials suggestions with descriptions', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: 'Sluggo', category: 'materials', quantity: 1 },
+      { description: "Lonicera 'Lemon Beauty'", category: 'plants', quantity: 2 }
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('lowercases the category before checking', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: 'Sluggo', category: 'Materials' }
+    ]);
+    expect(result[0].category).toBe('materials');
+  });
+
+  it('drops entries with unrecognized categories', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: 'Hammer', category: 'tools' },
+      { description: 'Sluggo', category: 'materials' }
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('Sluggo');
+  });
+
+  it('drops entries with empty or whitespace descriptions', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: '   ', category: 'materials' },
+      { description: '', category: 'plants' },
+      { description: 'Mulch', category: 'materials' }
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('Mulch');
+  });
+
+  it('defaults missing or non-positive quantity to 1', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: 'A', category: 'materials' },
+      { description: 'B', category: 'materials', quantity: 0 },
+      { description: 'C', category: 'materials', quantity: -5 },
+      { description: 'D', category: 'materials', quantity: 'three' }
+    ]);
+    expect(result.map(r => r.quantity)).toEqual([1, 1, 1, 1]);
+  });
+
+  it('preserves a positive quantity exactly', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: 'A', category: 'materials', quantity: 3.5 }
+    ]);
+    expect(result[0].quantity).toBe(3.5);
+  });
+
+  it('preserves sourceWorkActivityId only when it is a number', () => {
+    const result = normalizeSuggestedAdditions([
+      { description: 'A', category: 'materials', sourceWorkActivityId: 42 },
+      { description: 'B', category: 'materials', sourceWorkActivityId: '42' }
+    ]);
+    expect(result[0].sourceWorkActivityId).toBe(42);
+    expect(result[1].sourceWorkActivityId).toBeUndefined();
+  });
+
+  it('survives nulls and missing fields without throwing', () => {
+    const result = normalizeSuggestedAdditions([
+      null as unknown as object,
+      undefined as unknown as object,
+      {},
+      { description: 'Good', category: 'materials' }
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('Good');
+  });
+});

--- a/server/src/__tests__/invoiceLineItems.test.ts
+++ b/server/src/__tests__/invoiceLineItems.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeInvoiceLineItems,
   resolveInvoicedWorkActivityIds,
   pickSuggestionRate,
+  computeChargeLineMath,
   InvoiceLineItemData
 } from '../services/InvoiceService';
 
@@ -121,5 +122,47 @@ describe('pickSuggestionRate', () => {
     expect(pickSuggestionRate('specific', null)).toBe(0);
     expect(pickSuggestionRate('specific', { unitPrice: 0 })).toBe(0);
     expect(pickSuggestionRate('specific', { unitPrice: null })).toBe(0);
+  });
+});
+
+describe('computeChargeLineMath', () => {
+  it('handles a charge with only totalCost (the "Lonicera (Tony\'s): $25" case)', () => {
+    expect(computeChargeLineMath({ quantity: null, unitRate: null, totalCost: 25 }))
+      .toEqual({ quantity: 1, rate: 25, amount: 25 });
+  });
+
+  it('handles a charge with only unitRate and a specified quantity', () => {
+    expect(computeChargeLineMath({ quantity: 0.75, unitRate: 8, totalCost: null }))
+      .toEqual({ quantity: 0.75, rate: 8, amount: 6 });
+  });
+
+  it('defaults quantity to 1 when missing', () => {
+    expect(computeChargeLineMath({ quantity: null, unitRate: 5, totalCost: null }))
+      .toEqual({ quantity: 1, rate: 5, amount: 5 });
+  });
+
+  it('returns all zeros for a charge with no pricing data (the "Rose fert N/A" case)', () => {
+    expect(computeChargeLineMath({ quantity: null, unitRate: null, totalCost: null }))
+      .toEqual({ quantity: 1, rate: 0, amount: 0 });
+  });
+
+  it('prefers unitRate when both unitRate and totalCost are set, keeping the line internally consistent', () => {
+    // DB has inconsistent state: qty=2, unitRate=5, totalCost=20.
+    // We trust unitRate and recompute amount, so the invoice shows 2 × $5 = $10
+    // rather than displaying "2 × $5 = $20" which QBO would reject as inconsistent.
+    expect(computeChargeLineMath({ quantity: 2, unitRate: 5, totalCost: 20 }))
+      .toEqual({ quantity: 2, rate: 5, amount: 10 });
+  });
+
+  it('treats zero or negative quantity as 1', () => {
+    expect(computeChargeLineMath({ quantity: 0, unitRate: 10, totalCost: null }))
+      .toEqual({ quantity: 1, rate: 10, amount: 10 });
+    expect(computeChargeLineMath({ quantity: -2, unitRate: 10, totalCost: null }))
+      .toEqual({ quantity: 1, rate: 10, amount: 10 });
+  });
+
+  it('accepts a zero unitRate as an explicit free line', () => {
+    expect(computeChargeLineMath({ quantity: 3, unitRate: 0, totalCost: null }))
+      .toEqual({ quantity: 3, rate: 0, amount: 0 });
   });
 });

--- a/server/src/__tests__/invoiceLineItems.test.ts
+++ b/server/src/__tests__/invoiceLineItems.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import {
+  normalizeInvoiceLineItems,
+  resolveInvoicedWorkActivityIds,
+  pickSuggestionRate,
+  InvoiceLineItemData
+} from '../services/InvoiceService';
+
+const baseLine = (overrides: Partial<InvoiceLineItemData> = {}): InvoiceLineItemData => ({
+  qboItemId: 'qbo-1',
+  description: 'Garden maintenance.',
+  quantity: 2,
+  rate: 55,
+  amount: 0,
+  ...overrides
+});
+
+describe('normalizeInvoiceLineItems', () => {
+  it('recomputes amount from quantity × rate, ignoring the submitted amount', () => {
+    const result = normalizeInvoiceLineItems([
+      baseLine({ quantity: 2, rate: 55, amount: 999_999 })
+    ]);
+    expect(result[0].amount).toBe(110);
+  });
+
+  it('preserves workActivityId and otherChargeId', () => {
+    const result = normalizeInvoiceLineItems([
+      baseLine({ workActivityId: 42, otherChargeId: 7 })
+    ]);
+    expect(result[0].workActivityId).toBe(42);
+    expect(result[0].otherChargeId).toBe(7);
+  });
+
+  it('throws when qboItemId is missing', () => {
+    expect(() =>
+      normalizeInvoiceLineItems([baseLine({ qboItemId: '' })])
+    ).toThrow(/missing qboItemId/);
+  });
+
+  it('throws when quantity is zero or negative', () => {
+    expect(() =>
+      normalizeInvoiceLineItems([baseLine({ quantity: 0 })])
+    ).toThrow(/quantity > 0/);
+    expect(() =>
+      normalizeInvoiceLineItems([baseLine({ quantity: -1 })])
+    ).toThrow(/quantity > 0/);
+  });
+
+  it('throws when rate is negative', () => {
+    expect(() =>
+      normalizeInvoiceLineItems([baseLine({ rate: -0.01 })])
+    ).toThrow(/rate >= 0/);
+  });
+
+  it('accepts a zero rate (free line)', () => {
+    const result = normalizeInvoiceLineItems([baseLine({ rate: 0 })]);
+    expect(result[0].amount).toBe(0);
+  });
+
+  it('defaults missing description to empty string', () => {
+    const result = normalizeInvoiceLineItems([
+      baseLine({ description: undefined as unknown as string })
+    ]);
+    expect(result[0].description).toBe('');
+  });
+
+  it('reports the offending line number in the error message', () => {
+    expect(() =>
+      normalizeInvoiceLineItems([
+        baseLine(),
+        baseLine({ qboItemId: '' })
+      ])
+    ).toThrow(/Line 2/);
+  });
+});
+
+describe('resolveInvoicedWorkActivityIds', () => {
+  it('prefers the explicit selection over what survived on the line items', () => {
+    const ids = resolveInvoicedWorkActivityIds(
+      [1, 2, 3],
+      [baseLine({ workActivityId: 1 })] // user removed labor lines for 2 and 3
+    );
+    expect(ids.sort()).toEqual([1, 2, 3]);
+  });
+
+  it('deduplicates the selection', () => {
+    expect(resolveInvoicedWorkActivityIds([1, 1, 2], [])).toEqual([1, 2]);
+  });
+
+  it('falls back to line-item workActivityIds when no selection provided', () => {
+    const ids = resolveInvoicedWorkActivityIds(
+      undefined,
+      [
+        baseLine({ workActivityId: 5 }),
+        baseLine({ workActivityId: 6 }),
+        baseLine({ otherChargeId: 9 }) // no workActivityId — should be filtered
+      ]
+    );
+    expect(ids.sort()).toEqual([5, 6]);
+  });
+
+  it('returns empty when neither source has IDs', () => {
+    expect(resolveInvoicedWorkActivityIds(undefined, [baseLine()])).toEqual([]);
+    expect(resolveInvoicedWorkActivityIds([], [baseLine()])).toEqual([]);
+  });
+});
+
+describe('pickSuggestionRate', () => {
+  it('uses the QBO item unitPrice for a specific match', () => {
+    expect(pickSuggestionRate('specific', { unitPrice: 12.5 })).toBe(12.5);
+  });
+
+  it('returns 0 for category/fuzzy/fallback/none matches', () => {
+    expect(pickSuggestionRate('category', { unitPrice: 12.5 })).toBe(0);
+    expect(pickSuggestionRate('fuzzy', { unitPrice: 12.5 })).toBe(0);
+    expect(pickSuggestionRate('fallback', { unitPrice: 12.5 })).toBe(0);
+    expect(pickSuggestionRate('none', null)).toBe(0);
+  });
+
+  it('returns 0 when a specific match has no unitPrice', () => {
+    expect(pickSuggestionRate('specific', null)).toBe(0);
+    expect(pickSuggestionRate('specific', { unitPrice: 0 })).toBe(0);
+    expect(pickSuggestionRate('specific', { unitPrice: null })).toBe(0);
+  });
+});

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -173,7 +173,7 @@ router.get('/items', async (req, res) => {
  */
 router.post('/invoices', async (req, res) => {
   try {
-    const { clientId, lineItems, dueDate, memo } = req.body;
+    const { clientId, lineItems, workActivityIds, dueDate, memo } = req.body;
 
     if (!clientId) {
       return res.status(400).json({ error: 'Client ID is required' });
@@ -186,6 +186,9 @@ router.post('/invoices', async (req, res) => {
     const result = await invoiceService.createInvoiceFromLineItems({
       clientId,
       lineItems,
+      workActivityIds: Array.isArray(workActivityIds)
+        ? workActivityIds.filter((id: unknown): id is number => typeof id === 'number')
+        : undefined,
       dueDate,
       memo
     });

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { services } from '../services/container';
 import { requireAuth } from '../middleware/auth';
-import { invoices, invoiceLineItems, workActivities, clients, otherCharges } from '../db';
-import { eq, and, inArray } from 'drizzle-orm';
+import { invoices, invoiceLineItems, workActivities } from '../db';
+import { eq, and } from 'drizzle-orm';
 
 const router = Router();
 const qbService = services.quickBooksService;
@@ -169,44 +169,37 @@ router.get('/items', async (req, res) => {
 });
 
 /**
- * Create invoice from work activities
+ * Create invoice from previously-previewed (and possibly edited) line items.
  */
 router.post('/invoices', async (req, res) => {
   try {
-    const { workActivityIds, clientId, dueDate, memo, includeOtherCharges, useAIGeneration } = req.body;
-    
-    if (!workActivityIds || !Array.isArray(workActivityIds) || workActivityIds.length === 0) {
-      return res.status(400).json({ error: 'Work activity IDs are required' });
-    }
-    
+    const { clientId, lineItems, dueDate, memo } = req.body;
+
     if (!clientId) {
       return res.status(400).json({ error: 'Client ID is required' });
     }
-    
-    console.log(`Creating invoice for ${workActivityIds.length} work activities for client ${clientId}`);
-    if (useAIGeneration) {
-      console.log('🤖 AI enhancement requested');
+
+    if (!lineItems || !Array.isArray(lineItems) || lineItems.length === 0) {
+      return res.status(400).json({ error: 'lineItems (array) is required' });
     }
-    
-    const result = await invoiceService.createInvoiceFromWorkActivities({
-      workActivityIds,
+
+    const result = await invoiceService.createInvoiceFromLineItems({
       clientId,
+      lineItems,
       dueDate,
-      memo,
-      includeOtherCharges: includeOtherCharges !== false, // Default to true
-      useAIGeneration: useAIGeneration === true // Default to false
+      memo
     });
-    
-    res.json({ 
-      success: true, 
+
+    res.json({
+      success: true,
       result,
       message: 'Invoice created successfully'
     });
   } catch (error) {
     console.error('Error creating invoice:', error);
-    res.status(500).json({ 
-      error: 'Failed to create invoice', 
-      details: error instanceof Error ? error.message : 'Unknown error' 
+    res.status(500).json({
+      error: 'Failed to create invoice',
+      details: error instanceof Error ? error.message : 'Unknown error'
     });
   }
 });
@@ -324,109 +317,34 @@ router.get('/clients/:clientId/invoiceable-activities', async (req, res) => {
 });
 
 /**
- * Preview invoice before creating it
+ * Preview the exact invoice line items that would be sent to QBO.
+ * Uses the same builder and AI enhancement as creation so the preview cannot
+ * diverge from what gets created.
  */
 router.post('/invoices/preview', async (req, res) => {
   try {
-    const {
+    const { clientId, workActivityIds, includeOtherCharges, useAIGeneration } = req.body;
+
+    if (!clientId || !workActivityIds || !Array.isArray(workActivityIds) || workActivityIds.length === 0) {
+      return res.status(400).json({
+        error: 'clientId and workActivityIds (array) are required'
+      });
+    }
+
+    const result = await invoiceService.previewInvoice({
       clientId,
       workActivityIds,
-      includeOtherCharges = true
-    } = req.body;
-
-    // Validate required fields
-    if (!clientId || !workActivityIds || !Array.isArray(workActivityIds) || workActivityIds.length === 0) {
-      return res.status(400).json({ 
-        error: 'clientId and workActivityIds (array) are required' 
-      });
-    }
-
-    // Get client info
-    const client = await invoiceService.db
-      .select()
-      .from(clients)
-      .where(eq(clients.id, clientId))
-      .limit(1);
-
-    if (!client[0]) {
-      return res.status(404).json({ error: 'Client not found' });
-    }
-
-    // Get work activities
-    const activities = await invoiceService.db
-      .select()
-      .from(workActivities)
-      .where(inArray(workActivities.id, workActivityIds));
-
-    // Calculate preview data without creating actual invoice
-    let totalAmount = 0;
-    const previewLines = [];
-
-    // Group activities by work type
-    const serviceGroups = new Map();
-    for (const activity of activities) {
-      if (!serviceGroups.has(activity.workType)) {
-        serviceGroups.set(activity.workType, { activities: [], totalHours: 0 });
-      }
-      const group = serviceGroups.get(activity.workType);
-      group.activities.push(activity);
-      group.totalHours += activity.billableHours || activity.totalHours || 0;
-    }
-
-    // Add service lines
-    for (const [workType, group] of serviceGroups) {
-      const rate = 55.00; // Default rate - in production, get from QBO items
-      const amount = group.totalHours * rate;
-      
-      previewLines.push({
-        type: 'service',
-        workType: workType,
-        description: `${workType} - ${group.totalHours} hours`,
-        quantity: group.totalHours,
-        rate: rate,
-        amount: amount
-      });
-      
-      totalAmount += amount;
-    }
-
-    // Add other charges if requested
-    if (includeOtherCharges) {
-      for (const activity of activities) {
-        const charges = await invoiceService.db
-          .select()
-          .from(otherCharges)
-          .where(and(
-            eq(otherCharges.workActivityId, activity.id),
-            eq(otherCharges.billable, true)
-          ));
-
-        for (const charge of charges) {
-          previewLines.push({
-            type: 'charge',
-            chargeType: charge.chargeType,
-            description: charge.description,
-            quantity: charge.quantity || 1,
-            rate: charge.unitRate || charge.totalCost || 0,
-            amount: charge.totalCost || 0
-          });
-          
-          totalAmount += charge.totalCost || 0;
-        }
-      }
-    }
-
-    res.json({
-      client: client[0],
-      activities: activities,
-      previewLines: previewLines,
-      totalAmount: totalAmount,
-      lineCount: previewLines.length
+      includeOtherCharges: includeOtherCharges !== false,
+      useAIGeneration: useAIGeneration === true
     });
 
+    res.json(result);
   } catch (error) {
     console.error('Error generating invoice preview:', error);
-    res.status(500).json({ error: 'Failed to generate invoice preview' });
+    res.status(500).json({
+      error: 'Failed to generate invoice preview',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
   }
 });
 

--- a/server/src/services/AnthropicService.ts
+++ b/server/src/services/AnthropicService.ts
@@ -1429,51 +1429,48 @@ CRITICAL: Return ONLY a valid JSON array starting with [ and ending with ]. Extr
 
     console.log(`🤖 Generating AI-enhanced invoice line items for ${clientName}...`);
 
-    const systemPrompt = `You are an expert landscaping invoice generator. Your task is to transform basic work activity data into detailed, professional invoice line items that clients will find clear, valuable, and comprehensive.
+    const systemPrompt = `You rewrite invoice line item descriptions for a landscaping business. The house style is terse and factual: a single sentence, comma-separated list of the work performed, ending with a period. No marketing language.`;
 
-Transform basic entries like "Specialized garden care - 31.81 hours" into detailed line items that include:
-- Specific dates and work performed
-- Detailed descriptions of tasks completed
-- Materials used and plants installed
-- Professional presentation that justifies the value
+    const userPrompt = `Rewrite the description on each line item below to match the house style.
 
-Focus on creating line items that demonstrate the expertise, care, and value provided during the work.`;
+HOUSE STYLE
+- One sentence per description, ending with a period.
+- Comma-separated list of tasks performed. Examples of the target style:
+  • "Weeding, deadheading hellebores, pruning (rhododendrons, mahonia, camellia), garden meeting, planting cascara and spirea, general clean up."
+  • "Training vines/peas, volunteer tree removal, weeds, clean up, perennial care, sluggo."
+  • "Pruning (barberry, nandina, fringeflower, camellia), weeding, deadheading hellebores, irrigation check and adjustments."
+  • Plants/materials lines: "Cascara tree, mahonia nervosa." or "Horticultural oil, lacewings." or "Pomegranate tree, shrubs for border where fence fell."
+- Capitalize only the first word. Keep subsequent items lowercase except proper nouns (plant names, places, "Sluggo" if it's a brand, etc.).
+- Group related work in parentheses when natural, e.g., "pruning (rhododendrons, mahonia)".
+- Aim for under ~250 characters. Longer is OK only when the work genuinely required it.
 
-    const userPrompt = `Transform this basic invoice data into detailed professional line items for ${clientName}.
+DO NOT INCLUDE
+- Dates, hours, hourly rate, totals, or client name — those appear in their own invoice columns.
+- Adjectives like "professional", "comprehensive", "expert", "detailed", "meticulous".
+- First-person "we" / "our team" / "I".
+- "Value demonstration" framing — just list the work.
 
-Work Activities Data:
+DATA
+Client: ${clientName}
+
+Work activities (use these for raw task content):
 ${JSON.stringify(workActivities, null, 2)}
 
-Basic Line Items:
+Current line items (rewrite each description in place, preserve everything else):
 ${JSON.stringify(basicLineItems, null, 2)}
 
-Create enhanced line items that include:
-1. Specific dates and detailed work descriptions
-2. Professional task descriptions that show expertise
-3. Materials, plants, and supplies used
-4. Clear value demonstration
-
-CRITICAL REQUIREMENTS:
-- Keep the EXACT same quantity (hours) and rate ($55/hour) from the basic line items
-- ONLY enhance the description - do NOT change quantity, rate, or amount
-- Preserve the hourly billing structure
-
-Return a JSON array of enhanced line items with this structure:
+OUTPUT
+Return ONLY a JSON array, one object per current line item in the same order, with this shape (preserve quantity, rate, amount, workActivityId, qboItemId exactly from the input):
 [
   {
-    "description": "Enhanced professional description with dates and specific work details",
-    "quantity": 11.06,  // KEEP EXACT SAME HOURS from basic line item
-    "rate": 55.00,      // KEEP EXACT SAME HOURLY RATE
-    "amount": 608.30,   // KEEP EXACT SAME TOTAL AMOUNT
+    "description": "Rewritten description in house style.",
+    "quantity": 11.06,
+    "rate": 55.00,
+    "amount": 608.30,
     "workActivityId": 123,
     "qboItemId": "original-qbo-item-id"
   }
-]
-
-CRITICAL: 
-- ONLY enhance descriptions, preserve all numbers exactly
-- Return ONLY a valid JSON array
-- Transform ALL provided work activities into detailed line items`;
+]`;
 
     try {
       const response = await this.client.messages.create({

--- a/server/src/services/AnthropicService.ts
+++ b/server/src/services/AnthropicService.ts
@@ -1422,55 +1422,72 @@ CRITICAL: Return ONLY a valid JSON array starting with [ and ending with ]. Extr
     workActivities: any[],
     clientName: string,
     basicLineItems: any[]
-  ): Promise<any[]> {
+  ): Promise<{ lineItems: any[]; suggestedAdditions: SuggestedAddition[] }> {
     if (!this.client) {
       throw new Error('Anthropic API client not initialized');
     }
 
     console.log(`🤖 Generating AI-enhanced invoice line items for ${clientName}...`);
 
-    const systemPrompt = `You rewrite invoice line item descriptions for a landscaping business. The house style is terse and factual: a single sentence, comma-separated list of the work performed, ending with a period. No marketing language.`;
+    const systemPrompt = `You write invoice line item descriptions for a landscaping business AND identify plants/materials mentioned in the work notes that may need separate billing as their own line items.`;
 
-    const userPrompt = `Rewrite the description on each line item below to match the house style.
+    const userPrompt = `Two jobs:
+1. Rewrite the description on each line item to match the house style.
+2. Identify plants/materials/supplies mentioned in the work notes that are NOT already represented in the current line items.
 
-HOUSE STYLE
+HOUSE STYLE FOR DESCRIPTIONS
 - One sentence per description, ending with a period.
 - Comma-separated list of tasks performed. Examples of the target style:
   • "Weeding, deadheading hellebores, pruning (rhododendrons, mahonia, camellia), garden meeting, planting cascara and spirea, general clean up."
   • "Training vines/peas, volunteer tree removal, weeds, clean up, perennial care, sluggo."
-  • "Pruning (barberry, nandina, fringeflower, camellia), weeding, deadheading hellebores, irrigation check and adjustments."
-  • Plants/materials lines: "Cascara tree, mahonia nervosa." or "Horticultural oil, lacewings." or "Pomegranate tree, shrubs for border where fence fell."
-- Capitalize only the first word. Keep subsequent items lowercase except proper nouns (plant names, places, "Sluggo" if it's a brand, etc.).
-- Group related work in parentheses when natural, e.g., "pruning (rhododendrons, mahonia)".
-- Aim for under ~250 characters. Longer is OK only when the work genuinely required it.
+  • Plants/materials lines: "Cascara tree, mahonia nervosa." or "Horticultural oil, lacewings."
+- Capitalize only the first word. Subsequent items lowercase except proper nouns (plant names, places, brand names).
+- Group related work in parentheses when natural.
+- Aim for under ~250 characters.
+- DO NOT include dates, hours, rate, totals, or client name (other columns have those).
+- DO NOT use marketing words ("professional", "comprehensive", "expert", "value", etc.) or first-person "we".
 
-DO NOT INCLUDE
-- Dates, hours, hourly rate, totals, or client name — those appear in their own invoice columns.
-- Adjectives like "professional", "comprehensive", "expert", "detailed", "meticulous".
-- First-person "we" / "our team" / "I".
-- "Value demonstration" framing — just list the work.
+HOW TO IDENTIFY SUGGESTED ADDITIONS
+The labor line covers the work; suggested additions are the things bought/applied. Look in the work activity notes for:
+- Plants installed: "planted X", "planting X", "transplanted X", or specific plant names mentioned (lonicera, mahonia, cascara, hellebore, etc.) → category: "plants"
+- Branded products applied: "sluggo", "roundup", etc. → category: "materials"
+- Treatments and supplies: "horticultural oil", "lacewings", "rose fertilizer", "sluggo on hostas", "compost", "mulch" → category: "materials"
+- Soil, gravel, deliveries (when delivered for the job) → category: "materials"
+
+Skip suggestions when:
+- The current line items already include that material/plant (look at descriptions and qboItemId types).
+- The mention is generic labor without a specific product ("general planting", "transplanting from another bed", "weeding").
+- The item is clearly the client's own (e.g., "moved client's existing rose to new bed").
+
+Suggested descriptions should be short noun phrases in the house style for plants/materials lines (e.g., "Lonicera 'Lemon Beauty'", "Sluggo", "Rose fertilizer", "Horticultural oil"). Don't write sentences.
 
 DATA
 Client: ${clientName}
 
-Work activities (use these for raw task content):
+Work activities (raw notes/tasks live here):
 ${JSON.stringify(workActivities, null, 2)}
 
-Current line items (rewrite each description in place, preserve everything else):
+Current line items (already represented — do not re-suggest these):
 ${JSON.stringify(basicLineItems, null, 2)}
 
 OUTPUT
-Return ONLY a JSON array, one object per current line item in the same order, with this shape (preserve quantity, rate, amount, workActivityId, qboItemId exactly from the input):
-[
-  {
-    "description": "Rewritten description in house style.",
-    "quantity": 11.06,
-    "rate": 55.00,
-    "amount": 608.30,
-    "workActivityId": 123,
-    "qboItemId": "original-qbo-item-id"
-  }
-]`;
+Return ONLY a JSON object (not an array) in this exact shape. Preserve quantity, rate, amount, workActivityId, qboItemId exactly for each lineItems entry. Use an empty array for suggestedAdditions if nothing applies.
+{
+  "lineItems": [
+    {
+      "description": "Rewritten description in house style.",
+      "quantity": 11.06,
+      "rate": 55.00,
+      "amount": 608.30,
+      "workActivityId": 123,
+      "qboItemId": "original-qbo-item-id"
+    }
+  ],
+  "suggestedAdditions": [
+    { "description": "Lonicera 'Lemon Beauty'", "category": "plants", "quantity": 1, "sourceWorkActivityId": 123 },
+    { "description": "Sluggo", "category": "materials", "quantity": 1, "sourceWorkActivityId": 123 }
+  ]
+}`;
 
     try {
       const response = await this.client.messages.create({
@@ -1489,25 +1506,26 @@ Return ONLY a JSON array, one object per current line item in the same order, wi
       const responseText = (textContent as any).text;
       console.log(`📝 Claude AI invoice response: ${responseText.length} characters`);
 
-      // Extract JSON from response
-      let enhancedLineItems: any[] = [];
-      
+      // Extract a JSON object (preferred) — fall back to a bare array for safety if the
+      // model regresses to the older shape.
+      let parsed: any;
       try {
-        // Look for JSON array in the response
-        const jsonMatch = responseText.match(/\[[\s\S]*\]/);
-        if (jsonMatch) {
-          enhancedLineItems = JSON.parse(jsonMatch[0]);
-          console.log(`✅ Successfully generated ${enhancedLineItems.length} enhanced line items`);
+        const objectMatch = responseText.match(/\{[\s\S]*\}/);
+        const arrayMatch = responseText.match(/\[[\s\S]*\]/);
+        const codeBlockMatch = responseText.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+
+        if (objectMatch) {
+          parsed = JSON.parse(objectMatch[0]);
+        } else if (codeBlockMatch) {
+          parsed = JSON.parse(codeBlockMatch[1]);
+        } else if (arrayMatch) {
+          parsed = { lineItems: JSON.parse(arrayMatch[0]), suggestedAdditions: [] };
         } else {
-          // Try to extract from code blocks
-          const codeBlockMatch = responseText.match(/```(?:json)?\s*(\[[\s\S]*?\])\s*```/);
-          if (codeBlockMatch) {
-            enhancedLineItems = JSON.parse(codeBlockMatch[1]);
-            console.log(`✅ Generated ${enhancedLineItems.length} enhanced line items from code block`);
-          } else {
-            console.error(`❌ No JSON found in AI response:`, responseText.substring(0, 500));
-            throw new Error('No JSON array found in AI response');
-          }
+          throw new Error('No JSON object found in AI response');
+        }
+
+        if (Array.isArray(parsed)) {
+          parsed = { lineItems: parsed, suggestedAdditions: [] };
         }
       } catch (parseError) {
         console.error(`❌ Failed to parse AI response JSON:`, parseError);
@@ -1515,49 +1533,51 @@ Return ONLY a JSON array, one object per current line item in the same order, wi
         throw new Error(`Failed to parse AI-enhanced line items`);
       }
 
-      // Validate and normalize the enhanced line items, preserving original numbers
-      enhancedLineItems = enhancedLineItems.map((item: any, index: number) => {
+      const rawLineItems: any[] = Array.isArray(parsed.lineItems) ? parsed.lineItems : [];
+      const rawSuggestions: any[] = Array.isArray(parsed.suggestedAdditions) ? parsed.suggestedAdditions : [];
+      console.log(`✅ Parsed ${rawLineItems.length} line items and ${rawSuggestions.length} suggested additions`);
+
+      // Preserve numbers from the original line items; only the AI's description is trusted.
+      const lineItems = rawLineItems.map((item: any, index: number) => {
         const originalItem = basicLineItems[index];
         if (!originalItem) {
-          console.warn(`AI returned more line items than provided, using basic item`);
-          return basicLineItems[basicLineItems.length - 1];
-        }
-
-        // Validate that AI preserved the numbers correctly
-        const aiQuantity = parseFloat(item.quantity?.toString() || '0');
-        const aiRate = parseFloat(item.rate?.toString() || '0');
-        const aiAmount = parseFloat(item.amount?.toString() || '0');
-
-        const originalQuantity = originalItem.quantity;
-        const originalRate = originalItem.rate;
-        const originalAmount = originalItem.amount;
-
-        // Check if AI changed the numbers (allow small floating point differences)
-        const quantityChanged = Math.abs(aiQuantity - originalQuantity) > 0.01;
-        const rateChanged = Math.abs(aiRate - originalRate) > 0.01;
-        const amountChanged = Math.abs(aiAmount - originalAmount) > 0.01;
-
-        if (quantityChanged || rateChanged || amountChanged) {
-          console.warn(`AI changed numbers for line item ${index + 1}, preserving original values`);
-          console.warn(`Original: qty=${originalQuantity}, rate=${originalRate}, amount=${originalAmount}`);
-          console.warn(`AI: qty=${aiQuantity}, rate=${aiRate}, amount=${aiAmount}`);
+          console.warn(`AI returned more line items than provided, dropping extras`);
+          return null;
         }
 
         return {
           description: item.description || originalItem.description,
-          quantity: originalQuantity, // Always use original quantity
-          rate: originalRate, // Always use original rate
-          amount: originalAmount, // Always use original amount
+          quantity: originalItem.quantity,
+          rate: originalItem.rate,
+          amount: originalItem.amount,
           workActivityId: originalItem.workActivityId,
           qboItemId: originalItem.qboItemId
         };
-      });
+      }).filter((item): item is any => item !== null);
 
-      return enhancedLineItems;
+      const suggestedAdditions: SuggestedAddition[] = [];
+      for (const s of rawSuggestions) {
+        const category = String(s.category || '').toLowerCase();
+        if (category !== 'plants' && category !== 'materials') continue;
+        const description = String(s.description || '').trim();
+        if (!description) continue;
+        const quantity = typeof s.quantity === 'number' && s.quantity > 0 ? s.quantity : 1;
+        const sourceWorkActivityId = typeof s.sourceWorkActivityId === 'number' ? s.sourceWorkActivityId : undefined;
+        suggestedAdditions.push({ description, category, quantity, sourceWorkActivityId });
+      }
+
+      return { lineItems, suggestedAdditions };
 
     } catch (error) {
       console.error('❌ Error generating AI-enhanced invoice line items:', error);
       throw new Error(`Failed to generate AI-enhanced invoice: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
+}
+
+export interface SuggestedAddition {
+  description: string;
+  category: 'plants' | 'materials';
+  quantity: number;
+  sourceWorkActivityId?: number;
 }

--- a/server/src/services/AnthropicService.ts
+++ b/server/src/services/AnthropicService.ts
@@ -1537,34 +1537,8 @@ Return ONLY a JSON object (not an array) in this exact shape. Preserve quantity,
       const rawSuggestions: any[] = Array.isArray(parsed.suggestedAdditions) ? parsed.suggestedAdditions : [];
       console.log(`✅ Parsed ${rawLineItems.length} line items and ${rawSuggestions.length} suggested additions`);
 
-      // Preserve numbers from the original line items; only the AI's description is trusted.
-      const lineItems = rawLineItems.map((item: any, index: number) => {
-        const originalItem = basicLineItems[index];
-        if (!originalItem) {
-          console.warn(`AI returned more line items than provided, dropping extras`);
-          return null;
-        }
-
-        return {
-          description: item.description || originalItem.description,
-          quantity: originalItem.quantity,
-          rate: originalItem.rate,
-          amount: originalItem.amount,
-          workActivityId: originalItem.workActivityId,
-          qboItemId: originalItem.qboItemId
-        };
-      }).filter((item): item is any => item !== null);
-
-      const suggestedAdditions: SuggestedAddition[] = [];
-      for (const s of rawSuggestions) {
-        const category = String(s.category || '').toLowerCase();
-        if (category !== 'plants' && category !== 'materials') continue;
-        const description = String(s.description || '').trim();
-        if (!description) continue;
-        const quantity = typeof s.quantity === 'number' && s.quantity > 0 ? s.quantity : 1;
-        const sourceWorkActivityId = typeof s.sourceWorkActivityId === 'number' ? s.sourceWorkActivityId : undefined;
-        suggestedAdditions.push({ description, category, quantity, sourceWorkActivityId });
-      }
+      const lineItems = rebuildLineItemsFromAIResponse(rawLineItems, basicLineItems);
+      const suggestedAdditions = normalizeSuggestedAdditions(rawSuggestions);
 
       return { lineItems, suggestedAdditions };
 
@@ -1580,4 +1554,58 @@ export interface SuggestedAddition {
   category: 'plants' | 'materials';
   quantity: number;
   sourceWorkActivityId?: number;
+}
+
+/**
+ * Rebuild invoice line items from an AI response while preserving every
+ * non-description field (identity FKs and money values) from the originals.
+ *
+ * Two correctness rules drive this:
+ *   1. The AI is only trusted to rewrite the description. workActivityId,
+ *      otherChargeId, qboItemId, quantity, rate, and amount stay verbatim
+ *      from the original — otherwise the AI checkbox would silently change
+ *      what gets billed or which rows get FK-linked when saved locally.
+ *   2. We iterate the original line items (not the AI response) so a short
+ *      AI reply can never drop a billable row.
+ */
+export function rebuildLineItemsFromAIResponse(rawLineItems: any[], basicLineItems: any[]): any[] {
+  if (rawLineItems.length !== basicLineItems.length) {
+    console.warn(
+      `⚠️ AI returned ${rawLineItems.length} line items for ${basicLineItems.length} provided; ` +
+      `falling back to original descriptions for any missing entries to avoid silently dropping billable lines.`
+    );
+  }
+
+  return basicLineItems.map((originalItem: any, index: number) => {
+    const aiItem = rawLineItems[index];
+    const aiDescription =
+      aiItem && typeof aiItem.description === 'string' && aiItem.description.trim()
+        ? aiItem.description
+        : null;
+    return {
+      ...originalItem,
+      description: aiDescription ?? originalItem.description
+    };
+  });
+}
+
+/**
+ * Filter and normalize suggested additions from raw AI output:
+ *   - drop entries with an unrecognized category
+ *   - drop entries without a description
+ *   - default quantity to 1 if missing or non-positive
+ *   - preserve `sourceWorkActivityId` only when it's actually a number
+ */
+export function normalizeSuggestedAdditions(rawSuggestions: any[]): SuggestedAddition[] {
+  const out: SuggestedAddition[] = [];
+  for (const s of rawSuggestions) {
+    const category = String(s?.category || '').toLowerCase();
+    if (category !== 'plants' && category !== 'materials') continue;
+    const description = String(s?.description || '').trim();
+    if (!description) continue;
+    const quantity = typeof s?.quantity === 'number' && s.quantity > 0 ? s.quantity : 1;
+    const sourceWorkActivityId = typeof s?.sourceWorkActivityId === 'number' ? s.sourceWorkActivityId : undefined;
+    out.push({ description, category, quantity, sourceWorkActivityId });
+  }
+  return out;
 }

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -2,7 +2,7 @@ import { DatabaseService } from './DatabaseService';
 import { QuickBooksService } from './QuickBooksService';
 import { ClientService } from './ClientService';
 import { WorkActivityService } from './WorkActivityService';
-import { AnthropicService } from './AnthropicService';
+import { AnthropicService, SuggestedAddition } from './AnthropicService';
 import { 
   workActivities, 
   invoices, 
@@ -37,9 +37,15 @@ export interface InvoiceLineItemData {
   amount: number;
 }
 
+export interface SuggestedLineItem extends InvoiceLineItemData {
+  category: 'plants' | 'materials';
+  sourceWorkActivityId?: number;
+}
+
 export interface InvoicePreviewResult {
   client: any;
   lineItems: InvoiceLineItemData[];
+  suggestedLineItems: SuggestedLineItem[];
   totalAmount: number;
 }
 
@@ -137,17 +143,21 @@ export class InvoiceService extends DatabaseService {
       throw new Error('No line items could be generated for the invoice. Please check if QBO items are properly synced.');
     }
 
+    let suggestedLineItems: SuggestedLineItem[] = [];
+
     if (request.useAIGeneration) {
       try {
-        const enhancedLineItems = await this.anthropicService.generateInvoiceLineItems(
+        const aiResult = await this.anthropicService.generateInvoiceLineItems(
           workActivitiesData,
           client.name,
           lineItems
         );
 
-        if (enhancedLineItems && enhancedLineItems.length > 0) {
-          lineItems = enhancedLineItems;
+        if (aiResult.lineItems && aiResult.lineItems.length > 0) {
+          lineItems = aiResult.lineItems;
         }
+
+        suggestedLineItems = await this.materializeSuggestedAdditions(aiResult.suggestedAdditions);
       } catch (aiError) {
         console.error('AI generation failed during preview, falling back to basic line items:', aiError);
       }
@@ -155,7 +165,28 @@ export class InvoiceService extends DatabaseService {
 
     const totalAmount = lineItems.reduce((sum, item) => sum + item.amount, 0);
 
-    return { client, lineItems, totalAmount };
+    return { client, lineItems, suggestedLineItems, totalAmount };
+  }
+
+  private async materializeSuggestedAdditions(suggestions: SuggestedAddition[]): Promise<SuggestedLineItem[]> {
+    const out: SuggestedLineItem[] = [];
+    for (const suggestion of suggestions) {
+      const qboItem = await this.findQBOItemForChargeType(suggestion.category === 'plants' ? 'plant' : 'material');
+      if (!qboItem) {
+        console.warn(`No QBO item found for suggested ${suggestion.category}: ${suggestion.description} — dropping suggestion`);
+        continue;
+      }
+      out.push({
+        qboItemId: qboItem.qboId,
+        description: suggestion.description,
+        quantity: suggestion.quantity,
+        rate: 0,
+        amount: 0,
+        category: suggestion.category,
+        sourceWorkActivityId: suggestion.sourceWorkActivityId
+      });
+    }
+    return out;
   }
 
   /**

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -13,13 +13,18 @@ import {
 } from '../db';
 import { eq, and, inArray } from 'drizzle-orm';
 
-export interface CreateInvoiceRequest {
+export interface PreviewInvoiceRequest {
   clientId: number;
   workActivityIds: number[];
   includeOtherCharges?: boolean;
+  useAIGeneration?: boolean;
+}
+
+export interface CreateInvoiceFromLineItemsRequest {
+  clientId: number;
+  lineItems: InvoiceLineItemData[];
   dueDate?: string;
   memo?: string;
-  useAIGeneration?: boolean;
 }
 
 export interface InvoiceLineItemData {
@@ -30,6 +35,12 @@ export interface InvoiceLineItemData {
   quantity: number;
   rate: number;
   amount: number;
+}
+
+export interface InvoicePreviewResult {
+  client: any;
+  lineItems: InvoiceLineItemData[];
+  totalAmount: number;
 }
 
 export class InvoiceService extends DatabaseService {
@@ -108,80 +119,109 @@ export class InvoiceService extends DatabaseService {
   }
 
   /**
-   * Create invoice from work activities
+   * Build a preview of the invoice line items the server would send to QBO.
+   * Runs the same builder and AI enhancement that creation uses, so the user
+   * sees and edits the exact lines that will be submitted.
    */
-  async createInvoiceFromWorkActivities(request: CreateInvoiceRequest): Promise<any> {
-    try {
-      console.log('Starting invoice creation process...');
-      
-      // 0. Ensure QuickBooks service is properly initialized
-      await this.ensureQBServiceInitialized();
-      console.log('QuickBooks service initialized');
+  async previewInvoice(request: PreviewInvoiceRequest): Promise<InvoicePreviewResult> {
+    const client = await this.clientService.getClientById(request.clientId);
+    if (!client) {
+      throw new Error('Client not found');
+    }
 
-      // 1. Get client data and ensure QBO customer exists
+    const workActivitiesData = await this.validateWorkActivitiesForInvoicing(request.workActivityIds);
+
+    let lineItems = await this.buildInvoiceLineItems(workActivitiesData, request.includeOtherCharges);
+
+    if (lineItems.length === 0) {
+      throw new Error('No line items could be generated for the invoice. Please check if QBO items are properly synced.');
+    }
+
+    if (request.useAIGeneration) {
+      try {
+        const enhancedLineItems = await this.anthropicService.generateInvoiceLineItems(
+          workActivitiesData,
+          client.name,
+          lineItems
+        );
+
+        if (enhancedLineItems && enhancedLineItems.length > 0) {
+          lineItems = enhancedLineItems;
+        }
+      } catch (aiError) {
+        console.error('AI generation failed during preview, falling back to basic line items:', aiError);
+      }
+    }
+
+    const totalAmount = lineItems.reduce((sum, item) => sum + item.amount, 0);
+
+    return { client, lineItems, totalAmount };
+  }
+
+  /**
+   * Create an invoice from line items already reviewed and edited by the user.
+   * The submitted lines are sent to QBO verbatim — no rebuilding here.
+   */
+  async createInvoiceFromLineItems(request: CreateInvoiceFromLineItemsRequest): Promise<any> {
+    try {
+      await this.ensureQBServiceInitialized();
+
       const client = await this.clientService.getClientById(request.clientId);
       if (!client) {
         throw new Error('Client not found');
       }
-      console.log(`Creating invoice for client: ${client.name}`);
 
-      // 2. Find or create QBO customer
+      if (!request.lineItems || request.lineItems.length === 0) {
+        throw new Error('At least one line item is required');
+      }
+
+      const normalizedLineItems: InvoiceLineItemData[] = request.lineItems.map((line, index) => {
+        if (!line.qboItemId) {
+          throw new Error(`Line ${index + 1} is missing qboItemId`);
+        }
+        if (typeof line.quantity !== 'number' || line.quantity <= 0) {
+          throw new Error(`Line ${index + 1} must have quantity > 0`);
+        }
+        if (typeof line.rate !== 'number' || line.rate < 0) {
+          throw new Error(`Line ${index + 1} must have rate >= 0`);
+        }
+
+        return {
+          workActivityId: line.workActivityId,
+          otherChargeId: line.otherChargeId,
+          qboItemId: line.qboItemId,
+          description: line.description ?? '',
+          quantity: line.quantity,
+          rate: line.rate,
+          amount: line.quantity * line.rate
+        };
+      });
+
       const qboCustomer = await this.ensureQBOCustomer(client);
 
-      // 3. Get work activities and validate they're ready for invoicing
-      const workActivitiesData = await this.validateWorkActivitiesForInvoicing(request.workActivityIds);
-      console.log(`Validated ${workActivitiesData.length} work activities for invoicing`);
+      const qboInvoiceData = this.buildQBOInvoiceData(qboCustomer, normalizedLineItems, {
+        dueDate: request.dueDate,
+        memo: request.memo
+      });
 
-      // 4. Build invoice line items from work activities
-      let lineItems = await this.buildInvoiceLineItems(workActivitiesData, request.includeOtherCharges);
-      console.log(`Built ${lineItems.length} line items for invoice`);
-      
-      if (lineItems.length === 0) {
-        console.error('ERROR: No line items generated! This will cause invoice creation to fail.');
-        throw new Error('No line items could be generated for the invoice. Please check if QBO items are properly synced.');
-      }
-
-      // 4.5. Enhance line items with AI if requested
-      if (request.useAIGeneration) {
-        try {
-          console.log('🤖 Generating AI-enhanced invoice line items...');
-          const enhancedLineItems = await this.anthropicService.generateInvoiceLineItems(
-            workActivitiesData,
-            client.name,
-            lineItems
-          );
-          
-          if (enhancedLineItems && enhancedLineItems.length > 0) {
-            lineItems = enhancedLineItems;
-            console.log(`✅ Successfully generated ${enhancedLineItems.length} AI-enhanced line items`);
-          } else {
-            console.log('⚠️ AI generation returned no results, using basic line items');
-          }
-        } catch (aiError) {
-          console.error('❌ AI generation failed, falling back to basic line items:', aiError);
-          // Continue with basic line items instead of failing
-        }
-      }
-
-      // 5. Create invoice data for QBO
-      const qboInvoiceData = this.buildQBOInvoiceData(qboCustomer, lineItems, request);
-      console.log('Built QuickBooks invoice data:', JSON.stringify(qboInvoiceData, null, 2));
-
-      // 6. Create invoice in QuickBooks
       const qboInvoice = await this.qbService.createInvoice(qboInvoiceData);
-      console.log(`Created invoice in QuickBooks with ID: ${qboInvoice.Id}`);
 
-      // 7. Save invoice to local database
-      const localInvoice = await this.saveInvoiceToLocal(qboInvoice, client.id, lineItems);
+      const localInvoice = await this.saveInvoiceToLocal(qboInvoice, client.id, normalizedLineItems);
 
-      // 8. Update work activities status to 'invoiced'
-      await this.updateWorkActivitiesStatus(request.workActivityIds, 'invoiced');
-      console.log('Updated work activities status to invoiced');
+      const invoicedWorkActivityIds = Array.from(new Set(
+        normalizedLineItems
+          .map(line => line.workActivityId)
+          .filter((id): id is number => typeof id === 'number')
+      ));
+
+      if (invoicedWorkActivityIds.length > 0) {
+        await this.updateWorkActivitiesStatus(invoicedWorkActivityIds, 'invoiced');
+      }
 
       return {
         invoice: localInvoice,
         qboInvoice: qboInvoice,
-        lineItems: lineItems.length
+        lineItems: normalizedLineItems.length
       };
 
     } catch (error) {
@@ -488,7 +528,7 @@ export class InvoiceService extends DatabaseService {
     return workType.charAt(0).toUpperCase() + workType.slice(1).replace(/([A-Z])/g, ' $1');
   }
 
-  private buildQBOInvoiceData(qboCustomer: any, lineItems: InvoiceLineItemData[], request: CreateInvoiceRequest): any {
+  private buildQBOInvoiceData(qboCustomer: any, lineItems: InvoiceLineItemData[], request: { dueDate?: string; memo?: string }): any {
     const lines = lineItems.map((item, index) => ({
       LineNum: index + 1,
       Amount: item.amount,

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -174,14 +174,18 @@ export class InvoiceService extends DatabaseService {
     const out: SuggestedLineItem[] = [];
     for (const suggestion of suggestions) {
       const { item, quality } = await this.resolveQBOItemForSuggestion(suggestion.description, suggestion.category);
+      // Only pre-fill the rate when the QBO item is a specific name-level match.
+      // Category/fuzzy/fallback buckets share a unitPrice that probably doesn't apply
+      // to this specific plant or material, so leave the rate at 0 and force input.
+      const rate = quality === 'specific' && item?.unitPrice && item.unitPrice > 0
+        ? item.unitPrice
+        : 0;
       out.push({
         qboItemId: item?.qboId ?? '',
         description: suggestion.description,
         quantity: suggestion.quantity,
-        rate: item?.unitPrice && item.unitPrice > 0 && quality !== 'category' && quality !== 'fallback'
-          ? item.unitPrice
-          : 0,
-        amount: 0,
+        rate,
+        amount: suggestion.quantity * rate,
         category: suggestion.category,
         sourceWorkActivityId: suggestion.sourceWorkActivityId,
         qboItemName: item?.name,

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -41,7 +41,7 @@ export interface SuggestedLineItem extends InvoiceLineItemData {
   category: 'plants' | 'materials';
   sourceWorkActivityId?: number;
   qboItemName?: string;
-  qboItemMatchQuality: 'exact' | 'fuzzy' | 'fallback' | 'none';
+  qboItemMatchQuality: 'specific' | 'category' | 'fuzzy' | 'fallback' | 'none';
 }
 
 export interface InvoicePreviewResult {
@@ -173,12 +173,14 @@ export class InvoiceService extends DatabaseService {
   private async materializeSuggestedAdditions(suggestions: SuggestedAddition[]): Promise<SuggestedLineItem[]> {
     const out: SuggestedLineItem[] = [];
     for (const suggestion of suggestions) {
-      const { item, quality } = await this.resolveQBOItemForCategory(suggestion.category);
+      const { item, quality } = await this.resolveQBOItemForSuggestion(suggestion.description, suggestion.category);
       out.push({
         qboItemId: item?.qboId ?? '',
         description: suggestion.description,
         quantity: suggestion.quantity,
-        rate: 0,
+        rate: item?.unitPrice && item.unitPrice > 0 && quality !== 'category' && quality !== 'fallback'
+          ? item.unitPrice
+          : 0,
         amount: 0,
         category: suggestion.category,
         sourceWorkActivityId: suggestion.sourceWorkActivityId,
@@ -191,19 +193,37 @@ export class InvoiceService extends DatabaseService {
 
   /**
    * Find a QBO item to attach to a suggested addition. The match is best-effort:
-   * suggestions should still surface even when the catalog doesn't have a perfect
-   * fit, so the user can review them rather than silently lose information.
+   *   1. exact name match against the suggestion description (e.g., "Sluggo" → "Sluggo" item)
+   *   2. case-insensitive partial match against the description
+   *   3. generic category bucket (e.g., "Plants", "Materials")
+   *   4. fuzzy match on category keywords
+   *   5. first active Inventory/NonInventory/Service item
+   * Suggestions still surface when no match is found so the user can review them.
    */
-  private async resolveQBOItemForCategory(
+  private async resolveQBOItemForSuggestion(
+    description: string,
     category: 'plants' | 'materials'
-  ): Promise<{ item: any | null; quality: 'exact' | 'fuzzy' | 'fallback' | 'none' }> {
+  ): Promise<{ item: any | null; quality: 'specific' | 'category' | 'fuzzy' | 'fallback' | 'none' }> {
+    const trimmed = description.trim();
+    if (trimmed) {
+      const exactByDescription = await this.findQBOItemByName(trimmed);
+      if (exactByDescription) return { item: exactByDescription, quality: 'specific' };
+
+      const partial = await this.db
+        .select()
+        .from(qboItems)
+        .where(and(eq(qboItems.active, true), ilike(qboItems.name, `%${trimmed}%`)))
+        .limit(1);
+      if (partial[0]) return { item: partial[0], quality: 'specific' };
+    }
+
     const exactNames = category === 'plants'
       ? ['Plants', 'Plant']
       : ['Materials', 'Garden Supplies', 'Supplies'];
 
     for (const name of exactNames) {
       const hit = await this.findQBOItemByName(name);
-      if (hit) return { item: hit, quality: 'exact' };
+      if (hit) return { item: hit, quality: 'category' };
     }
 
     const fuzzyKeywords = category === 'plants'

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -536,10 +536,7 @@ export class InvoiceService extends DatabaseService {
             continue;
           }
 
-          const quantity = charge.quantity || 1;
-          const rate = charge.unitRate
-            ?? (charge.totalCost != null ? charge.totalCost / quantity : 0);
-          const amount = charge.totalCost ?? quantity * rate;
+          const { quantity, rate, amount } = computeChargeLineMath(charge);
 
           lineItems.push({
             otherChargeId: charge.id,
@@ -896,4 +893,33 @@ export function pickSuggestionRate(
   if (quality !== 'specific') return 0;
   const unit = item?.unitPrice;
   return typeof unit === 'number' && unit > 0 ? unit : 0;
-} 
+}
+
+/**
+ * Reconcile the three pricing fields on an other_charge into a consistent
+ * (quantity, rate, amount) triple for the invoice line. The DB can have any
+ * combination set or null — common patterns:
+ *   - totalCost only ("Lonicera (Tony's): $25 total") → qty=1, rate=25, amount=25
+ *   - unitRate only ("Sluggo $8/unit, qty 0.75")     → qty=0.75, rate=8, amount=6
+ *   - both set                                        → trust unitRate, recompute amount
+ *   - nothing                                         → qty=1, rate=0, amount=0
+ */
+export function computeChargeLineMath(charge: {
+  quantity?: number | null;
+  unitRate?: number | null;
+  totalCost?: number | null;
+}): { quantity: number; rate: number; amount: number } {
+  const quantity = charge.quantity && charge.quantity > 0 ? charge.quantity : 1;
+
+  const rate = typeof charge.unitRate === 'number'
+    ? charge.unitRate
+    : (typeof charge.totalCost === 'number' ? charge.totalCost / quantity : 0);
+
+  // If unitRate is set we always derive amount from qty × rate so the line is
+  // internally consistent; totalCost only fills in when we have no unit info.
+  const amount = typeof charge.unitRate === 'number'
+    ? quantity * rate
+    : (typeof charge.totalCost === 'number' ? charge.totalCost : 0);
+
+  return { quantity, rate, amount };
+}

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -206,23 +206,19 @@ export class InvoiceService extends DatabaseService {
   ): Promise<{ item: any | null; quality: 'specific' | 'category' | 'fuzzy' | 'fallback' | 'none' }> {
     const trimmed = description.trim();
     if (trimmed) {
-      const exactByDescription = await this.findQBOItemByName(trimmed);
-      if (exactByDescription) return { item: exactByDescription, quality: 'specific' };
+      const exactCI = await this.findActiveQBOItemILike(trimmed);
+      if (exactCI) return { item: exactCI, quality: 'specific' };
 
-      const partial = await this.db
-        .select()
-        .from(qboItems)
-        .where(and(eq(qboItems.active, true), ilike(qboItems.name, `%${trimmed}%`)))
-        .limit(1);
-      if (partial[0]) return { item: partial[0], quality: 'specific' };
+      const partial = await this.findActiveQBOItemILike(`%${trimmed}%`);
+      if (partial) return { item: partial, quality: 'specific' };
     }
 
-    const exactNames = category === 'plants'
+    const categoryNames = category === 'plants'
       ? ['Plants', 'Plant']
       : ['Materials', 'Garden Supplies', 'Supplies'];
 
-    for (const name of exactNames) {
-      const hit = await this.findQBOItemByName(name);
+    for (const name of categoryNames) {
+      const hit = await this.findActiveQBOItemILike(name);
       if (hit) return { item: hit, quality: 'category' };
     }
 
@@ -231,12 +227,8 @@ export class InvoiceService extends DatabaseService {
       : ['material', 'supply', 'supplies'];
 
     for (const keyword of fuzzyKeywords) {
-      const matches = await this.db
-        .select()
-        .from(qboItems)
-        .where(and(eq(qboItems.active, true), ilike(qboItems.name, `%${keyword}%`)))
-        .limit(1);
-      if (matches[0]) return { item: matches[0], quality: 'fuzzy' };
+      const hit = await this.findActiveQBOItemILike(`%${keyword}%`);
+      if (hit) return { item: hit, quality: 'fuzzy' };
     }
 
     const fallback = await this.db
@@ -250,6 +242,15 @@ export class InvoiceService extends DatabaseService {
     if (fallback[0]) return { item: fallback[0], quality: 'fallback' };
 
     return { item: null, quality: 'none' };
+  }
+
+  private async findActiveQBOItemILike(pattern: string): Promise<any | null> {
+    const matches = await this.db
+      .select()
+      .from(qboItems)
+      .where(and(eq(qboItems.active, true), ilike(qboItems.name, pattern)))
+      .limit(1);
+    return matches[0] || null;
   }
 
   /**

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -11,7 +11,7 @@ import {
   otherCharges,
   clients 
 } from '../db';
-import { eq, and, inArray, ilike, or } from 'drizzle-orm';
+import { eq, and, inArray, ilike, or, sql } from 'drizzle-orm';
 
 export interface PreviewInvoiceRequest {
   clientId: number;
@@ -249,10 +249,13 @@ export class InvoiceService extends DatabaseService {
   }
 
   private async findActiveQBOItemILike(pattern: string): Promise<any | null> {
+    // Prefer shorter names: a generic "Plants" bucket beats a specialized
+    // "Plant installation" service when both match a fuzzy %plant% query.
     const matches = await this.db
       .select()
       .from(qboItems)
       .where(and(eq(qboItems.active, true), ilike(qboItems.name, pattern)))
+      .orderBy(sql`LENGTH(${qboItems.name})`)
       .limit(1);
     return matches[0] || null;
   }

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -23,6 +23,11 @@ export interface PreviewInvoiceRequest {
 export interface CreateInvoiceFromLineItemsRequest {
   clientId: number;
   lineItems: InvoiceLineItemData[];
+  // Work activities the user selected for this invoice. Marked `invoiced`
+  // when the invoice is created, regardless of which labor lines survived
+  // editing — otherwise removing a labor line would leave the activity
+  // stuck as `completed` and keep reappearing in the invoiceable list.
+  workActivityIds?: number[];
   dueDate?: string;
   memo?: string;
 }
@@ -174,12 +179,7 @@ export class InvoiceService extends DatabaseService {
     const out: SuggestedLineItem[] = [];
     for (const suggestion of suggestions) {
       const { item, quality } = await this.resolveQBOItemForSuggestion(suggestion.description, suggestion.category);
-      // Only pre-fill the rate when the QBO item is a specific name-level match.
-      // Category/fuzzy/fallback buckets share a unitPrice that probably doesn't apply
-      // to this specific plant or material, so leave the rate at 0 and force input.
-      const rate = quality === 'specific' && item?.unitPrice && item.unitPrice > 0
-        ? item.unitPrice
-        : 0;
+      const rate = pickSuggestionRate(quality, item);
       out.push({
         qboItemId: item?.qboId ?? '',
         description: suggestion.description,
@@ -277,27 +277,7 @@ export class InvoiceService extends DatabaseService {
         throw new Error('At least one line item is required');
       }
 
-      const normalizedLineItems: InvoiceLineItemData[] = request.lineItems.map((line, index) => {
-        if (!line.qboItemId) {
-          throw new Error(`Line ${index + 1} is missing qboItemId`);
-        }
-        if (typeof line.quantity !== 'number' || line.quantity <= 0) {
-          throw new Error(`Line ${index + 1} must have quantity > 0`);
-        }
-        if (typeof line.rate !== 'number' || line.rate < 0) {
-          throw new Error(`Line ${index + 1} must have rate >= 0`);
-        }
-
-        return {
-          workActivityId: line.workActivityId,
-          otherChargeId: line.otherChargeId,
-          qboItemId: line.qboItemId,
-          description: line.description ?? '',
-          quantity: line.quantity,
-          rate: line.rate,
-          amount: line.quantity * line.rate
-        };
-      });
+      const normalizedLineItems = normalizeInvoiceLineItems(request.lineItems);
 
       const qboCustomer = await this.ensureQBOCustomer(client);
 
@@ -310,11 +290,10 @@ export class InvoiceService extends DatabaseService {
 
       const localInvoice = await this.saveInvoiceToLocal(qboInvoice, client.id, normalizedLineItems);
 
-      const invoicedWorkActivityIds = Array.from(new Set(
+      const invoicedWorkActivityIds = resolveInvoicedWorkActivityIds(
+        request.workActivityIds,
         normalizedLineItems
-          .map(line => line.workActivityId)
-          .filter((id): id is number => typeof id === 'number')
-      ));
+      );
 
       if (invoicedWorkActivityIds.length > 0) {
         await this.updateWorkActivitiesStatus(invoicedWorkActivityIds, 'invoiced');
@@ -547,18 +526,29 @@ export class InvoiceService extends DatabaseService {
           ));
 
         for (const charge of charges) {
-          const qboItem = await this.findQBOItemForChargeType(charge.chargeType);
-          
-          if (qboItem) {
-            lineItems.push({
-              otherChargeId: charge.id,
-              qboItemId: qboItem.qboId,
-              description: charge.description,
-              quantity: charge.quantity || 1,
-              rate: charge.unitRate || charge.totalCost || 0,
-              amount: charge.totalCost || 0
-            });
+          const qboItem = await this.findQBOItemForChargeType(charge.chargeType, charge.description);
+
+          if (!qboItem) {
+            console.warn(
+              `Skipping billable charge ${charge.id} (chargeType="${charge.chargeType}", description="${charge.description}"): no QBO item matched. ` +
+              `Sync QBO items or add an item named after the chargeType.`
+            );
+            continue;
           }
+
+          const quantity = charge.quantity || 1;
+          const rate = charge.unitRate
+            ?? (charge.totalCost != null ? charge.totalCost / quantity : 0);
+          const amount = charge.totalCost ?? quantity * rate;
+
+          lineItems.push({
+            otherChargeId: charge.id,
+            qboItemId: qboItem.qboId,
+            description: charge.description,
+            quantity,
+            rate,
+            amount
+          });
         }
       }
     }
@@ -598,21 +588,37 @@ export class InvoiceService extends DatabaseService {
     return defaultItem[0] || null;
   }
 
-  private async findQBOItemForChargeType(chargeType: string): Promise<any> {
-    // Map charge types to QBO items
+  /**
+   * Find a QBO item for a structured other_charge.
+   *   1. If the charge description matches a QBO item name (exact CI, then ILIKE), use it.
+   *      Catches per-product items like "Sluggo" or "Lonicera" without needing a chargeType map.
+   *   2. Otherwise try chargeType-mapped canonical names ("Plants", "Materials", etc.) case-insensitively.
+   *   3. Fall back to a fuzzy ILIKE on the chargeType itself.
+   */
+  private async findQBOItemForChargeType(chargeType: string, description?: string): Promise<any> {
+    const trimmedDesc = description?.trim() || '';
+    if (trimmedDesc) {
+      const descExact = await this.findActiveQBOItemILike(trimmedDesc);
+      if (descExact) return descExact;
+      const descPartial = await this.findActiveQBOItemILike(`%${trimmedDesc}%`);
+      if (descPartial) return descPartial;
+    }
+
     const chargeTypeMapping: { [key: string]: string[] } = {
       'debris': ['Debris disposal per yard', 'Debris disposal'],
-      'material': ['Garden Supplies', 'Materials'],
-      'plant': ['Plants', 'Garden Supplies'],
+      'material': ['Materials', 'Garden Supplies', 'Supplies'],
+      'plant': ['Plants', 'Plant', 'Garden Supplies'],
       'delivery': ['Delivery', 'Service']
     };
 
     const possibleNames = chargeTypeMapping[chargeType.toLowerCase()] || [chargeType];
-    
     for (const name of possibleNames) {
-      const item = await this.findQBOItemByName(name);
-      if (item) return item;
+      const hit = await this.findActiveQBOItemILike(name);
+      if (hit) return hit;
     }
+
+    const fuzzy = await this.findActiveQBOItemILike(`%${chargeType}%`);
+    if (fuzzy) return fuzzy;
 
     return null;
   }
@@ -819,4 +825,75 @@ export class InvoiceService extends DatabaseService {
       throw error;
     }
   }
+}
+
+/**
+ * Validate user-submitted line items and recompute `amount` server-side.
+ * Server never trusts the client's `amount` — it's recomputed from
+ * quantity × rate so a bad UI calculation can't push wrong money to QBO.
+ * Throws on the first invalid line so the caller gets a clear error.
+ */
+export function normalizeInvoiceLineItems(lineItems: InvoiceLineItemData[]): InvoiceLineItemData[] {
+  return lineItems.map((line, index) => {
+    if (!line.qboItemId) {
+      throw new Error(`Line ${index + 1} is missing qboItemId`);
+    }
+    if (typeof line.quantity !== 'number' || line.quantity <= 0) {
+      throw new Error(`Line ${index + 1} must have quantity > 0`);
+    }
+    if (typeof line.rate !== 'number' || line.rate < 0) {
+      throw new Error(`Line ${index + 1} must have rate >= 0`);
+    }
+
+    return {
+      workActivityId: line.workActivityId,
+      otherChargeId: line.otherChargeId,
+      qboItemId: line.qboItemId,
+      description: line.description ?? '',
+      quantity: line.quantity,
+      rate: line.rate,
+      amount: line.quantity * line.rate
+    };
+  });
+}
+
+/**
+ * Decide which work activities should be marked `invoiced`.
+ *
+ * Prefer the caller's explicit selection — that's the user's intent at the
+ * time of invoicing, regardless of which labor lines they edited or removed
+ * during the preview step. Without this, removing a labor line would leave
+ * the activity stuck as `completed` and keep re-surfacing in the invoiceable
+ * list. Falls back to whatever survived on the line items so older API
+ * callers continue to mark activities invoiced.
+ */
+export function resolveInvoicedWorkActivityIds(
+  selectedWorkActivityIds: number[] | undefined,
+  lineItems: InvoiceLineItemData[]
+): number[] {
+  const source = selectedWorkActivityIds && selectedWorkActivityIds.length > 0
+    ? selectedWorkActivityIds
+    : lineItems
+        .map(line => line.workActivityId)
+        .filter((id): id is number => typeof id === 'number');
+  return Array.from(new Set(source));
+}
+
+/**
+ * Pick a rate for a suggested addition based on how confident we are in the
+ * QBO item match.
+ *
+ * Only a `specific` (name-level) match gets the QBO item's unitPrice. The
+ * category/fuzzy/fallback buckets share a single unit price that almost
+ * certainly does not apply to this specific plant or material, so the rate
+ * is zeroed out and the user is forced to set one. The submit guard in the
+ * UI catches the zero before any wrong-money invoice can be sent.
+ */
+export function pickSuggestionRate(
+  quality: SuggestedLineItem['qboItemMatchQuality'],
+  item: { unitPrice?: number | null } | null | undefined
+): number {
+  if (quality !== 'specific') return 0;
+  const unit = item?.unitPrice;
+  return typeof unit === 'number' && unit > 0 ? unit : 0;
 } 

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -11,7 +11,7 @@ import {
   otherCharges,
   clients 
 } from '../db';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, ilike, or } from 'drizzle-orm';
 
 export interface PreviewInvoiceRequest {
   clientId: number;
@@ -40,6 +40,8 @@ export interface InvoiceLineItemData {
 export interface SuggestedLineItem extends InvoiceLineItemData {
   category: 'plants' | 'materials';
   sourceWorkActivityId?: number;
+  qboItemName?: string;
+  qboItemMatchQuality: 'exact' | 'fuzzy' | 'fallback' | 'none';
 }
 
 export interface InvoicePreviewResult {
@@ -171,22 +173,63 @@ export class InvoiceService extends DatabaseService {
   private async materializeSuggestedAdditions(suggestions: SuggestedAddition[]): Promise<SuggestedLineItem[]> {
     const out: SuggestedLineItem[] = [];
     for (const suggestion of suggestions) {
-      const qboItem = await this.findQBOItemForChargeType(suggestion.category === 'plants' ? 'plant' : 'material');
-      if (!qboItem) {
-        console.warn(`No QBO item found for suggested ${suggestion.category}: ${suggestion.description} — dropping suggestion`);
-        continue;
-      }
+      const { item, quality } = await this.resolveQBOItemForCategory(suggestion.category);
       out.push({
-        qboItemId: qboItem.qboId,
+        qboItemId: item?.qboId ?? '',
         description: suggestion.description,
         quantity: suggestion.quantity,
         rate: 0,
         amount: 0,
         category: suggestion.category,
-        sourceWorkActivityId: suggestion.sourceWorkActivityId
+        sourceWorkActivityId: suggestion.sourceWorkActivityId,
+        qboItemName: item?.name,
+        qboItemMatchQuality: quality
       });
     }
     return out;
+  }
+
+  /**
+   * Find a QBO item to attach to a suggested addition. The match is best-effort:
+   * suggestions should still surface even when the catalog doesn't have a perfect
+   * fit, so the user can review them rather than silently lose information.
+   */
+  private async resolveQBOItemForCategory(
+    category: 'plants' | 'materials'
+  ): Promise<{ item: any | null; quality: 'exact' | 'fuzzy' | 'fallback' | 'none' }> {
+    const exactNames = category === 'plants'
+      ? ['Plants', 'Plant']
+      : ['Materials', 'Garden Supplies', 'Supplies'];
+
+    for (const name of exactNames) {
+      const hit = await this.findQBOItemByName(name);
+      if (hit) return { item: hit, quality: 'exact' };
+    }
+
+    const fuzzyKeywords = category === 'plants'
+      ? ['plant', 'flora']
+      : ['material', 'supply', 'supplies'];
+
+    for (const keyword of fuzzyKeywords) {
+      const matches = await this.db
+        .select()
+        .from(qboItems)
+        .where(and(eq(qboItems.active, true), ilike(qboItems.name, `%${keyword}%`)))
+        .limit(1);
+      if (matches[0]) return { item: matches[0], quality: 'fuzzy' };
+    }
+
+    const fallback = await this.db
+      .select()
+      .from(qboItems)
+      .where(and(
+        eq(qboItems.active, true),
+        or(eq(qboItems.type, 'Inventory'), eq(qboItems.type, 'NonInventory'), eq(qboItems.type, 'Service'))
+      ))
+      .limit(1);
+    if (fallback[0]) return { item: fallback[0], quality: 'fallback' };
+
+    return { item: null, quality: 'none' };
   }
 
   /**

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -420,7 +420,7 @@ export class InvoiceService extends DatabaseService {
       if (qboItem && (activity.billableHours || activity.totalHours) > 0) {
         const hours = activity.billableHours || activity.totalHours || 0;
         const rate = qboItem.unitPrice || 55.00; // Default rate if not set in QBO
-        const description = this.buildServiceDescription(activity.workType, [activity]);
+        const description = this.buildServiceDescription(activity);
         
         lineItems.push({
           workActivityId: activity.id,
@@ -515,13 +515,9 @@ export class InvoiceService extends DatabaseService {
     return null;
   }
 
-  private buildServiceDescription(workType: string, activities: any[]): string {
-    const dates = activities.map(a => new Date(a.date).toLocaleDateString('en-US', {
-      timeZone: 'America/Los_Angeles'
-    })).join(', ');
-    const totalHours = activities.reduce((sum, a) => sum + (a.billableHours || a.totalHours || 0), 0);
-    
-    return `${this.formatWorkType(workType)} - ${totalHours} hours (${dates})`;
+  private buildServiceDescription(activity: any): string {
+    const raw = (activity.notes || activity.tasks || '').trim();
+    return raw || this.formatWorkType(activity.workType);
   }
 
   private formatWorkType(workType: string): string {

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -36,6 +36,7 @@ import {
   TableRow,
   TableCell,
   IconButton,
+  Checkbox,
 } from '@mui/material';
 import {
   ArrowBack as ArrowBackIcon,
@@ -163,6 +164,11 @@ interface InvoiceLineItem {
   amount: number;
 }
 
+interface SuggestedLineItem extends InvoiceLineItem {
+  category: 'plants' | 'materials';
+  sourceWorkActivityId?: number;
+}
+
 interface UpcomingScheduleData {
   upcomingEvents: CalendarEvent[];
   client: {
@@ -224,6 +230,8 @@ const ClientDetail: React.FC = () => {
   const [useAIGeneration, setUseAIGeneration] = useState(false);
   const [dialogStep, setDialogStep] = useState<'select' | 'edit'>('select');
   const [previewLineItems, setPreviewLineItems] = useState<InvoiceLineItem[]>([]);
+  const [suggestedLineItems, setSuggestedLineItems] = useState<SuggestedLineItem[]>([]);
+  const [includedSuggestionIndices, setIncludedSuggestionIndices] = useState<Set<number>>(new Set());
   const [workActivitiesView, setWorkActivitiesView] = useState<'table' | 'date' | 'notes'>('table');
 
   useEffect(() => {
@@ -530,6 +538,8 @@ const ClientDetail: React.FC = () => {
 
       const result = await response.json();
       setPreviewLineItems(result.lineItems || []);
+      setSuggestedLineItems(result.suggestedLineItems || []);
+      setIncludedSuggestionIndices(new Set());
       setDialogStep('edit');
     } catch (error) {
       setSnackbar({
@@ -559,19 +569,44 @@ const ClientDetail: React.FC = () => {
     setShowInvoiceDialog(false);
     setDialogStep('select');
     setPreviewLineItems([]);
+    setSuggestedLineItems([]);
+    setIncludedSuggestionIndices(new Set());
   };
+
+  const updateSuggestedLineItem = (index: number, patch: Partial<SuggestedLineItem>) => {
+    setSuggestedLineItems(prev => prev.map((line, i) => {
+      if (i !== index) return line;
+      const next = { ...line, ...patch };
+      next.amount = next.quantity * next.rate;
+      return next;
+    }));
+  };
+
+  const toggleSuggestion = (index: number) => {
+    setIncludedSuggestionIndices(prev => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index); else next.add(index);
+      return next;
+    });
+  };
+
+  const includedSuggestions = suggestedLineItems.filter((_, i) => includedSuggestionIndices.has(i));
+  const hasIncludedSuggestionWithoutRate = includedSuggestions.some(line => line.rate <= 0);
+  const grandTotal = previewLineItems.reduce((sum, line) => sum + line.amount, 0)
+    + includedSuggestions.reduce((sum, line) => sum + line.amount, 0);
 
   const handleSendInvoice = async () => {
     if (!client || previewLineItems.length === 0) return;
 
     setInvoiceCreationLoading(true);
     try {
+      const additions = includedSuggestions.map(({ category, sourceWorkActivityId, ...line }) => line);
       const response = await secureFetch('/api/qbo/invoices', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           clientId: client.id,
-          lineItems: previewLineItems,
+          lineItems: [...previewLineItems, ...additions],
         }),
       });
 
@@ -1126,10 +1161,10 @@ const ClientDetail: React.FC = () => {
                   />
                   <Box sx={{ flex: 1 }}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.800', mb: 0.5 }}>
-                      ✨ AI-cleaned descriptions
+                      ✨ AI cleanup + material/plant suggestions
                     </Typography>
                     <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.875rem' }}>
-                      Rewrites raw work notes into the house style: terse, comma-separated task list per line, no dates or hours.
+                      Rewrites descriptions in the house style and flags plants/materials mentioned in notes that may need separate billing.
                     </Typography>
                   </Box>
                 </Box>
@@ -1353,17 +1388,97 @@ const ClientDetail: React.FC = () => {
                         </TableCell>
                       </TableRow>
                     )}
-                    <TableRow>
-                      <TableCell colSpan={3} align="right" sx={{ fontWeight: 600, borderTop: '2px solid', borderColor: 'grey.300' }}>
-                        Total
-                      </TableCell>
-                      <TableCell align="right" sx={{ fontWeight: 700, borderTop: '2px solid', borderColor: 'grey.300' }}>
-                        ${previewLineItems.reduce((sum, line) => sum + line.amount, 0).toFixed(2)}
-                      </TableCell>
-                      <TableCell sx={{ borderTop: '2px solid', borderColor: 'grey.300' }} />
-                    </TableRow>
                   </TableBody>
                 </Table>
+
+                {suggestedLineItems.length > 0 && (
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, mt: 1 }}>
+                      Suggested additions
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      These plants/materials were mentioned in the work notes but aren't yet on the invoice. Check any you want to bill separately, then set a rate.
+                    </Typography>
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell padding="checkbox">Include</TableCell>
+                          <TableCell>Description</TableCell>
+                          <TableCell align="center" sx={{ width: 90 }}>Category</TableCell>
+                          <TableCell align="right" sx={{ width: 100 }}>Qty</TableCell>
+                          <TableCell align="right" sx={{ width: 120 }}>Rate</TableCell>
+                          <TableCell align="right" sx={{ width: 120 }}>Amount</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {suggestedLineItems.map((line, index) => {
+                          const included = includedSuggestionIndices.has(index);
+                          const needsRate = included && line.rate <= 0;
+                          return (
+                            <TableRow key={index} sx={{ bgcolor: included ? 'primary.50' : 'transparent' }}>
+                              <TableCell padding="checkbox">
+                                <Checkbox
+                                  checked={included}
+                                  onChange={() => toggleSuggestion(index)}
+                                  size="small"
+                                />
+                              </TableCell>
+                              <TableCell>
+                                <TextField
+                                  value={line.description}
+                                  onChange={e => updateSuggestedLineItem(index, { description: e.target.value })}
+                                  fullWidth
+                                  size="small"
+                                  variant="outlined"
+                                />
+                              </TableCell>
+                              <TableCell align="center">
+                                <Typography variant="caption" sx={{ textTransform: 'capitalize' }}>
+                                  {line.category}
+                                </Typography>
+                              </TableCell>
+                              <TableCell align="right">
+                                <TextField
+                                  value={line.quantity}
+                                  onChange={e => {
+                                    const v = parseFloat(e.target.value);
+                                    updateSuggestedLineItem(index, { quantity: Number.isFinite(v) ? v : 0 });
+                                  }}
+                                  type="number"
+                                  size="small"
+                                  inputProps={{ step: 1, min: 0, style: { textAlign: 'right' } }}
+                                />
+                              </TableCell>
+                              <TableCell align="right">
+                                <TextField
+                                  value={line.rate}
+                                  onChange={e => {
+                                    const v = parseFloat(e.target.value);
+                                    updateSuggestedLineItem(index, { rate: Number.isFinite(v) ? v : 0 });
+                                  }}
+                                  type="number"
+                                  size="small"
+                                  error={needsRate}
+                                  helperText={needsRate ? 'Set a rate' : undefined}
+                                  inputProps={{ step: 0.01, min: 0, style: { textAlign: 'right' } }}
+                                />
+                              </TableCell>
+                              <TableCell align="right">
+                                <Typography variant="body2">${line.amount.toFixed(2)}</Typography>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </Box>
+                )}
+
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', pt: 1, borderTop: '2px solid', borderColor: 'grey.300' }}>
+                  <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                    Total: ${grandTotal.toFixed(2)}
+                  </Typography>
+                </Box>
               </Box>
             )}
           </DialogContent>
@@ -1392,7 +1507,11 @@ const ClientDetail: React.FC = () => {
                 <Button
                   onClick={handleSendInvoice}
                   variant="contained"
-                  disabled={previewLineItems.length === 0 || invoiceCreationLoading}
+                  disabled={
+                    (previewLineItems.length === 0 && includedSuggestions.length === 0)
+                    || hasIncludedSuggestionWithoutRate
+                    || invoiceCreationLoading
+                  }
                 >
                   {invoiceCreationLoading ? 'Sending…' : 'Send to QuickBooks'}
                 </Button>

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -1126,10 +1126,10 @@ const ClientDetail: React.FC = () => {
                   />
                   <Box sx={{ flex: 1 }}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.800', mb: 0.5 }}>
-                      ✨ AI-Enhanced Professional Descriptions
+                      ✨ AI-cleaned descriptions
                     </Typography>
                     <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.875rem' }}>
-                      Transforms basic work notes into detailed, professional invoice line items with specific tasks, dates, and value demonstration
+                      Rewrites raw work notes into the house style: terse, comma-separated task list per line, no dates or hours.
                     </Typography>
                   </Box>
                 </Box>
@@ -1274,7 +1274,7 @@ const ClientDetail: React.FC = () => {
                         </Typography>
                       </Box>
                       <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.8rem' }}>
-                        Invoice descriptions will be enhanced with detailed task breakdowns, professional language, and value demonstration
+                        Descriptions will be rewritten as terse, comma-separated task lists matching the existing invoice style.
                       </Typography>
                     </Box>
                   )}

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -167,6 +167,8 @@ interface InvoiceLineItem {
 interface SuggestedLineItem extends InvoiceLineItem {
   category: 'plants' | 'materials';
   sourceWorkActivityId?: number;
+  qboItemName?: string;
+  qboItemMatchQuality: 'exact' | 'fuzzy' | 'fallback' | 'none';
 }
 
 interface UpcomingScheduleData {
@@ -592,6 +594,7 @@ const ClientDetail: React.FC = () => {
 
   const includedSuggestions = suggestedLineItems.filter((_, i) => includedSuggestionIndices.has(i));
   const hasIncludedSuggestionWithoutRate = includedSuggestions.some(line => line.rate <= 0);
+  const hasIncludedSuggestionWithoutItem = includedSuggestions.some(line => !line.qboItemId);
   const grandTotal = previewLineItems.reduce((sum, line) => sum + line.amount, 0)
     + includedSuggestions.reduce((sum, line) => sum + line.amount, 0);
 
@@ -1404,7 +1407,7 @@ const ClientDetail: React.FC = () => {
                         <TableRow>
                           <TableCell padding="checkbox">Include</TableCell>
                           <TableCell>Description</TableCell>
-                          <TableCell align="center" sx={{ width: 90 }}>Category</TableCell>
+                          <TableCell sx={{ width: 180 }}>QBO item</TableCell>
                           <TableCell align="right" sx={{ width: 100 }}>Qty</TableCell>
                           <TableCell align="right" sx={{ width: 120 }}>Rate</TableCell>
                           <TableCell align="right" sx={{ width: 120 }}>Amount</TableCell>
@@ -1414,6 +1417,14 @@ const ClientDetail: React.FC = () => {
                         {suggestedLineItems.map((line, index) => {
                           const included = includedSuggestionIndices.has(index);
                           const needsRate = included && line.rate <= 0;
+                          const noItem = !line.qboItemId;
+                          const itemHelper = noItem
+                            ? 'No QBO item available — add one in QBO and re-sync, or skip.'
+                            : line.qboItemMatchQuality === 'exact'
+                              ? null
+                              : line.qboItemMatchQuality === 'fuzzy'
+                                ? 'Closest match by name'
+                                : 'Generic fallback — verify in QBO';
                           return (
                             <TableRow key={index} sx={{ bgcolor: included ? 'primary.50' : 'transparent' }}>
                               <TableCell padding="checkbox">
@@ -1421,6 +1432,7 @@ const ClientDetail: React.FC = () => {
                                   checked={included}
                                   onChange={() => toggleSuggestion(index)}
                                   size="small"
+                                  disabled={noItem}
                                 />
                               </TableCell>
                               <TableCell>
@@ -1432,9 +1444,12 @@ const ClientDetail: React.FC = () => {
                                   variant="outlined"
                                 />
                               </TableCell>
-                              <TableCell align="center">
-                                <Typography variant="caption" sx={{ textTransform: 'capitalize' }}>
-                                  {line.category}
+                              <TableCell>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                  {line.qboItemName || <Box component="span" sx={{ color: 'error.main' }}>none</Box>}
+                                </Typography>
+                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', lineHeight: 1.2 }}>
+                                  {line.category}{itemHelper ? ` · ${itemHelper}` : ''}
                                 </Typography>
                               </TableCell>
                               <TableCell align="right">
@@ -1510,6 +1525,7 @@ const ClientDetail: React.FC = () => {
                   disabled={
                     (previewLineItems.length === 0 && includedSuggestions.length === 0)
                     || hasIncludedSuggestionWithoutRate
+                    || hasIncludedSuggestionWithoutItem
                     || invoiceCreationLoading
                   }
                 >

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -36,7 +36,7 @@ import {
   TableRow,
   TableCell,
   IconButton,
-  Checkbox,
+  Autocomplete,
 } from '@mui/material';
 import {
   ArrowBack as ArrowBackIcon,
@@ -169,6 +169,14 @@ interface SuggestedLineItem extends InvoiceLineItem {
   sourceWorkActivityId?: number;
   qboItemName?: string;
   qboItemMatchQuality: 'specific' | 'category' | 'fuzzy' | 'fallback' | 'none';
+  qboItemUserSelected?: boolean;
+}
+
+interface QBOItemOption {
+  qboId: string;
+  name: string;
+  type?: string;
+  unitPrice?: number | null;
 }
 
 interface UpcomingScheduleData {
@@ -233,7 +241,7 @@ const ClientDetail: React.FC = () => {
   const [dialogStep, setDialogStep] = useState<'select' | 'edit'>('select');
   const [previewLineItems, setPreviewLineItems] = useState<InvoiceLineItem[]>([]);
   const [suggestedLineItems, setSuggestedLineItems] = useState<SuggestedLineItem[]>([]);
-  const [includedSuggestionIndices, setIncludedSuggestionIndices] = useState<Set<number>>(new Set());
+  const [availableQBOItems, setAvailableQBOItems] = useState<QBOItemOption[]>([]);
   const [workActivitiesView, setWorkActivitiesView] = useState<'table' | 'date' | 'notes'>('table');
 
   useEffect(() => {
@@ -541,8 +549,24 @@ const ClientDetail: React.FC = () => {
       const result = await response.json();
       setPreviewLineItems(result.lineItems || []);
       setSuggestedLineItems(result.suggestedLineItems || []);
-      setIncludedSuggestionIndices(new Set());
       setDialogStep('edit');
+
+      if (availableQBOItems.length === 0) {
+        try {
+          const itemsResponse = await fetch('/api/qbo/items');
+          if (itemsResponse.ok) {
+            const items = await itemsResponse.json();
+            setAvailableQBOItems(items.map((i: any) => ({
+              qboId: i.qboId,
+              name: i.name,
+              type: i.type,
+              unitPrice: i.unitPrice
+            })));
+          }
+        } catch (err) {
+          console.error('Failed to fetch QBO items for picker:', err);
+        }
+      }
     } catch (error) {
       setSnackbar({
         open: true,
@@ -572,7 +596,6 @@ const ClientDetail: React.FC = () => {
     setDialogStep('select');
     setPreviewLineItems([]);
     setSuggestedLineItems([]);
-    setIncludedSuggestionIndices(new Set());
   };
 
   const updateSuggestedLineItem = (index: number, patch: Partial<SuggestedLineItem>) => {
@@ -584,26 +607,21 @@ const ClientDetail: React.FC = () => {
     }));
   };
 
-  const toggleSuggestion = (index: number) => {
-    setIncludedSuggestionIndices(prev => {
-      const next = new Set(prev);
-      if (next.has(index)) next.delete(index); else next.add(index);
-      return next;
-    });
+  const removeSuggestedLineItem = (index: number) => {
+    setSuggestedLineItems(prev => prev.filter((_, i) => i !== index));
   };
 
-  const includedSuggestions = suggestedLineItems.filter((_, i) => includedSuggestionIndices.has(i));
-  const hasIncludedSuggestionWithoutRate = includedSuggestions.some(line => line.rate <= 0);
-  const hasIncludedSuggestionWithoutItem = includedSuggestions.some(line => !line.qboItemId);
+  const hasSuggestionWithoutRate = suggestedLineItems.some(line => line.rate <= 0);
+  const hasSuggestionWithoutItem = suggestedLineItems.some(line => !line.qboItemId);
   const grandTotal = previewLineItems.reduce((sum, line) => sum + line.amount, 0)
-    + includedSuggestions.reduce((sum, line) => sum + line.amount, 0);
+    + suggestedLineItems.reduce((sum, line) => sum + line.amount, 0);
 
   const handleSendInvoice = async () => {
     if (!client || previewLineItems.length === 0) return;
 
     setInvoiceCreationLoading(true);
     try {
-      const additions = includedSuggestions.map(({ category, sourceWorkActivityId, ...line }) => line);
+      const additions = suggestedLineItems.map(({ category, sourceWorkActivityId, qboItemName, qboItemMatchQuality, qboItemUserSelected, ...line }) => line);
       const response = await secureFetch('/api/qbo/invoices', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1400,43 +1418,39 @@ const ClientDetail: React.FC = () => {
                       Suggested additions
                     </Typography>
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                      These plants/materials were mentioned in the work notes but aren't yet on the invoice. Check any you want to bill separately, then set a rate.
+                      Plants/materials mentioned in the work notes. Edit, set a rate, or remove any you don't want to bill.
                     </Typography>
                     <Table size="small">
                       <TableHead>
                         <TableRow>
-                          <TableCell padding="checkbox">Include</TableCell>
                           <TableCell>Description</TableCell>
-                          <TableCell sx={{ width: 180 }}>QBO item</TableCell>
+                          <TableCell sx={{ width: 220 }}>QBO item</TableCell>
                           <TableCell align="right" sx={{ width: 100 }}>Qty</TableCell>
                           <TableCell align="right" sx={{ width: 120 }}>Rate</TableCell>
                           <TableCell align="right" sx={{ width: 120 }}>Amount</TableCell>
+                          <TableCell align="center" sx={{ width: 60 }}>Remove</TableCell>
                         </TableRow>
                       </TableHead>
                       <TableBody>
                         {suggestedLineItems.map((line, index) => {
-                          const included = includedSuggestionIndices.has(index);
-                          const needsRate = included && line.rate <= 0;
+                          const needsRate = line.rate <= 0;
                           const noItem = !line.qboItemId;
+                          const showAutoHint = !line.qboItemUserSelected && !noItem;
                           const itemHelper = noItem
-                            ? 'No QBO item available — add one in QBO and re-sync, or skip.'
-                            : line.qboItemMatchQuality === 'specific'
+                            ? 'Pick a QBO item below'
+                            : showAutoHint && line.qboItemMatchQuality === 'specific'
                               ? 'Matched by name'
-                              : line.qboItemMatchQuality === 'category'
-                                ? null
-                                : line.qboItemMatchQuality === 'fuzzy'
-                                  ? 'Closest category match'
-                                  : 'Generic fallback — verify in QBO';
+                              : showAutoHint && line.qboItemMatchQuality === 'fuzzy'
+                                ? 'Closest category match'
+                                : showAutoHint && line.qboItemMatchQuality === 'fallback'
+                                  ? 'Generic fallback — verify'
+                                  : null;
+                          const selectedOption = availableQBOItems.find(o => o.qboId === line.qboItemId)
+                            ?? (line.qboItemId
+                              ? { qboId: line.qboItemId, name: line.qboItemName ?? line.qboItemId }
+                              : null);
                           return (
-                            <TableRow key={index} sx={{ bgcolor: included ? 'primary.50' : 'transparent' }}>
-                              <TableCell padding="checkbox">
-                                <Checkbox
-                                  checked={included}
-                                  onChange={() => toggleSuggestion(index)}
-                                  size="small"
-                                  disabled={noItem}
-                                />
-                              </TableCell>
+                            <TableRow key={index}>
                               <TableCell>
                                 <TextField
                                   value={line.description}
@@ -1447,12 +1461,46 @@ const ClientDetail: React.FC = () => {
                                 />
                               </TableCell>
                               <TableCell>
-                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                  {line.qboItemName || <Box component="span" sx={{ color: 'error.main' }}>none</Box>}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', lineHeight: 1.2 }}>
-                                  {line.category}{itemHelper ? ` · ${itemHelper}` : ''}
-                                </Typography>
+                                <Autocomplete
+                                  size="small"
+                                  options={availableQBOItems}
+                                  value={selectedOption}
+                                  getOptionLabel={(option) => option?.name ?? ''}
+                                  isOptionEqualToValue={(option, value) => option.qboId === value?.qboId}
+                                  onChange={(_, value) => {
+                                    if (!value) {
+                                      updateSuggestedLineItem(index, {
+                                        qboItemId: '',
+                                        qboItemName: undefined,
+                                        qboItemUserSelected: true,
+                                      });
+                                      return;
+                                    }
+                                    updateSuggestedLineItem(index, {
+                                      qboItemId: value.qboId,
+                                      qboItemName: value.name,
+                                      qboItemUserSelected: true,
+                                      rate: line.rate > 0 ? line.rate : (value.unitPrice ?? 0),
+                                    });
+                                  }}
+                                  renderOption={(props, option) => (
+                                    <Box component="li" {...props} key={option.qboId} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start !important' }}>
+                                      <Typography variant="body2">{option.name}</Typography>
+                                      <Typography variant="caption" color="text.secondary">
+                                        {option.type ?? '—'}
+                                        {option.unitPrice ? ` · $${option.unitPrice.toFixed(2)}` : ''}
+                                      </Typography>
+                                    </Box>
+                                  )}
+                                  renderInput={(params) => (
+                                    <TextField
+                                      {...params}
+                                      placeholder={noItem ? 'Pick item…' : ''}
+                                      error={noItem}
+                                      helperText={itemHelper ? <Box component="span" sx={{ textTransform: 'capitalize' }}>{line.category} · {itemHelper}</Box> : line.category}
+                                    />
+                                  )}
+                                />
                               </TableCell>
                               <TableCell align="right">
                                 <TextField
@@ -1482,6 +1530,15 @@ const ClientDetail: React.FC = () => {
                               </TableCell>
                               <TableCell align="right">
                                 <Typography variant="body2">${line.amount.toFixed(2)}</Typography>
+                              </TableCell>
+                              <TableCell align="center">
+                                <IconButton
+                                  size="small"
+                                  onClick={() => removeSuggestedLineItem(index)}
+                                  aria-label="Remove suggestion"
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
                               </TableCell>
                             </TableRow>
                           );
@@ -1525,9 +1582,9 @@ const ClientDetail: React.FC = () => {
                   onClick={handleSendInvoice}
                   variant="contained"
                   disabled={
-                    (previewLineItems.length === 0 && includedSuggestions.length === 0)
-                    || hasIncludedSuggestionWithoutRate
-                    || hasIncludedSuggestionWithoutItem
+                    (previewLineItems.length === 0 && suggestedLineItems.length === 0)
+                    || hasSuggestionWithoutRate
+                    || hasSuggestionWithoutItem
                     || invoiceCreationLoading
                   }
                 >

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -168,7 +168,7 @@ interface SuggestedLineItem extends InvoiceLineItem {
   category: 'plants' | 'materials';
   sourceWorkActivityId?: number;
   qboItemName?: string;
-  qboItemMatchQuality: 'exact' | 'fuzzy' | 'fallback' | 'none';
+  qboItemMatchQuality: 'specific' | 'category' | 'fuzzy' | 'fallback' | 'none';
 }
 
 interface UpcomingScheduleData {
@@ -1420,11 +1420,13 @@ const ClientDetail: React.FC = () => {
                           const noItem = !line.qboItemId;
                           const itemHelper = noItem
                             ? 'No QBO item available — add one in QBO and re-sync, or skip.'
-                            : line.qboItemMatchQuality === 'exact'
-                              ? null
-                              : line.qboItemMatchQuality === 'fuzzy'
-                                ? 'Closest match by name'
-                                : 'Generic fallback — verify in QBO';
+                            : line.qboItemMatchQuality === 'specific'
+                              ? 'Matched by name'
+                              : line.qboItemMatchQuality === 'category'
+                                ? null
+                                : line.qboItemMatchQuality === 'fuzzy'
+                                  ? 'Closest category match'
+                                  : 'Generic fallback — verify in QBO';
                           return (
                             <TableRow key={index} sx={{ bgcolor: included ? 'primary.50' : 'transparent' }}>
                               <TableCell padding="checkbox">

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -30,6 +30,12 @@ import {
   Snackbar,
   ToggleButton,
   ToggleButtonGroup,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  IconButton,
 } from '@mui/material';
 import {
   ArrowBack as ArrowBackIcon,
@@ -147,6 +153,16 @@ interface NewClientNote {
   date?: string;
 }
 
+interface InvoiceLineItem {
+  workActivityId?: number;
+  otherChargeId?: number;
+  qboItemId: string;
+  description: string;
+  quantity: number;
+  rate: number;
+  amount: number;
+}
+
 interface UpcomingScheduleData {
   upcomingEvents: CalendarEvent[];
   client: {
@@ -203,8 +219,11 @@ const ClientDetail: React.FC = () => {
 
   const [selectedActivitiesForInvoice, setSelectedActivitiesForInvoice] = useState<number[]>([]);
   const [invoiceCreationLoading, setInvoiceCreationLoading] = useState(false);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const [showInvoiceDialog, setShowInvoiceDialog] = useState(false);
   const [useAIGeneration, setUseAIGeneration] = useState(false);
+  const [dialogStep, setDialogStep] = useState<'select' | 'edit'>('select');
+  const [previewLineItems, setPreviewLineItems] = useState<InvoiceLineItem[]>([]);
   const [workActivitiesView, setWorkActivitiesView] = useState<'table' | 'date' | 'notes'>('table');
 
   useEffect(() => {
@@ -488,35 +507,84 @@ const ClientDetail: React.FC = () => {
 
   // Removed unused invoice functions - now using new dialog implementation
 
-  const handleCreateInvoiceConfirm = async () => {
+  const handlePreviewInvoice = async () => {
     if (!client || selectedActivitiesForInvoice.length === 0) return;
+
+    setPreviewLoading(true);
+    try {
+      const response = await fetch('/api/qbo/invoices/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          clientId: client.id,
+          workActivityIds: selectedActivitiesForInvoice,
+          includeOtherCharges: true,
+          useAIGeneration,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.details || error.error || 'Failed to preview invoice');
+      }
+
+      const result = await response.json();
+      setPreviewLineItems(result.lineItems || []);
+      setDialogStep('edit');
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: error instanceof Error ? error.message : 'Failed to preview invoice',
+        severity: 'error'
+      });
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const updatePreviewLineItem = (index: number, patch: Partial<InvoiceLineItem>) => {
+    setPreviewLineItems(prev => prev.map((line, i) => {
+      if (i !== index) return line;
+      const next = { ...line, ...patch };
+      next.amount = next.quantity * next.rate;
+      return next;
+    }));
+  };
+
+  const removePreviewLineItem = (index: number) => {
+    setPreviewLineItems(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const closeInvoiceDialog = () => {
+    setShowInvoiceDialog(false);
+    setDialogStep('select');
+    setPreviewLineItems([]);
+  };
+
+  const handleSendInvoice = async () => {
+    if (!client || previewLineItems.length === 0) return;
 
     setInvoiceCreationLoading(true);
     try {
       const response = await secureFetch('/api/qbo/invoices', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           clientId: client.id,
-          workActivityIds: selectedActivitiesForInvoice,
-          includeOtherCharges: true,
-          useAIGeneration: useAIGeneration,
+          lineItems: previewLineItems,
         }),
       });
 
       if (response.ok) {
         const result = await response.json();
-        setSnackbar({ 
-          open: true, 
-          message: `Invoice created successfully! Invoice #${result.result.invoice.invoiceNumber}`, 
-          severity: 'success' 
+        setSnackbar({
+          open: true,
+          message: `Invoice created successfully! Invoice #${result.result.invoice.invoiceNumber}`,
+          severity: 'success'
         });
-        setShowInvoiceDialog(false);
+        closeInvoiceDialog();
         setSelectedActivitiesForInvoice([]);
-        
-        // Refresh work activities to update status
+
         if (id) {
           const activitiesResponse = await fetch(`/api/clients/${id}/work-activities`);
           if (activitiesResponse.ok) {
@@ -527,13 +595,13 @@ const ClientDetail: React.FC = () => {
         }
       } else {
         const error = await response.json();
-        throw new Error(error.error || 'Failed to create invoice');
+        throw new Error(error.details || error.error || 'Failed to create invoice');
       }
     } catch (error) {
-      setSnackbar({ 
-        open: true, 
-        message: error instanceof Error ? error.message : 'Failed to create invoice', 
-        severity: 'error' 
+      setSnackbar({
+        open: true,
+        message: error instanceof Error ? error.message : 'Failed to create invoice',
+        severity: 'error'
       });
     } finally {
       setInvoiceCreationLoading(false);
@@ -1031,18 +1099,21 @@ const ClientDetail: React.FC = () => {
 
 
         {/* Invoice Creation Dialog */}
-        <Dialog open={showInvoiceDialog} onClose={() => setShowInvoiceDialog(false)} maxWidth="lg" fullWidth>
+        <Dialog open={showInvoiceDialog} onClose={closeInvoiceDialog} maxWidth="lg" fullWidth>
           <DialogTitle sx={{ pb: 1 }}>
             <Typography variant="h5" component="h2" sx={{ fontWeight: 600 }}>
-              Create Invoice
+              {dialogStep === 'select' ? 'Create Invoice' : 'Review & Edit Invoice'}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Select work activities and customize invoice generation
+              {dialogStep === 'select'
+                ? 'Select work activities and customize invoice generation'
+                : 'Edit each line below. Removed lines stay marked as completed (not invoiced).'}
             </Typography>
           </DialogTitle>
           <DialogContent sx={{ px: 3, py: 2 }}>
+            {dialogStep === 'select' ? (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-              
+
               {/* AI Enhancement Option */}
               <Paper sx={{ p: 2, bgcolor: 'primary.50', border: '1px solid', borderColor: 'primary.200' }}>
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
@@ -1210,21 +1281,123 @@ const ClientDetail: React.FC = () => {
                 </Paper>
               )}
             </Box>
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ width: '50%' }}>Description</TableCell>
+                      <TableCell align="right" sx={{ width: 100 }}>Hours/Qty</TableCell>
+                      <TableCell align="right" sx={{ width: 120 }}>Rate</TableCell>
+                      <TableCell align="right" sx={{ width: 120 }}>Amount</TableCell>
+                      <TableCell align="center" sx={{ width: 60 }}>Remove</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {previewLineItems.map((line, index) => (
+                      <TableRow key={index}>
+                        <TableCell>
+                          <TextField
+                            value={line.description}
+                            onChange={e => updatePreviewLineItem(index, { description: e.target.value })}
+                            multiline
+                            fullWidth
+                            size="small"
+                            variant="outlined"
+                          />
+                        </TableCell>
+                        <TableCell align="right">
+                          <TextField
+                            value={line.quantity}
+                            onChange={e => {
+                              const v = parseFloat(e.target.value);
+                              updatePreviewLineItem(index, { quantity: Number.isFinite(v) ? v : 0 });
+                            }}
+                            type="number"
+                            size="small"
+                            inputProps={{ step: 0.25, min: 0, style: { textAlign: 'right' } }}
+                          />
+                        </TableCell>
+                        <TableCell align="right">
+                          <TextField
+                            value={line.rate}
+                            onChange={e => {
+                              const v = parseFloat(e.target.value);
+                              updatePreviewLineItem(index, { rate: Number.isFinite(v) ? v : 0 });
+                            }}
+                            type="number"
+                            size="small"
+                            inputProps={{ step: 0.01, min: 0, style: { textAlign: 'right' } }}
+                          />
+                        </TableCell>
+                        <TableCell align="right">
+                          <Typography variant="body2">${line.amount.toFixed(2)}</Typography>
+                        </TableCell>
+                        <TableCell align="center">
+                          <IconButton
+                            size="small"
+                            onClick={() => removePreviewLineItem(index)}
+                            aria-label="Remove line"
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                    {previewLineItems.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={5} align="center">
+                          <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+                            All lines removed. Add some back by going Back, or cancel.
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    <TableRow>
+                      <TableCell colSpan={3} align="right" sx={{ fontWeight: 600, borderTop: '2px solid', borderColor: 'grey.300' }}>
+                        Total
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700, borderTop: '2px solid', borderColor: 'grey.300' }}>
+                        ${previewLineItems.reduce((sum, line) => sum + line.amount, 0).toFixed(2)}
+                      </TableCell>
+                      <TableCell sx={{ borderTop: '2px solid', borderColor: 'grey.300' }} />
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </Box>
+            )}
           </DialogContent>
           <DialogActions>
-            <Button 
-              variant="outlined" 
-              onClick={() => setShowInvoiceDialog(false)}
-            >
-              Cancel
-            </Button>
-            <Button 
-              onClick={handleCreateInvoiceConfirm}
-              variant="contained"
-              disabled={selectedActivitiesForInvoice.length === 0 || invoiceCreationLoading}
-            >
-              {invoiceCreationLoading ? 'Creating Invoice...' : 'Create Invoice'}
-            </Button>
+            {dialogStep === 'select' ? (
+              <>
+                <Button variant="outlined" onClick={closeInvoiceDialog}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handlePreviewInvoice}
+                  variant="contained"
+                  disabled={selectedActivitiesForInvoice.length === 0 || previewLoading}
+                >
+                  {previewLoading ? 'Loading Preview…' : 'Preview'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="outlined" onClick={() => setDialogStep('select')} disabled={invoiceCreationLoading}>
+                  Back
+                </Button>
+                <Button variant="outlined" onClick={closeInvoiceDialog} disabled={invoiceCreationLoading}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleSendInvoice}
+                  variant="contained"
+                  disabled={previewLineItems.length === 0 || invoiceCreationLoading}
+                >
+                  {invoiceCreationLoading ? 'Sending…' : 'Send to QuickBooks'}
+                </Button>
+              </>
+            )}
           </DialogActions>
         </Dialog>
       </Grid>

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -63,6 +63,7 @@ import { secureFetch } from '../services/csrf';
 import { ClientTasksList } from './ClientTasksList';
 import { ClientNotesList } from './ClientNotesList';
 import WorkActivityEditDialog from './WorkActivityEditDialog';
+import { NumericInputCell } from './NumericInputCell';
 import { formatDatePacific } from '../utils/dateUtils';
 
 interface Client {
@@ -628,6 +629,7 @@ const ClientDetail: React.FC = () => {
         body: JSON.stringify({
           clientId: client.id,
           lineItems: [...previewLineItems, ...additions],
+          workActivityIds: selectedActivitiesForInvoice,
         }),
       });
 
@@ -1363,27 +1365,19 @@ const ClientDetail: React.FC = () => {
                           />
                         </TableCell>
                         <TableCell align="right">
-                          <TextField
+                          <NumericInputCell
                             value={line.quantity}
-                            onChange={e => {
-                              const v = parseFloat(e.target.value);
-                              updatePreviewLineItem(index, { quantity: Number.isFinite(v) ? v : 0 });
-                            }}
-                            type="number"
-                            size="small"
-                            inputProps={{ step: 0.25, min: 0, style: { textAlign: 'right' } }}
+                            onCommit={v => updatePreviewLineItem(index, { quantity: v })}
+                            step={0.25}
+                            min={0}
                           />
                         </TableCell>
                         <TableCell align="right">
-                          <TextField
+                          <NumericInputCell
                             value={line.rate}
-                            onChange={e => {
-                              const v = parseFloat(e.target.value);
-                              updatePreviewLineItem(index, { rate: Number.isFinite(v) ? v : 0 });
-                            }}
-                            type="number"
-                            size="small"
-                            inputProps={{ step: 0.01, min: 0, style: { textAlign: 'right' } }}
+                            onCommit={v => updatePreviewLineItem(index, { rate: v })}
+                            step={0.01}
+                            min={0}
                           />
                         </TableCell>
                         <TableCell align="right">
@@ -1503,29 +1497,21 @@ const ClientDetail: React.FC = () => {
                                 />
                               </TableCell>
                               <TableCell align="right">
-                                <TextField
+                                <NumericInputCell
                                   value={line.quantity}
-                                  onChange={e => {
-                                    const v = parseFloat(e.target.value);
-                                    updateSuggestedLineItem(index, { quantity: Number.isFinite(v) ? v : 0 });
-                                  }}
-                                  type="number"
-                                  size="small"
-                                  inputProps={{ step: 1, min: 0, style: { textAlign: 'right' } }}
+                                  onCommit={v => updateSuggestedLineItem(index, { quantity: v })}
+                                  step={1}
+                                  min={0}
                                 />
                               </TableCell>
                               <TableCell align="right">
-                                <TextField
+                                <NumericInputCell
                                   value={line.rate}
-                                  onChange={e => {
-                                    const v = parseFloat(e.target.value);
-                                    updateSuggestedLineItem(index, { rate: Number.isFinite(v) ? v : 0 });
-                                  }}
-                                  type="number"
-                                  size="small"
+                                  onCommit={v => updateSuggestedLineItem(index, { rate: v })}
+                                  step={0.01}
+                                  min={0}
                                   error={needsRate}
                                   helperText={needsRate ? 'Set a rate' : undefined}
-                                  inputProps={{ step: 0.01, min: 0, style: { textAlign: 'right' } }}
                                 />
                               </TableCell>
                               <TableCell align="right">

--- a/src/components/NumericInputCell.test.tsx
+++ b/src/components/NumericInputCell.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NumericInputCell } from './NumericInputCell';
+
+// These tests guard against a real wrong-money risk: the previous controlled
+// `value={line.rate}` snapped the rate to $0 the moment the user cleared the
+// field to retype it. NumericInputCell holds an editable string buffer so the
+// committed numeric value only changes on a parseable input.
+
+describe('NumericInputCell', () => {
+  it('renders the initial value as a string', () => {
+    render(<NumericInputCell value={75} onCommit={() => {}} />);
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).value).toBe('75');
+  });
+
+  it('commits a parseable new value', () => {
+    const onCommit = jest.fn();
+    render(<NumericInputCell value={0} onCommit={onCommit} />);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '75' } });
+    expect(onCommit).toHaveBeenLastCalledWith(75);
+  });
+
+  it('does NOT commit 0 when the field is cleared mid-edit', () => {
+    const onCommit = jest.fn();
+    render(<NumericInputCell value={75} onCommit={onCommit} />);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } });
+
+    // Buffer is allowed to be empty so the user can retype, but no commit fires.
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('lets the user clear and retype without losing the committed value', () => {
+    const onCommit = jest.fn();
+    render(<NumericInputCell value={75} onCommit={onCommit} />);
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.change(input, { target: { value: '8' } });
+    fireEvent.change(input, { target: { value: '85' } });
+
+    // Each parseable keystroke commits; 0 is never committed because the empty
+    // intermediate state didn't trigger a commit.
+    expect(onCommit).not.toHaveBeenCalledWith(0);
+    expect(onCommit).toHaveBeenLastCalledWith(85);
+  });
+
+  it('does not commit values below `min`', () => {
+    const onCommit = jest.fn();
+    render(<NumericInputCell value={10} min={0} onCommit={onCommit} />);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '-5' } });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('restores the displayed value on blur if the field was left empty', () => {
+    const onCommit = jest.fn();
+    render(<NumericInputCell value={75} onCommit={onCommit} />);
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+
+    fireEvent.blur(input);
+    expect(input.value).toBe('75');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('reflects external value changes (e.g. QBO item pre-filling a rate)', () => {
+    const { rerender } = render(<NumericInputCell value={0} onCommit={() => {}} />);
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).value).toBe('0');
+
+    rerender(<NumericInputCell value={12.5} onCommit={() => {}} />);
+    expect((screen.getByRole('spinbutton') as HTMLInputElement).value).toBe('12.5');
+  });
+});

--- a/src/components/NumericInputCell.tsx
+++ b/src/components/NumericInputCell.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { TextField } from '@mui/material';
+
+export interface NumericInputCellProps {
+  value: number;
+  onCommit: (next: number) => void;
+  step?: number;
+  min?: number;
+  error?: boolean;
+  helperText?: React.ReactNode;
+}
+
+// Holds an editable string buffer separate from the numeric value so clearing
+// the field to retype doesn't snap the value to $0 — and so submitting always
+// reflects what the user sees. The buffer is committed on every parseable
+// change; partial states like "" or "-" keep the previous numeric value until
+// the user either types something parseable or blurs (which restores the
+// buffer to the committed value).
+export const NumericInputCell: React.FC<NumericInputCellProps> = ({
+  value,
+  onCommit,
+  step,
+  min,
+  error,
+  helperText
+}) => {
+  const [buffer, setBuffer] = React.useState<string>(String(value));
+
+  // Sync the buffer when the parent-supplied value changes for reasons other
+  // than the user typing (e.g. picking a QBO item that pre-fills a rate).
+  React.useEffect(() => {
+    setBuffer(prev => (parseFloat(prev) === value ? prev : String(value)));
+  }, [value]);
+
+  const handleBlur = () => {
+    if (buffer.trim() === '' || !Number.isFinite(parseFloat(buffer))) {
+      setBuffer(String(value));
+    }
+  };
+
+  return (
+    <TextField
+      value={buffer}
+      onChange={e => {
+        const next = e.target.value;
+        setBuffer(next);
+        const parsed = parseFloat(next);
+        if (Number.isFinite(parsed) && (min === undefined || parsed >= min)) {
+          onCommit(parsed);
+        }
+      }}
+      onBlur={handleBlur}
+      type="number"
+      size="small"
+      error={error}
+      helperText={helperText}
+      inputProps={{ step, min, style: { textAlign: 'right' } }}
+    />
+  );
+};
+
+export default NumericInputCell;


### PR DESCRIPTION
## Summary

Replaces the one-shot "Create Invoice" button with a preview-and-edit workflow, fixes the divergent preview/create code paths, and adds AI-assisted extraction of plants/materials that get mentioned in work notes but were silently lost on their way to QuickBooks.

### Preview-and-edit flow
- New `POST /api/qbo/invoices/preview` returns the **exact** line items that would post to QBO. The dialog opens to a two-step flow: step 1 selects activities + AI toggle (unchanged), step 2 is an editable table with description (multiline), qty, rate, live amount + total, and a trash icon per row.
- `POST /api/qbo/invoices` accepts `{ clientId, lineItems, workActivityIds?, dueDate?, memo? }` verbatim. The server recomputes `amount = qty × rate` per line and flips the selected work activities to `invoiced` (regardless of which labor lines survived editing, so removing a line doesn't strand an activity in `completed` forever).
- Preview and create share `buildInvoiceLineItems` + `AnthropicService.generateInvoiceLineItems` — they can no longer drift apart. The old `createInvoiceFromWorkActivities` is gone (no backward-compat shim).

### House-style descriptions
- Fallback `buildServiceDescription` now uses the activity's own `notes` (or `tasks`) verbatim, instead of synthesizing `"Specialized Garden Care - 9 hours (4/1/2026)"` that duplicates the date and qty columns.
- AI prompt rewritten with concrete examples drawn from recent invoices. Explicit "do not" list (no dates, hours, "professional"/"comprehensive" adjectives, first-person "we", value-demo framing).

### AI-suggested additions
- When AI is on, the same call returns a `suggestedAdditions[]` of plants/materials mentioned in notes (e.g., "planting lonicera", "sluggo on hostas") that aren't represented in the structured charges. Each becomes a row in a new "Suggested additions" section in step 2.
- Suggestions arrive **included by default** with a trash icon to remove (no opt-in checkbox).
- **Editable QBO item via Autocomplete** — searchable dropdown of all active QBO items fetched once from `/api/qbo/items`. Picking a different item updates the line and auto-fills the rate from `unitPrice` if the user hasn't already set one.
- The Send button is disabled while any suggestion has rate ≤ 0 or no QBO item assigned.

### Robust QBO item matching
Both the suggestion resolver and the existing structured-charge lookup now use a shared multi-tier resolver via `findActiveQBOItemILike`:

1. **specific** — case-insensitive match against the description (`"Sluggo"` → `"Sluggo"` item)
2. **specific (partial)** — case-insensitive ILIKE on the description
3. **category** — `"Plants"` / `"Materials"` / `"Garden Supplies"` exact CI
4. **fuzzy** — `ILIKE %plant%` / `%material%`, ordered by `LENGTH(name) ASC` so the generic `"Plants"` bucket beats specialized `"Plant installation"`
5. **fallback** — any active Inventory / NonInventory / Service item

Rate is pre-filled from `unitPrice` only on **specific** matches (where the price actually applies to that line). For category/fuzzy/fallback the rate stays at $0 so the user explicitly enters a price. UI shows a match-quality hint ("Matched by name" / "Closest category match" / "Generic fallback — verify") that disappears once the user manually picks an item.

### Other_charges silent-drop fix
The pre-existing structured `other_charges` lookup had the same case-sensitive single-tier match bug, so charges like "Lonicera (Tony's)" at $25 were silently disappearing from invoices when the user's QBO item name didn't exactly match the mapped string. The AI suggestion pass then "rediscovered" them from the notes, producing duplicates. Fixed by routing through the same resolver; unresolved charges now emit a `console.warn` instead of vanishing.

Also fixed a math bug in that line: `rate` was falling back to `totalCost` when `unitRate` was null, treating the whole total as a unit price. Now `rate = unitRate ?? totalCost/quantity` and `amount = totalCost ?? quantity*rate`.

## Files of note
- `server/src/services/InvoiceService.ts` — `previewInvoice`, `createInvoiceFromLineItems`, `materializeSuggestedAdditions`, `resolveQBOItemForSuggestion`, `findQBOItemForChargeType` refactor
- `server/src/services/AnthropicService.ts` — rewritten prompt for terse house style + `suggestedAdditions` extraction
- `server/src/routes/quickbooks.ts` — rewritten `/invoices/preview` and `/invoices`
- `src/components/ClientDetail.tsx` — two-step dialog, suggested additions table with Autocomplete, trash-icon removal

## Test plan
- [x] `npm run type-check` (root) — passes
- [x] `cd server && npm run type-check` — passes
- [x] `cd server && npm run test:with-db` — 71/71 passing (integration tests need local Postgres)
- [ ] Manual: select 2–3 activities, toggle AI on, click Preview; confirm one row per activity at QBO `unitPrice`, with descriptions in house style
- [ ] Manual: confirm structured "Other Charges" appear in the main lines (not just as AI suggestions)
- [ ] Manual: confirm AI suggestions surface for plants/materials only mentioned in notes
- [ ] Manual: edit description, change qty, remove a line; total updates live
- [ ] Manual: pick a different QBO item from the Autocomplete for a suggestion; rate auto-fills if it wasn't set
- [ ] Manual: Send to QuickBooks; confirm sandbox invoice lines match the edited values exactly
- [ ] Manual: verify removed line's `work_activity` stays `completed`; selected activities flip to `invoiced` even when their labor line was removed
- [ ] Manual divergence sanity check: with AI off, preview total equals created invoice `TotalAmt` to the cent

## Deferred / out of scope
- Editing the QBO item per **main** line (only suggested additions are editable for now)
- "Add custom line" button in step 2
- Persisting "draft" previews across sessions
- Voiding old invoices in QBO (separate known TODO at `InvoiceService.ts:670`)
- Logging hand edits to drive future automation (the original plan's Iteration 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)