### PR TITLE
Fix start_time/end_time regex in migration 0012

### DIFF
--- a/server/drizzle/0012_normal_reaper.sql
+++ b/server/drizzle/0012_normal_reaper.sql
@@ -65,18 +65,19 @@ BEGIN
     RAISE EXCEPTION 'invoices.due_date has % non-ISO rows — normalize before migrating', bad_count;
   END IF;
 
-  -- start/end times: HH:MM or HH:MM:SS (with optional am/pm not allowed —
-  -- Postgres `time` is 24h ISO format)
+  -- start/end times: H:MM, HH:MM, or HH:MM:SS. Postgres' `time` parser
+  -- handles single-digit hours natively ('9:00'::time → 09:00:00) so we
+  -- accept either width here — the USING cast below does the real check.
   SELECT COUNT(*) INTO bad_count FROM work_activities
-   WHERE start_time IS NOT NULL AND start_time !~ '^\d{2}:\d{2}(:\d{2})?$';
+   WHERE start_time IS NOT NULL AND start_time !~ '^\d{1,2}:\d{2}(:\d{2})?$';
   IF bad_count > 0 THEN
-    RAISE EXCEPTION 'work_activities.start_time has % non-ISO rows — normalize to HH:MM[:SS] before migrating', bad_count;
+    RAISE EXCEPTION 'work_activities.start_time has % non-parseable rows — expected H:MM, HH:MM, or HH:MM:SS', bad_count;
   END IF;
 
   SELECT COUNT(*) INTO bad_count FROM work_activities
-   WHERE end_time IS NOT NULL AND end_time !~ '^\d{2}:\d{2}(:\d{2})?$';
+   WHERE end_time IS NOT NULL AND end_time !~ '^\d{1,2}:\d{2}(:\d{2})?$';
   IF bad_count > 0 THEN
-    RAISE EXCEPTION 'work_activities.end_time has % non-ISO rows — normalize to HH:MM[:SS] before migrating', bad_count;
+    RAISE EXCEPTION 'work_activities.end_time has % non-parseable rows — expected H:MM, HH:MM, or HH:MM:SS', bad_count;
   END IF;
 END $$;
 --> statement-breakpoint


### PR DESCRIPTION
## Summary

The pre-flight guard in `0012_normal_reaper.sql` required start/end times to match `^\d{2}:\d{2}(:\d{2})?$` (zero-padded hour), but **production has 98 rows in `work_activities.start_time` with single-digit hour values** like `9:00`, `9:05`, `9:30`. The strict regex was rejecting them before the cast could run, blocking the whole migration. Postgres' `time` parser handles `'9:00'::time` → `09:00:00` natively.

Loosened the regex to `^\d{1,2}:\d{2}(:\d{2})?$`. The `USING start_time::time` clause still does the real validation, so any genuinely unparseable value would still abort with a clean rollback.

## Why editing the file in place is safe

The original migration aborted at the `RAISE EXCEPTION` **before any schema change**, so Drizzle never recorded it as applied. Every DB that's seen this migration is still in its pre-0012 state — the next run will pick up the corrected version.

## Test plan

Verified end-to-end against a fresh test DB:

- [x] Applied migrations through `0011`
- [x] Seeded `work_activities` with `9:00`, `9:05`, `09:00`, and `NULL` start times (mirroring prod)
- [x] Ran updated `0012` — applied cleanly
- [x] Confirmed values are now `09:00:00`, `09:05:00`, `09:00:00`, `NULL` in a proper `time` column
- [x] Full server test suite: **128/128 passing**
- [ ] **After deploy**: re-run migration on Railway and confirm it applies

## Production observed

```
work_activities.start_time has 98 non-ISO rows
— normalize to HH:MM[:SS] before migrating
```

Sample of distinct bad values (5 pages × 5 = ~25 distinct, all single-digit-hour `H:MM`):

| start_time | count |
|---|---|
| 9:00 | 27 |
| 9:05 | 17 |
| 9:10 | 6 |
| 9:15 | 6 |
| 9:30 | 6 |
| … | … |

🤖 Generated with [Claude Code](https://claude.com/claude-code)