### PR TITLE
Add architectural remediation plan portfolio

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,10 @@ Technical documentation for the Blossom & Bough Scheduling Assistant.
 - [Other Charges](./features/other-charges.md) - Materials, services, and additional billing items
 - [Work Activities Schema](./features/work-activities-schema.md) - Non-billable time and travel time schema updates
 
+## Architectural Plans
+
+- [Remediation Plan Portfolio](./plans/README.md) - Index of 11 themed plans addressing findings from a multi-agent architectural review
+
 ## Design Documents
 
 - [POC PRD](./design/poc-prd.md) - Original proof-of-concept product requirements

--- a/docs/plans/01-security-hardening.md
+++ b/docs/plans/01-security-hardening.md
@@ -1,0 +1,61 @@
+# Plan 1 — Security Hardening
+
+**Findings**: #1, #2, #3, #4, #5, #6
+**Effort**: 2–3 days
+**Tier**: 🚨 Urgent
+
+## Why
+
+Six exploitable gaps. The most severe (#1) lets any authenticated user run arbitrary SQL; #2 + #3 + #4 together make a one-typo full-takeover. #5 is stored XSS via Notion content. #6 lets any Notion workspace worldwide trigger admin actions on a logged-in user.
+
+## 1.1 — Disable arbitrary-SQL endpoint (Finding #1)
+
+- **Files**: `server/src/routes/naturalLanguageSQL.ts`, `server/src/services/NaturalLanguageSQLService.ts:123-132`
+- **Problem**: User input → Claude → regex extraction → `db.execute(sql.raw())` with the app's full-privilege Postgres connection. Zero allowlist, zero SELECT-only enforcement, no statement timeout, no row limits. Any authenticated user can craft a prompt that returns `DROP TABLE`, `UPDATE`, or `pg_sleep(3600)` and the server will execute it.
+- **Approach**:
+  1. Comment out the route mount in `server/src/server.ts` first (5 min, eliminates risk while planning hardening).
+  2. To re-enable safely: (a) create a read-only Postgres role; (b) instantiate a separate `Pool` in `NaturalLanguageSQLService` using it; (c) parse generated SQL with `pg-query-parser` or similar — reject anything whose top-level statement isn't `SELECT`; reject references to `pg_*` / `information_schema`; (d) `SET LOCAL statement_timeout = '5s'`; (e) append `LIMIT 1000` if missing; (f) log every query to an audit table with requesting user email.
+- **Verify**: Attempt `"DROP TABLE clients"` → rejected. Attempt `"SELECT * FROM pg_user"` → rejected. Attempt `"; UPDATE clients SET ..."` injection → rejected. Read-only role attempt at write → permission error.
+
+## 1.2 — Fail-closed authentication (Findings #2, #3)
+
+- **Files**: `server/src/middleware/auth.ts:31-36`, `server/src/server.ts:93`
+- **Problem**: If `GOOGLE_OAUTH_CLIENT_ID` or `GOOGLE_OAUTH_CLIENT_SECRET` is unset, `requireAuth` returns `next()` with a warning. One typo during a deploy opens every protected route. Also `secret: process.env.SESSION_SECRET || 'your-secret-key-change-in-production'` — if `SESSION_SECRET` is unset, anyone can forge admin session cookies.
+- **Approach**:
+  1. At top of `server.ts`: `if (process.env.NODE_ENV === 'production' && (!process.env.GOOGLE_OAUTH_CLIENT_ID || !process.env.GOOGLE_OAUTH_CLIENT_SECRET || !process.env.SESSION_SECRET)) throw new Error('Missing required auth env vars')`.
+  2. Remove the silent-bypass branch in `auth.ts:31-36`. If OAuth not configured, return 503 from middleware, never `next()`.
+  3. Delete the `'your-secret-key-change-in-production'` fallback in `server.ts:93`; require the env var.
+  4. Dev bypass at `auth.ts:18-29` must also assert `NODE_ENV === 'development'`.
+- **Verify**: Unset `SESSION_SECRET` locally → server refuses to start in production mode. Unset OAuth vars → all protected routes return 503.
+
+## 1.3 — Secure session cookies (Finding #4)
+
+- **Files**: `server/src/server.ts:90-102`
+- **Problem**: `secure: false` is hardcoded. Cookies travel over HTTP. Anyone on the same wifi captures the session.
+- **Approach**:
+  1. `cookie.secure: process.env.NODE_ENV === 'production'`
+  2. `saveUninitialized: false`
+  3. Add `app.set('trust proxy', 1)` so Express honors `X-Forwarded-Proto` from the load balancer.
+- **Verify**: In production, inspect `Set-Cookie` → contains `Secure; HttpOnly; SameSite=Lax`. Locally, cookies still work over HTTP.
+
+## 1.4 — Sanitize Notion-sourced HTML (Finding #5)
+
+- **Files**: `src/components/WorkActivityDetail.tsx:521,535`; `src/components/ClientNotesList.tsx:248`; `src/components/WorkActivitiesTable.tsx:521,543`; `server/src/server.ts:583` (CSP for `/notion-embed`)
+- **Problem**: `activity.notes` and `activity.tasks` rendered with `dangerouslySetInnerHTML` without sanitization. These fields are populated from a WYSIWYG editor and AI-parsed Notion pages (user-controlled). The `/notion-embed` CSP allows `'unsafe-inline'` for script-src, so the embed iframe is fully exploitable.
+- **Approach**:
+  1. `npm i dompurify @types/dompurify` in the root package.
+  2. Create `src/utils/sanitizeHtml.ts` exporting `sanitize(html: string): string` using DOMPurify with a restrictive allowlist (strip `<script>`, `on*` handlers, `javascript:` URLs).
+  3. Wrap every `dangerouslySetInnerHTML={{ __html: x }}` with `__html: sanitize(x)`.
+  4. Remove `'unsafe-inline'` from `scriptSrc` in the `/notion-embed` CSP block.
+- **Verify**: Manual XSS payload (`<img src=x onerror=alert(1)>`) in a Notion note → renders as inert text in the work activities table. Embed page no longer allows inline scripts (check console).
+
+## 1.5 — Narrow CORS + add CSRF (Finding #6)
+
+- **Files**: `server/src/server.ts:65-85`
+- **Problem**: `^https://.*\.notion\.so$` is a wildcard match across Notion's multi-tenant domain. Combined with no CSRF tokens and `credentials: true`, any Notion user worldwide can publish a page that triggers `POST /api/admin/clear-all-data` against a logged-in admin.
+- **Approach**:
+  1. Replace the `^https://.*\.notion\.so$` wildcard with the exact embed origin(s) Notion uses for iframes — or split the API into `/api/embed/*` (no credentials, narrow CORS) vs `/api/*` (credentials, no Notion origin).
+  2. `npm i csurf` (server). Mount CSRF middleware after `express.json()` for non-embed routes.
+  3. Frontend axios interceptor reads CSRF token from cookie, sends as `X-CSRF-Token` header.
+  4. Set `frameguard: { action: 'deny' }` globally; keep Notion `frameAncestors` only in the embed route's CSP.
+- **Verify**: `curl` from non-allowlisted origin → CORS blocked. POST without CSRF token → 403. Embed iframe still loads in Notion.

--- a/docs/plans/02-data-integrity.md
+++ b/docs/plans/02-data-integrity.md
@@ -1,0 +1,80 @@
+# Plan 2 — Data Integrity & Schema
+
+**Findings**: #8, #9, #10, #11, #12
+**Effort**: 1.5 weeks
+**Tier**: 🚨 Urgent
+
+## Why
+
+Zero transactions across the entire codebase + several silent-corruption risks in column types and constraints. Each item below is independently shippable. The transaction fix (2.1) alone closes the largest class of silent data-loss risks in the codebase.
+
+## 2.1 — Add `db.transaction()` to all multi-statement writes (Finding #8)
+
+- **Files**:
+  - `server/src/services/WorkActivityService.ts:286-339` (createWorkActivity — 4 separate inserts)
+  - `server/src/services/WorkActivityService.ts:463-473` (deleteWorkActivity — 4 separate deletes)
+  - `server/src/services/WorkActivityService.ts` updateWorkActivity (find the multi-step update)
+  - `server/src/services/NotionSyncService.ts:1271-1370` (delete-then-reinsert charges + employees — biggest data-loss risk)
+  - `server/src/services/InvoiceService.ts:526-566` (saveInvoiceToLocal — invoice + line items)
+  - `server/src/services/InvoiceService.ts:589-638` (deleteInvoice)
+  - `server/src/services/DataMigrationService.ts:198-211` (clearAllData)
+  - `server/src/services/AdminService.ts:113-115` (clearWorkActivities), `:113-152` (clearAllData)
+- **Problem**: Grepping `db.transaction` returns zero hits. Multi-statement writes execute as independent transactions. A failure between any two statements leaves orphaned rows or half-deleted records. Concrete scenario: `NotionSyncService.updateWorkActivityFromParsedData` deletes all `otherCharges` rows, then crashes before reinserting → billing data permanently lost.
+- **Approach**: Wrap each multi-statement body in `await this.db.transaction(async (tx) => { ... })`. Pass `tx` through to any helper methods called from within. Add a helper `withTransaction<T>(fn: (tx) => Promise<T>): Promise<T>` on `DatabaseService` for use by services that compose across multiple service methods.
+- **Verify**: For each fixed path, write an integration test that injects a synthetic failure between writes and asserts no partial state remains (use `tx.rollback()` mid-method to simulate).
+
+## 2.2 — Migrate money columns to `numeric` (Finding #9)
+
+- **Files**: `server/src/db/schema.ts:13-14, 64-65, 87, 99-100, 135, 151, 168-169`
+- **Problem**: Invoice amounts, rates, hours, totals all use Postgres `real` (~7 significant digits, IEEE-754). Invoice line totals will drift from invoice totals; QuickBooks reconciliation breaks. Also `clients.maintenance_hours_per_visit` and `clients.maintenance_rate` are stored as `text` — also wrong.
+- **Approach**: Update schema column types and generate a migration:
+  ```typescript
+  // schema.ts: replace real() with numeric({ precision: 12, scale: 2 }) for money,
+  //            numeric({ precision: 6, scale: 2 }) for hours.
+  ```
+  Migration SQL pattern:
+  ```sql
+  ALTER TABLE invoices ALTER COLUMN total_amount TYPE numeric(12,2) USING total_amount::numeric(12,2);
+  -- repeat for: invoice_line_items.rate, .amount; other_charges.unit_rate, .total_cost;
+  -- qbo_items.unit_price; work_activities.hourly_rate, .billable_hours, .total_hours
+  ```
+  For `clients.maintenance_hours_per_visit` and `clients.maintenance_rate` (text), validate first: `SELECT id FROM clients WHERE maintenance_rate !~ '^\d+(\.\d+)?$'`.
+- **Verify**: After migration, `SELECT 0.1::numeric(12,2) + 0.2::numeric(12,2)` returns `0.30` (not 0.30000000000000004). Existing invoice totals unchanged.
+
+## 2.3 — Migrate text date columns to native `date` (Finding #10)
+
+- **Files**: `server/src/db/schema.ts` (clients.last_maintenance_date, clients.next_maintenance_target, work_activities.date, client_notes.date, invoices.invoice_date, invoices.due_date); `work_activities.start_time` and `end_time` → `time`.
+- **Problem**: Range queries work only by accident (ISO sort ≈ date sort). One non-ISO string corrupts ordering. `WorkActivityService.getWorkActivitiesByDateRange` (lines 206-216) has a broken implementation — uses `eq` instead of `between` with a `// TODO` comment.
+- **Approach**:
+  1. Pre-flight: `SELECT id, date FROM work_activities WHERE date !~ '^\d{4}-\d{2}-\d{2}$'` — if any rows, normalize first.
+  2. Update schema, generate migration with `ALTER TABLE ... TYPE date USING col::date`.
+  3. Fix `WorkActivityService.getWorkActivitiesByDateRange` — switch to `between(workActivities.date, start, end)`.
+  4. Update any frontend code that compares dates as strings.
+- **Verify**: `getWorkActivitiesByDateRange('2024-01-01', '2024-12-31')` returns expected rows. `EXPLAIN` shows index usage (after Plan 4 adds indexes).
+
+## 2.4 — Add composite unique on `work_activity_employees` (Finding #11)
+
+- **Files**: `server/src/db/schema.ts:83-90`
+- **Problem**: Same `(workActivityId, employeeId)` pair can be inserted twice. Double-clicks, retries, or re-runs of `NotionSyncService` double-count employee hours, which flow into invoices.
+- **Approach**:
+  1. De-dupe existing rows:
+     ```sql
+     DELETE FROM work_activity_employees a USING work_activity_employees b
+      WHERE a.id < b.id
+        AND a.work_activity_id = b.work_activity_id
+        AND a.employee_id = b.employee_id;
+     ```
+  2. Add `uniqueIndex('wae_wa_emp_uidx').on(t.workActivityId, t.employeeId)` in schema.
+  3. Update `WorkActivityService` insert paths to use `.onConflictDoUpdate({ target: [workActivityId, employeeId], set: { hours, ... } })`.
+- **Verify**: Insert same `(workActivityId, employeeId)` twice → second call updates, doesn't create duplicate.
+
+## 2.5 — Make FK on-delete behavior explicit (Finding #12)
+
+- **Files**: `server/src/db/schema.ts` (all 13 FK columns)
+- **Problem**: All FKs use `ON DELETE NO ACTION`. `ClientService.deleteClient`, `EmployeeService.deleteEmployee`, `ProjectService.deleteProject` just call `db.delete()` and rely on the FK to throw. If anyone "fixes" this by switching to `CASCADE` to silence the error, a single client delete wipes their invoice history.
+- **Approach**: Per-FK intent:
+  - **`CASCADE`** (true junction/child): `work_activity_employees.work_activity_id`, `other_charges.work_activity_id`, `plant_list.work_activity_id`, `invoice_line_items.invoice_id`.
+  - **`RESTRICT`/`NO ACTION`** (preserve business entity): `work_activities.client_id`, `invoices.client_id`, `projects.client_id`, `work_activity_employees.employee_id`.
+  - **`SET NULL`** (preserve historical row): `invoice_line_items.qbo_item_id`, `invoice_line_items.work_activity_id`.
+  - Add a `deleted_at timestamp` column to `clients`, `employees`, `projects`, `invoices` and convert their `delete*` service methods to UPDATE-set-deleted-at. Filter every active query by `isNull(table.deletedAt)`.
+- **Verify**: Delete a client with no children → succeeds, sets `deleted_at`. Delete a client with invoices → still succeeds (soft delete). All active queries hide soft-deleted rows.

--- a/docs/plans/03-background-jobs.md
+++ b/docs/plans/03-background-jobs.md
@@ -1,0 +1,29 @@
+# Plan 3 — Background Job Reliability
+
+**Findings**: #13
+**Effort**: 1 week
+**Tier**: 📉 Medium
+
+## Why
+
+Long-running operations (Notion sync, historical imports, production pull) run as fire-and-forget IIFEs with progress stored in process-local `Map`s. A redeploy mid-job loses state; the polling client gets a 404 on its next check. The cleanup logic at `admin.ts:455-464` is also broken (`Date.now() - new Date().getTime() ≈ 0`). Multi-instance deployment is impossible because state isn't shared.
+
+## Approach
+
+- **Files**:
+  - `server/src/routes/admin.ts:9-13, 16-20, 371-414, 530-592`
+  - `server/src/services/CronService.ts:139-223, 249-400`
+  - `server/src/services/NotionSyncService.ts` (sync entry points)
+- **Steps**:
+  1. `npm i pg-boss` in `server/`. Postgres already in use, so no new infra.
+  2. Initialize a `JobQueue` singleton in `server/src/services/JobQueue.ts`; start it from `server.ts`.
+  3. Define jobs: `import-work-activities`, `pull-from-production`, `notion-sync`, `daily-maintenance-entries`. Each handler accepts a typed payload + a `progress(percent, message)` callback that persists to the `pgboss.job` table.
+  4. Routes enqueue via `jobQueue.send('notion-sync', payload)` and return `{ jobId }`. A new `GET /api/jobs/:id` returns persisted status.
+  5. Migrate `CronService` from `node-cron` to `pg-boss`'s `schedule()` — also gives distributed locking for free (current `processingLocks` map is in-memory only).
+  6. Delete the `activeImports` / `activePulls` Maps and the broken cleanup logic at `admin.ts:455-464`.
+
+## Verify
+
+- Start a long sync; kill the server mid-run; restart → job status shows the prior run + new attempt; client polling continues without 404.
+- Two server instances running simultaneously → only one cron firing per scheduled tick.
+- `GET /api/jobs/:id` returns the same status after a process restart (state survives).

--- a/docs/plans/04-query-performance.md
+++ b/docs/plans/04-query-performance.md
@@ -1,0 +1,75 @@
+# Plan 4 — Query Performance
+
+**Findings**: #14, #15, #19
+**Effort**: 1 week
+**Tier**: 📉 Urgent-soon
+
+## Why
+
+List endpoints currently run ~3001 queries for 1000 activities (N+1 in `WorkActivityService`). Zero non-PK indexes means every FK filter is a sequential scan. Already painful, breaks at ~5k activities. SchedulingService also fetches the calendar O(helpers × days) when it could be O(1).
+
+## 4.1 — Add indexes for every FK + common filter (Finding #15)
+
+- **Files**: `server/src/db/schema.ts`
+- **Problem**: Verified every table has `"indexes": {}` in the snapshot. Postgres does NOT auto-index FKs. Every join/filter on `client_id`, `employee_id`, `date`, `work_activity_id`, etc. is a sequential scan.
+- **Approach**: Add to each table's second arg:
+  ```typescript
+  // work_activities
+  (t) => ({
+    clientIdx: index('work_activities_client_id_idx').on(t.clientId),
+    projectIdx: index('work_activities_project_id_idx').on(t.projectId),
+    dateIdx: index('work_activities_date_idx').on(t.date),
+    statusIdx: index('work_activities_status_idx').on(t.status),
+    clientDateIdx: index('work_activities_client_date_idx').on(t.clientId, t.date),
+  })
+  ```
+  Same pattern for: `work_activity_employees(work_activity_id)` and `(employee_id)`, `other_charges(work_activity_id)`, `plant_list(work_activity_id)`, `client_notes(client_id)`, `projects(client_id)`, `invoices(client_id)`, `invoice_line_items(invoice_id)` and `(work_activity_id)`.
+- **Verify**: Generate + run migration. `EXPLAIN ANALYZE SELECT * FROM work_activities WHERE client_id = 5` shows `Index Scan` not `Seq Scan`.
+
+## 4.2 — Fix N+1 in WorkActivityService list methods (Finding #14)
+
+- **Files**: `server/src/services/WorkActivityService.ts:157-172, 219-237, 540-555, 571-588, 606-623`
+- **Problem**: Every list method loops `for (activity of activities) { await employees; await charges; await plants; }`. 1000 activities → 3001 sequential queries.
+- **Approach**: Replace the per-row sub-query loop with three batched IN queries:
+  ```typescript
+  const activityIds = activities.map(a => a.id);
+  const [allEmps, allCharges, allPlants] = await Promise.all([
+    db.select({...}).from(workActivityEmployees)
+      .leftJoin(employees, eq(workActivityEmployees.employeeId, employees.id))
+      .where(inArray(workActivityEmployees.workActivityId, activityIds)),
+    db.select().from(otherCharges).where(inArray(otherCharges.workActivityId, activityIds)),
+    db.select().from(plantList).where(inArray(plantList.workActivityId, activityIds)),
+  ]);
+  const empsByActivity = Map.groupBy(allEmps, e => e.workActivityId);
+  // ...attach to activities
+  ```
+  Apply to: `getAllWorkActivities`, `getWorkActivitiesByDateRange`, `findExistingWorkActivities`, `getWorkActivitiesByClientId`, `getWorkActivitiesByEmployeeId`.
+- **Verify**: Add a query-count assertion in a test: list 100 activities runs ≤ 5 queries (was 301).
+
+## 4.3 — Add `/api/dashboard/stats` endpoint (part of Finding #14)
+
+- **Files**: New route `server/src/routes/dashboard.ts`; new service method on `WorkActivityService` or a new `DashboardService`; update `src/components/Dashboard.tsx:92-186`.
+- **Problem**: Dashboard fetches the entire `/api/work-activities` (no filter, no pagination) on every page load and aggregates client-side.
+- **Approach**: Backend computes `{ totalActivities, thisWeekActivities, totalHours, billableHours, needsReviewCount, recentActivities (LIMIT 5), upcomingActivities (LIMIT 5) }` with SQL `COUNT/SUM/GROUP BY`. Dashboard stops calling `/api/work-activities` and instead calls `/api/dashboard/stats`.
+- **Verify**: Dashboard loads in <500ms even with 10k+ work activities (use the prod-pull feature to seed test data).
+
+## 4.4 — Convert Reports route to SQL aggregation (also Finding #14)
+
+- **Files**: `server/src/routes/reports.ts:59-138, 171-309`
+- **Problem**: Both `/api/reports/time-series` and `/api/reports/summary` call `workActivityService.getAllWorkActivities(filters)` (full N+1 cost), then loop in JS to group by date/client/employee/day-of-week.
+- **Approach**: Replace JS forEach loops with SQL `GROUP BY` queries. Example for day-of-week breakdown:
+  ```typescript
+  db.select({
+    dayOfWeek: sql<string>`to_char(${workActivities.date}::date, 'Day')`,
+    billableHours: sql<number>`SUM(${workActivities.billableHours})`,
+    activities: sql<number>`COUNT(*)`,
+  }).from(workActivities).where(...).groupBy(sql`to_char(${workActivities.date}::date, 'Day')`);
+  ```
+- **Verify**: Reports for "Last year" loads in <1s. Numbers match the prior JS-aggregated output on a known dataset.
+
+## 4.5 — Calendar fetch deduplication (Finding #19)
+
+- **Files**: `server/src/services/SchedulingService.ts:360-440, 75-148`
+- **Problem**: `generateHelperAvailabilitySummary(helpers, 56)` loops over each helper and calls `checkHelperAvailability` → `getCalendarEventsInRange`. So for 5 helpers × 56 days = 5 separate Google Calendar API calls for the same range. Hits quota at ~50 chat queries/hour.
+- **Approach**: In `getSchedulingContext`, fetch the full calendar range ONCE via `getCalendarEventsInRange`, then pass the events array into `generateHelperAvailabilitySummary` which filters per helper in-memory. Remove the per-helper `checkHelperAvailability` → `getEvents` call chain.
+- **Verify**: A chat query that involves 5 helpers triggers exactly 1 Google Calendar API call (log/instrument to confirm).

--- a/docs/plans/05-integration-efficiency.md
+++ b/docs/plans/05-integration-efficiency.md
@@ -1,0 +1,40 @@
+# Plan 5 — Integration Efficiency
+
+**Findings**: #16, #17, #18
+**Effort**: 4–5 days
+**Tier**: 📉 Medium
+
+## Why
+
+The Anthropic, Notion, and QuickBooks integrations all leave significant cost/latency wins on the table — prompt caching disabled, sync runs sequentially with redundant lookups, and QBO customer fetches pull the full table per invoice.
+
+## 5.1 — Enable Anthropic prompt caching (Finding #16)
+
+- **Files**: `server/src/services/AnthropicService.ts:60-209, 437-753`
+- **Problem**: System prompt rebuilt from scratch per call. No `cache_control` on `messages.create`. A 5-tool-call scheduling query = ~100k input tokens billed; with caching it would be ~10k. Roughly 10× cost reduction available.
+- **Approach**:
+  1. Mark the system prompt with `cache_control: { type: 'ephemeral' }` in the `messages.create` call.
+  2. Move large semi-static content (helpers table, clients-by-zone, calendar context) into structured tool responses Claude can fetch on demand instead of always-on system prompt.
+  3. Add `anthropic-beta: prompt-caching-2024-07-31` header if not already present.
+  4. Trim conversation history in the tool loop (`AnthropicService.ts:125-179`) to last N messages once total tokens exceed a threshold.
+- **Verify**: Inspect `response.usage` → `cache_read_input_tokens > 0` on the second call within 5 min. Per-query cost drops ~10×.
+
+## 5.2 — Parallelize Notion sync with hoisted lookup maps (Finding #17)
+
+- **Files**: `server/src/services/NotionSyncService.ts:80-120, 820-866, 935-990`
+- **Problem**: Per page: one `getAllClients()` + one `getAllEmployees()` + one Anthropic AI call, all sequential. 200 pages = 10–15 minutes. 1000 pages will exceed the cron window.
+- **Approach**:
+  1. Before the page loop in `syncNotionPages`: fetch `clientService.getAllClients()` and `employeeService.getAllEmployees()` ONCE; build `Map<lowerName, Client>` and `Map<lowerName, Employee>`. Pass these into `processSingleNotionPage`.
+  2. Replace the sequential `for` loop with `pLimit(5)` (or chunked `Promise.all` of 5) to process 5 pages concurrently. (Respect Notion's ~3 req/s — tune as needed.)
+  3. Use Notion's `filter: { property: 'Last edited time', date: { on_or_after: lastSyncAt } }` to skip unchanged pages without fetching their content. Persist `last_successful_sync_at` to `settings` table.
+- **Verify**: Sync of 200 pages drops from ~10–15 min to ~2–3 min. Re-sync immediately after = near-instant (filter skips everything).
+
+## 5.3 — Fix QBO customer fetch pattern (Finding #18)
+
+- **Files**: `server/src/services/QuickBooksService.ts:455-484`; `server/src/services/InvoiceService.ts:280-308`
+- **Problem**: `findCustomerByName` calls `findCustomers({})` — fetching all QBO customers — to do client-side filtering. Then `ensureQBOCustomer` calls `getAllCustomers()` again for fuzzy matching. So every invoice creation triggers 2 full QBO customer fetches plus debug logs stringifying the entire list.
+- **Approach**:
+  1. Replace `findCustomers({})` + JS filter with `qbo.findCustomers([{ field: 'DisplayName', value: name, operator: 'LIKE' }])`.
+  2. Remove the duplicate `getAllCustomers()` call in `ensureQBOCustomer` — use the same query or extend the existing local cache pattern (already used for `qbo_items`).
+  3. Delete the `console.log` lines that stringify entire customer lists.
+- **Verify**: Creating an invoice triggers 1 QBO API call (not 2 full fetches). Log inspection confirms no big stringified lists.

--- a/docs/plans/06-frontend-bundle.md
+++ b/docs/plans/06-frontend-bundle.md
@@ -1,0 +1,31 @@
+# Plan 6 — Frontend Bundle & Rendering
+
+**Findings**: #20
+**Effort**: 1–2 days
+**Tier**: 📉 Medium
+
+## Why
+
+Zero `React.lazy`/`Suspense`. `draft-js`, `react-draft-wysiwyg`, `recharts`, `@mui/x-date-pickers` all ship in the initial bundle. Likely ~1.5–3 MB gzipped on first load. Bundle savings of 30–50% available with a half-day refactor.
+
+## Approach
+
+- **Files**: `src/App.tsx:7-28`; `src/components/WorkActivityEditDialog.tsx:31-35`
+- **Steps**:
+  1. Lazy-load every route component:
+     ```typescript
+     const Dashboard = React.lazy(() => import('./components/Dashboard'));
+     const Reports = React.lazy(() => import('./components/Reports'));
+     const Admin = React.lazy(() => import('./components/Admin'));
+     const Invoices = React.lazy(() => import('./components/Invoices'));
+     // ...all 30+ route components
+     ```
+  2. Wrap `<Routes>` in `<Suspense fallback={<CircularProgress />}>`.
+  3. Inside `WorkActivityEditDialog.tsx`, lazy-load the rich-text editor: split the editor body into a separate component and `React.lazy` it so `draft-js` only loads when the dialog opens.
+  4. Optional: install `source-map-explorer` to verify before/after.
+
+## Verify
+
+- `npm run build` → check `build/static/js/` for split chunks (multiple JS files instead of one giant `main.*.js`).
+- Login page first load <500KB gzipped (was likely 1.5–3MB).
+- Opening `WorkActivityEditDialog` triggers a network request for the editor chunk on first open only.

--- a/docs/plans/07-backend-architecture.md
+++ b/docs/plans/07-backend-architecture.md
@@ -1,0 +1,97 @@
+# Plan 7 — Backend Architecture Cleanup
+
+**Findings**: #21, #22, #23, #24, #29, #30, #31
+**Effort**: 2 weeks
+**Tier**: 🏗️ Debt
+
+## Why
+
+The architectural pieces are sound on paper (DI container, service layer, route layer) but discipline gaps everywhere break the abstractions. These are independent cleanups that can ship one at a time.
+
+## 7.1 — Make DI container authoritative (Finding #21)
+
+- **Files**: `server/src/services/container.ts` (the container itself is fine); all sites currently calling `new XService()`:
+  - `WorkActivityService.ts:90-93`, `NotionSyncService.ts:38-43`, `InvoiceService.ts:43-46`, `AdminService.ts:72-76`, `CronService.ts:25-26, 190-191`, `BaseTimeAllocationService.ts:85`, `DataMigrationService.ts:32-34`, `ProductionPullService.ts:95`, `QuickBooksService.ts:508`, `server.ts:115-116, 505`, `routes/notionSync.ts:10`
+- **Problem**: Each `new XService()` creates a parallel singleton — defeating the container. There are ~5 separate `AnthropicService` instances at runtime. The `setSchedulingService` hack at `AnthropicService.ts:55-58` only patches the container's instance — the others stay broken.
+- **Approach**:
+  1. Refactor each service's constructor to accept its dependencies: `constructor(private deps: { anthropic: AnthropicService, work: WorkActivityService, ... })`.
+  2. Update `container.ts` to wire dependencies in topological order (leaf services first).
+  3. Delete every `new XService()` outside `container.ts` and tests.
+  4. Add an ESLint rule (`no-restricted-syntax`) banning `NewExpression[callee.name=/.*Service$/]` outside `container.ts` and `__tests__/`.
+  5. Removes the need for the `setSchedulingService` hack in `AnthropicService.ts:55-58`.
+- **Verify**: `grep -rn "new \w*Service" server/src --include='*.ts' | grep -v container.ts | grep -v __tests__` returns empty. App still boots; chat still works (was previously broken outside `/api/chat` due to the injection hack).
+
+## 7.2 — Encapsulate DB access (Finding #22)
+
+- **Files**: `server/src/services/DatabaseService.ts:4`; route files reaching in: `routes/dataExport.ts:50`, `routes/quickbooks.ts:256-396`; service files: `NotionSyncService.ts:1271-1370`, `AdminService.ts:85-87,113-152`
+- **Problem**: `DatabaseService.db` is `public`. Routes contain 100+ lines of Drizzle queries; services reach into each other's tables. Business logic in `WorkActivityService.updateWorkActivity` is silently bypassed.
+- **Approach**:
+  1. Change `DatabaseService.db` from `public` to `protected`.
+  2. Move every Drizzle query out of routes into the owning service. New service methods as needed (e.g., `WorkActivityService.bulkSetCharges()`, `InvoiceService.markActivitiesInvoiced()`).
+  3. Cross-service writes (e.g., `NotionSyncService` mutating `otherCharges`) must go through `WorkActivityService` methods.
+  4. ESLint rule banning Drizzle table imports (`from '../db/schema'`) outside `services/` and `db/` paths.
+- **Verify**: `grep -rn "from.*db/schema" server/src/routes/` returns empty. Build still succeeds.
+
+## 7.3 — Standardize error handling (Finding #23)
+
+- **Files**: All 16 route files in `server/src/routes/`; `server/src/middleware/asyncHandler.ts`; `server/src/server.ts:624-627` (global error handler)
+- **Problem**: 30 routes use `asyncHandler`, 76 use manual try/catch. 4 different response shapes. The global error handler at `server.ts:624-627` only fires for `asyncHandler` routes; bespoke catches leak schema names in `details` fields.
+- **Approach**:
+  1. Define `AppError` class in `server/src/utils/AppError.ts` with `statusCode`, `code`, `message` properties.
+  2. Convert every route handler in `routes/admin.ts`, `quickbooks.ts`, `settings.ts`, `notionSync.ts`, `migration.ts`, `breakTime.ts`, `travelTime.ts`, `naturalLanguageSQL.ts`, `reports.ts` from manual try/catch to `asyncHandler` wrapping.
+  3. Update global error handler to produce a single response shape: `{ error: string, code?: string }`. Hide `details` in production; log full error server-side with request ID.
+  4. Replace all `console.error` / `console.log` in route handlers with `debugLog.*`.
+  5. ESLint rule against bare `try/catch` at route handler top level.
+- **Verify**: All errors return `{ error, code? }` shape (curl + grep). Server logs contain full stack + request ID; client sees only sanitized message.
+
+## 7.4 — Normalize API response shapes (Finding #24)
+
+- **Files**: All route files
+- **Problem**: `GET /api/work-activities` returns `[]`, `GET /api/clients` returns `{ clients: [] }`, `GET /api/admin/status` returns `{ success: true, data: {...} }`. Frontend has to know per-endpoint how to unwrap.
+- **Approach**: Pick one convention — recommend **bare values for GET (arrays or objects), `{ data, error }` for mutations**. Audit each route, change response shapes, update each frontend caller in lockstep. Group by route file to ship one PR per route file (`/api/clients` → `/api/employees` → ...). Add a TypeScript type per endpoint shared between FE/BE if [Plan 8.2](./08-frontend-foundation.md) is done.
+- **Verify**: One consistent shape per HTTP method category. Frontend type errors flush out any missed call sites.
+
+## 7.5 — Centralize env config (Finding #30)
+
+- **Files**: `server/src/db/index.ts:6-9`, `server/src/services/NotionService.ts:4-9`, `server/src/services/NotionSyncService.ts:10-14`, `server/src/server.ts` (many), and 20+ others doing raw `process.env.X`
+- **Problem**: 24 files do raw `process.env.*` lookups. Module-load-time captures in `NotionService.ts:4-9` and `db/index.ts:6-9` mean `dotenv.config()` ordering matters. Hardcoded fallbacks like `'postgresql://localhost...'`, `'your-secret-key-change-in-production'`, `'http://localhost:3000'` litter the code.
+- **Approach**:
+  1. Create `server/src/config.ts`:
+     ```typescript
+     import { z } from 'zod';
+     const schema = z.object({
+       NODE_ENV: z.enum(['development','production','test']),
+       DATABASE_URL: z.string().url(),
+       SESSION_SECRET: z.string().min(32),
+       GOOGLE_OAUTH_CLIENT_ID: z.string(),
+       // ...all env vars
+     });
+     export const config = schema.parse(process.env);
+     ```
+  2. Replace all `process.env.X` reads with `config.X`. Boot fails-fast on missing/invalid vars.
+  3. Remove all hardcoded fallback strings.
+- **Verify**: Unset required env var → server fails at boot with clear zod error message. `grep -rn "process.env" server/src/ | grep -v config.ts` near-empty.
+
+## 7.6 — Deduplicate time allocation services (Finding #29)
+
+- **Files**: `server/src/services/BreakTimeAllocationService.ts`, `server/src/services/TravelTimeAllocationService.ts`, `server/src/services/BaseTimeAllocationService.ts`; `server/src/routes/breakTime.ts`, `server/src/routes/travelTime.ts`
+- **Problem**: 410 lines of mirror-image copy-paste. Both subclasses are 95% identical wrappers translating between near-identical interfaces. Both route files (187 lines each) have identical structure.
+- **Approach**:
+  1. Delete `BreakTimeAllocationService` and `TravelTimeAllocationService` wrappers. The base class already has the logic.
+  2. Expose a single `services.timeAllocation.allocate(date, type: 'break' | 'travel')` API.
+  3. Create `createTimeAllocationRouter(type: 'break' | 'travel')` factory; both routes become ~30 lines each.
+  4. Frontend `TravelTimeAllocation.tsx` + `BreakTimeAllocation.tsx` already share shape — point both at the unified API.
+- **Verify**: 410 lines deleted. Both routes still pass any existing tests; frontend allocation UI unchanged.
+
+## 7.7 — Harden QBO OAuth (Finding #31)
+
+- **Files**: `server/src/services/QuickBooksService.ts:88, 124-194`; `server/src/routes/quickbooks.ts:21-23`
+- **Problem**: Hardcoded OAuth `state = 'qbo_auth'` (`QuickBooksService.ts:153`) defeats CSRF protection — attacker submits their own valid callback to your `/api/qbo/callback`, your server stores attacker's QBO tokens, future invoices route to their QuickBooks. Tokens are also written to `process.env` at runtime (lost on every restart, process-global, mutating runtime env).
+- **Approach**:
+  1. Generate random `state` per OAuth init: `crypto.randomBytes(32).toString('hex')`. Store in `req.session.qboState`.
+  2. Callback validates `req.query.state === req.session.qboState`; reject mismatch.
+  3. Create `qbo_credentials` table: `id`, `realm_id`, `access_token` (encrypted), `refresh_token` (encrypted), `expires_at`, `updated_at`. Persist tokens here, not `process.env`.
+  4. Encryption: app-level AES-GCM with key from `config.QBO_TOKEN_ENCRYPTION_KEY` (Plan 7.5).
+  5. On refresh: write new tokens back to DB.
+  6. Use `crypto.timingSafeEqual` for any bearer-token compares in `server.ts:436-498`, `routes/dataExport.ts:35`.
+- **Verify**: Restart server → QBO connection survives. Replay attack with stale state → rejected. Tokens in DB encrypted (visual inspection).

--- a/docs/plans/08-frontend-foundation.md
+++ b/docs/plans/08-frontend-foundation.md
@@ -1,0 +1,44 @@
+# Plan 8 — Frontend Foundation
+
+**Findings**: #25, #26
+**Effort**: 1 week
+**Tier**: 🏗️ Debt
+
+## Why
+
+4 competing API client patterns, no server cache, no 401 handling, `WorkActivity` type defined 10× and already drifted. These two changes remove ~30% of every component's code and unlock cleaner downstream refactors (Plan 9).
+
+## 8.1 — Unify API client + add React Query (Finding #25)
+
+- **Files**: `src/config/api.ts` (delete), `src/services/api.ts` (canonical), `src/contexts/AuthContext.tsx`, all 14+ components using raw `fetch()` or local `axios.create()`
+- **Problem**:
+  - `src/services/api.ts` (axios) — 8 importers
+  - `src/config/api.ts` (fetch wrapper, marked `@deprecated`) — still imported by 10 files including `AuthContext.tsx`
+  - Local `axios.create()` in `NotionSync.tsx:47`, `Admin.tsx:66`, `NaturalLanguageSQL.tsx`
+  - Raw `fetch()` in 14 files (55 occurrences)
+  - `ClientDetail.tsx` uses raw `fetch()` exclusively (13 calls)
+  - Zero 401/403 handling anywhere — session expiry shows as random "Failed to load X" toasts
+  - No React Query / SWR: 191 `setLoading`/`setError`/`setSaving` calls across 24 files
+- **Approach**:
+  1. Audit `src/config/api.ts` imports (10 files); migrate each to `src/services/api.ts`. Then delete `src/config/api.ts`.
+  2. Move `API_ENDPOINTS` constants into `src/services/api.ts` with consistent leading `/api/` paths.
+  3. Add axios response interceptor: 401 → `window.dispatchEvent(new CustomEvent('auth:expired'))`; `AuthProvider` listens and calls `setUser(null)`.
+  4. `npm i @tanstack/react-query`; wrap `<App />` in `<QueryClientProvider>`.
+  5. Co-locate hooks with API layer: `services/api.ts` exports `useWorkActivities(filters)`, `useClient(id)`, `useUpdateWorkActivity()`, etc.
+  6. Cache keys: `['work-activities', filters]`, `['clients', id]`, `['clients', id, 'work-activities']`.
+  7. Migrate file-by-file: start with `Dashboard.tsx` and `ClientDetail.tsx` (most state to retire).
+  8. Replace local `axios.create()` in `NotionSync.tsx:47`, `Admin.tsx:66`, `NaturalLanguageSQL.tsx` with the canonical client.
+  9. Add ESLint rule `no-restricted-globals: ['error', 'fetch']` after migration complete.
+- **Verify**: `grep -rn "fetch(" src/` returns empty (or only inside `services/`). Session expiry → automatic redirect to login. Mutating a work activity in one component invalidates other components' caches.
+
+## 8.2 — Canonical entity types (Finding #26)
+
+- **Files**: `src/types/entities.ts` (new); 10+ component files declaring `interface WorkActivity` / `Client` / `Employee` / `OtherCharge`
+- **Problem**: `WorkActivity` defined in 10 files; `Client` in 3; `Employee` in 4. Definitions have already drifted — `services/api.ts:193` has 14 fields; `WorkActivityEditDialog.tsx:37` has 27 fields. `priorityLevel` is `string` in one and `'High' | 'Medium' | 'Low'` in another (causes the `as any` at `ClientDetail.tsx:617`).
+- **Approach**:
+  1. Create `src/types/entities.ts` exporting `WorkActivity`, `Client`, `Employee`, `Project`, `OtherCharge`, `PlantListItem`, `ClientNote`. Use the most complete shape (typically from `*EditDialog.tsx` files).
+  2. **Bonus**: Use `drizzle-zod` to generate types from `server/src/db/schema.ts` and share via a `shared/` package — this prevents future drift permanently.
+  3. Replace local interface declarations with `import { WorkActivity } from '../types/entities'`.
+  4. ESLint rule: `no-restricted-syntax: TSInterfaceDeclaration[id.name=/^(WorkActivity|Client|Employee|Project)$/]` outside `src/types/`.
+  5. Tighten unions where text was used: `priorityLevel: 'High' | 'Medium' | 'Low'`, `status: 'planned' | 'in_progress' | ...`. Removes the `as any` at `ClientDetail.tsx:617`.
+- **Verify**: `tsc --noEmit` passes. Adding a new field to `WorkActivity` requires touching exactly 1 file (+ Drizzle schema if shared).

--- a/docs/plans/09-god-class-decomposition.md
+++ b/docs/plans/09-god-class-decomposition.md
@@ -1,0 +1,71 @@
+# Plan 9 — God Class Decomposition
+
+**Findings**: #27 (4 sub-plans)
+**Effort**: 2–3 weeks
+**Tier**: 🏗️ Debt
+
+## Why
+
+Four files past the threshold where additional features cost more than they deliver. Splits are designed to make domain testing possible and unblock parallel work by multiple engineers.
+
+## 🚧 Prerequisite
+
+**This plan requires [Plan 10 (Test Coverage Foundation)](./10-test-coverage.md) for the `NotionSyncService` and `AnthropicService` paths.** Frontend components (9.3 and 9.4) can be split safely with render tests in place.
+
+Also benefits from:
+- [Plan 7.1 (DI container)](./07-backend-architecture.md) before 9.2 (removes circular-dep hack)
+- [Plan 8 (Frontend Foundation)](./08-frontend-foundation.md) before 9.4 (cleaner `useClientData` hook)
+
+## 9.1 — Split `NotionSyncService` (1987 lines)
+
+- **Files**: `server/src/services/NotionSyncService.ts`
+- **Target modules** (all in `server/src/services/notion/`):
+  - `NotionClient.ts` — wraps `@notionhq/client`, no business logic (~100 lines)
+  - `NotionPageParser.ts` — `get*Property`, `parse*`, `extractTextFromRichText`, `extractClientNameFromNotionPage`, `extractDateFromNotionPage` (~400 lines, stateless utility class)
+  - `NotionPageContentParser.ts` — `getPageContent`, `parseChargeFromText` (~300 lines)
+  - `ClientMatcher.ts` — `calculateSimilarity`, `findBestClientMatch`, `ensureClientExists` (~150 lines)
+  - `EmployeeMatcher.ts` — name variants + matching (~100 lines)
+  - `WorkActivityMapper.ts` — parsed Notion data → `CreateWorkActivityData` (pure functions, ~200 lines)
+  - `NotionSyncOrchestrator.ts` — `syncNotionPages`, `processSingleNotionPage`, SSE progress (~300 lines, only this one has DI dependencies)
+- **Approach**: Build new modules with tests, then incrementally replace methods on the existing service, then delete the old class once parity confirmed. Use [Plan 2.1](./02-data-integrity.md) transaction wrappers in `WorkActivityMapper` consumers.
+- **Verify**: New unit tests pass for parsers (no DB/Notion needed — pure functions). Integration test against a fixture Notion page returns same result as the prior implementation.
+
+## 9.2 — Split `AnthropicService` (1565 lines)
+
+- **Files**: `server/src/services/AnthropicService.ts`
+- **Target modules** (in `server/src/services/anthropic/`):
+  - `AnthropicClient.ts` — SDK wrapper + retry + cache headers (~80 lines)
+  - `SchedulingTools.ts` — tool schema definitions + dispatch table (pure data + small dispatch fn, ~250 lines)
+  - `SchedulingChatService.ts` — `getSchedulingRecommendation`, tool-call loop (~400 lines, depends on SchedulingService)
+  - `WorkNotesParser.ts` — `parseWorkNotes` (~200 lines)
+  - `HistoricalSheetParser.ts` — `parseHistoricalSheetData` + batching/progress (~300 lines)
+  - `InvoiceLineItemGenerator.ts` — `generateInvoiceLineItems` (~150 lines)
+  - `NotionDataExtractor.ts` — `processStructuredNotionData` (~150 lines, used by NotionSyncService)
+- **Approach**: Eliminates the circular-dep `setSchedulingService` hack — `SchedulingChatService` simply receives `SchedulingService` via constructor injection ([Plan 7.1](./07-backend-architecture.md)).
+- **Verify**: `/api/chat` returns identical responses to a known query before/after split. Tool execution still works.
+
+## 9.3 — Split `WorkActivityReviewFlow.tsx` (2281 lines)
+
+- **Files**: `src/components/WorkActivityReviewFlow.tsx`
+- **Target modules** (in `src/components/workActivityReview/`):
+  - `WorkActivityReviewFlow.tsx` (~400 lines) — top-level orchestrator
+  - `ReviewCarousel.tsx` (~250 lines) — single-activity card + next/prev/skip
+  - `BulkAllocationStep.tsx` (~400 lines) — wraps existing `TravelTimeAllocation`/`BreakTimeAllocation`
+  - `hooks/useReviewQueue.ts` — currentIndex, approvedActivityIds, navigation (~80 lines)
+  - `hooks/useBulkTravelTimeAllocation.ts` (~200 lines)
+  - `hooks/useBulkBreakTimeAllocation.ts` (~200 lines)
+  - `utils/workActivityCalculations.ts` — `calculateBillableHours`, `distributeHoursProportionally` (pure, testable, ~40 lines)
+- **Critical**: Delete the inline 240-line edit dialog (lines 1735-1995). Use existing `<WorkActivityEditDialog>` with a new `mode="quick-review"` prop that hides charges/plants sections. Saving from the current inline dialog silently drops edits to charges/plants — this is a real bug being fixed.
+- **Verify**: All review flow user actions still work (approve, skip, edit, bulk allocate). Render tests on each extracted component pass.
+
+## 9.4 — Split `ClientDetail.tsx` (1462 lines)
+
+- **Files**: `src/components/ClientDetail.tsx`
+- **Target modules** (in `src/components/clientDetail/`):
+  - `ClientDetail.tsx` (~300 lines) — tabs/layout
+  - `ClientEditDialog.tsx` (~250 lines) — extract from inline dialog at line 1232+
+  - `ClientInvoiceCreator.tsx` (~300 lines) — extract from lines 490-540, 802-880, 950-1228
+  - `ClientNoteEditor.tsx` (~150 lines) — extract notes dialog
+  - `hooks/useClientData.ts` — React Query wrapper returning `{ client, workActivities, summary, schedule, notes }`
+- **Approach**: Once React Query is in place ([Plan 8.1](./08-frontend-foundation.md)), `useClientData` replaces the 4 sequential `useEffect` fetches and prevents the artificially-slow page load.
+- **Verify**: Client detail page renders identically. All CRUD actions (edit client, add note, create invoice, edit activity) still work.

--- a/docs/plans/10-test-coverage.md
+++ b/docs/plans/10-test-coverage.md
@@ -1,0 +1,27 @@
+# Plan 10 — Test Coverage Foundation
+
+**Findings**: #28
+**Effort**: 1–2 weeks
+**Tier**: 🏗️ Enabler
+
+## Why
+
+4 test files exist, all on billable-hours math + reports date helpers. Zero coverage on the highest-risk surfaces (`NotionSyncService`, `AnthropicService`, all routes, all React components). [Plan 9 (god class decomposition)](./09-god-class-decomposition.md) cannot ship safely without this.
+
+## Approach
+
+- **Files**:
+  - `server/src/__tests__/routes/*.test.ts` (new) — supertest-based integration tests
+  - `server/src/services/__tests__/*.test.ts` (new) — pure unit tests for parsers/matchers
+  - `src/components/__tests__/*.test.tsx` (new) — RTL-based render tests
+- **Steps**:
+  1. **Integration tests for top 5 routes** (`workActivities`, `clients`, `employees`, `breakTime`, `travelTime`): use `supertest` + a test database from `server/scripts/migrate-and-exit.js`. Cover CRUD happy paths + auth rejection.
+  2. **Unit tests for `NotionSyncService` extractors** (after [Plan 9.1](./09-god-class-decomposition.md) split — or do these in parallel by extracting just the pure functions first): test `NotionPageParser`, `ClientMatcher`, `WorkActivityMapper` as pure functions with fixture data.
+  3. **Render tests for top 5 frontend components**: `Dashboard`, `ClientDetail`, `WorkActivityReviewFlow`, `WorkActivitiesTable`, `Reports` — render with mock API responses (MSW), assert key elements present + key user interactions fire correct mutations.
+  4. Wire `npm test` into CI on every PR.
+
+## Verify
+
+- `npm test` passes both server and frontend.
+- Coverage report shows ≥40% on services + ≥30% on routes (vs. current ~5%).
+- CI fails any PR that breaks an existing test.

--- a/docs/plans/11-tooling-hygiene.md
+++ b/docs/plans/11-tooling-hygiene.md
@@ -1,0 +1,37 @@
+# Plan 11 — Tooling & Hygiene
+
+**Findings**: #32 + repo cleanup items
+**Effort**: 1 day
+**Tier**: 🧹 Cleanup
+
+## Why
+
+28 server-side dependency vulnerabilities (3 critical, 10 high) + 61 frontend. Plus accumulated dead files and duplicate configs at the repo root that confuse new contributors.
+
+## 11.1 — Dependency vulnerabilities (Finding #32)
+
+- **Files**: `package.json`, `server/package.json`
+- **Notable critical/high**:
+  - `axios <1.12.0` (server uses `^1.5.0`) — DoS (CVSS 7.5) and SSRF
+  - `fast-xml-parser` (via `node-quickbooks`) — critical: entity-encoding bypass, DoS
+  - `form-data <2.5.4` (via `node-quickbooks`) — critical: unsafe boundary RNG
+  - `underscore` (via `node-quickbooks`) — high: unlimited recursion DoS
+  - `validator <=13.15.20` — high: URL-validation bypass
+- **Approach**:
+  1. `npm audit fix` in both — apply all non-breaking patches.
+  2. Replace or wrap `node-quickbooks` (drags `fast-xml-parser`, `form-data`, `underscore` vulnerabilities). Option A: pin to a maintained fork. Option B: write a thin wrapper around QBO's REST API with `axios` and drop the SDK.
+  3. Bump axios to `^1.12.0`+ for the SSRF fix.
+  4. Plan a follow-up migration off CRA → Vite (out of scope for this plan).
+- **Verify**: `npm audit` shows no critical/high vulns. App still runs.
+
+## 11.2 — Repo cleanup
+
+- **Files (delete)**:
+  - `test_work_notes_import.py` (orphaned — calls non-existent endpoints `/api/work-notes/parse` and `/api/work-notes/templates`)
+  - `.env.example` (keep `env.example` — the longer, accurate one; the shorter version references SQLite which was migrated off)
+  - `design docs/` folder (with space; move `nadler_invoice.pdf` to `docs/design/`)
+  - `scripts/calendar_enhancer.py` (verify unused first)
+  - `server/src/types/index.d.ts` (duplicate of `quickbooks.d.ts`)
+- **Files (also consider, but verify dependencies first)**:
+  - Legacy type system in `server/src/types/index.ts:36-110` (`Helper`/`Client`/`Project` interfaces marked `@deprecated`). Only valuable to delete if [Plan 7.1](./07-backend-architecture.md) migrates `SchedulingService`/`GoogleSheetsService`/`AnthropicService` off legacy shapes first.
+- **Verify**: `npm run type-check` passes after each deletion. No references found via `grep -rn '<filename>' .`.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,71 @@
+# Architectural Remediation Plans
+
+A portfolio of independent, executable plans for addressing findings from a multi-agent architectural review of the codebase. Each plan is self-contained — an agent (or developer) given a single plan should be able to execute it without reading the others. Cross-plan dependencies are called out where they exist.
+
+## Context
+
+A multi-agent architectural review of the codebase surfaced 32 substantial findings spanning security, data integrity, performance, frontend architecture, backend architecture, and code quality. They fall into known categories: critical security gaps, silent data-loss risks, performance ceilings that will hit at moderate scale, and architectural debt that slows feature work.
+
+Finding #7 ("all authenticated users are admins") is intentionally omitted from these plans — the app is only used by ~2 people, so role-separation isn't worth doing yet.
+
+## Index
+
+| # | Plan | Findings | Effort | Tier |
+|---|---|---|---|---|
+| 1 | [Security Hardening](./01-security-hardening.md) | #1, #2, #3, #4, #5, #6 | 2–3 days | 🚨 Urgent |
+| 2 | [Data Integrity & Schema](./02-data-integrity.md) | #8, #9, #10, #11, #12 | 1.5 weeks | 🚨 Urgent |
+| 3 | [Background Job Reliability](./03-background-jobs.md) | #13 | 1 week | 📉 Medium |
+| 4 | [Query Performance](./04-query-performance.md) | #14, #15, #19 | 1 week | 📉 Urgent-soon |
+| 5 | [Integration Efficiency](./05-integration-efficiency.md) | #16, #17, #18 | 4–5 days | 📉 Medium |
+| 6 | [Frontend Bundle & Rendering](./06-frontend-bundle.md) | #20 | 1–2 days | 📉 Medium |
+| 7 | [Backend Architecture Cleanup](./07-backend-architecture.md) | #21, #22, #23, #24, #29, #30, #31 | 2 weeks | 🏗️ Debt |
+| 8 | [Frontend Foundation](./08-frontend-foundation.md) | #25, #26 | 1 week | 🏗️ Debt |
+| 9 | [God Class Decomposition](./09-god-class-decomposition.md) | #27 (4 sub-plans) | 2–3 weeks | 🏗️ Debt |
+| 10 | [Test Coverage Foundation](./10-test-coverage.md) | #28 | 1–2 weeks | 🏗️ Enabler |
+| 11 | [Tooling & Hygiene](./11-tooling-hygiene.md) | #32 + repo cleanup | 1 day | 🧹 Cleanup |
+
+## Cross-Plan Dependency Graph
+
+```
+Plan 1 (Security) ──── independent ──── ship anytime
+Plan 2 (Data Integrity)
+  ├─ 2.1 (transactions) ── independent ── ship first
+  └─ 2.2-2.5 ─────── independent migrations
+Plan 3 (Background Jobs) ── independent ── ship anytime
+Plan 4 (Query Perf)
+  ├─ 4.1 (indexes) ── ship first
+  └─ 4.2-4.5 ─── benefits multiply with 4.1
+Plan 5 (Integration Perf) ── independent ── ship anytime
+Plan 6 (Frontend Bundle) ── independent ── ship anytime
+Plan 7 (Backend Arch Cleanup)
+  ├─ 7.5 (config) ── enables 7.7 (QBO OAuth secrets)
+  ├─ 7.1 (DI) ── enables removal of AnthropicService hack in 9.2
+  └─ 7.2-7.4, 7.6 ── independent
+Plan 8 (Frontend Foundation)
+  ├─ 8.2 (types) ── ship first; enables cleaner 8.1
+  └─ 8.1 (API + React Query) ── enables cleaner 9.4
+Plan 9 (God Class Splits) ─── REQUIRES Plan 10 (tests) ─── frontend splits benefit from Plan 8
+Plan 10 (Tests) ─── enables Plan 9 ─── ship before Plan 9
+Plan 11 (Hygiene)
+  └─ both items independent ── ship anytime
+```
+
+## Suggested Execution Order (if doing sequentially)
+
+1. **Week 1 — stop the bleeding**: Plan 1 (all), Plan 2.1 (transactions), Plan 11 (hygiene)
+2. **Week 2 — make it fast**: Plan 4 (all), Plan 5.1 (Anthropic caching)
+3. **Week 3 — make it correct long-term**: Plan 2.2–2.5 (types + constraints), Plan 5.2 (Notion sync), Plan 5.3 (QBO)
+4. **Week 4 — frontend foundation**: Plan 8.2 → Plan 8.1, Plan 6
+5. **Weeks 5–6 — backend architecture**: Plan 7.5 → Plan 7.1, then 7.2, 7.3, 7.4, 7.6, 7.7
+6. **Weeks 7–8 — testing foundation**: Plan 10
+7. **Weeks 9–11 — decomposition**: Plan 9.1 → 9.2 → 9.3 → 9.4 (after Plan 10 lands)
+8. **Anytime in parallel**: Plan 3 (background jobs)
+
+## Verification (cross-cutting)
+
+After any plan ships:
+- `cd server && npm run type-check` and `npm run build` — both pass
+- `cd server && npm test` — existing tests still pass
+- `npm run type-check` (frontend) and `npm run build:production` — both pass
+- Smoke test: log in, view dashboard, view a client detail, edit a work activity, run a Notion sync, generate an invoice. All work.
+- For data-touching plans: take a `pg_dump` snapshot before running migrations; verify row counts and key invariants (`SELECT SUM(billable_hours) FROM work_activities WHERE date >= '2024-01-01'`) unchanged unless the plan explicitly modifies them.


### PR DESCRIPTION
## Summary

Adds `docs/plans/` containing **11 independently-executable plans** addressing 31 findings (omitting the "all users are admins" item as not relevant for a 2-user app) surfaced by a multi-agent architectural review of the codebase. No code changes — documentation only.

Each plan is self-contained with file paths, fix approach, and verification steps — pickup-able by another agent or developer. The portfolio README includes a cross-plan dependency graph and a suggested sequential execution order.

### Plans

| # | Theme | Tier |
|---|---|---|
| 1 | Security Hardening | 🚨 Urgent |
| 2 | Data Integrity & Schema | 🚨 Urgent |
| 3 | Background Job Reliability | 📉 Medium |
| 4 | Query Performance | 📉 Urgent-soon |
| 5 | Integration Efficiency | 📉 Medium |
| 6 | Frontend Bundle & Rendering | 📉 Medium |
| 7 | Backend Architecture Cleanup | 🏗️ Debt |
| 8 | Frontend Foundation | 🏗️ Debt |
| 9 | God Class Decomposition | 🏗️ Debt |
| 10 | Test Coverage Foundation | 🏗️ Enabler |
| 11 | Tooling & Hygiene | 🧹 Cleanup |

### Highest-value items
- **Plan 1.1**: Disable `/api/natural-language-sql` — currently any authenticated user can run arbitrary SQL
- **Plan 1.2 + 1.3**: Fail-closed auth + remove hardcoded session secret fallback (one-typo full-takeover risk)
- **Plan 2.1**: Wrap every multi-statement write in `db.transaction()` — closes the largest class of silent data-loss risks
- **Plan 4.1 + 4.2**: Add FK indexes + fix N+1 in WorkActivityService (3001 queries → 4)

## Test plan

- [ ] Skim `docs/plans/README.md` to confirm the cross-plan dependency graph and execution order make sense
- [ ] Spot-check 2-3 individual plans to verify file paths/line numbers are accurate
- [ ] Confirm `docs/README.md` link to the plans portfolio renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)