### PR TITLE
Fix CSRF for Admin requests; skip CSRF in dev

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -152,6 +152,9 @@ const { doubleCsrfProtection, generateCsrfToken } = doubleCsrf({
   },
   getCsrfTokenFromRequest: (req) => req.headers['x-csrf-token'] as string | undefined,
   skipCsrfProtection: (req) => {
+    // DEV: MemoryStore sessions get wiped on backend restart, which breaks the
+    // sessionID-bound CSRF tokens until the user re-auths. Skip in dev only.
+    if (process.env.NODE_ENV !== 'production') return true;
     const p = req.path;
     return (
       p === '/api/health' ||

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import { apiClient as api } from '../services/api';
 import {
   Container,
   Grid,
@@ -62,15 +62,6 @@ import {
 const API_BASE = process.env.NODE_ENV === 'production' 
   ? (process.env.REACT_APP_API_URL || '/api')
   : '/api'; // Use proxy in development
-
-const api = axios.create({
-  baseURL: API_BASE,
-  timeout: 60000,
-  withCredentials: true,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
 
 interface DatabaseStatus {
   employeesCount: number;


### PR DESCRIPTION
## Summary
- Fix `invalid csrf token` on the Pull from Production button (and every other state-changing Admin call) by routing `Admin.tsx` through the shared `apiClient` that attaches `X-CSRF-Token`, instead of its own bare `axios.create()` instance.
- Skip CSRF protection entirely in non-production environments. `csrf-csrf` ties tokens to `req.sessionID` and we're on the default in-memory session store, so every backend restart invalidates every browser's CSRF state until the user re-auths — a constant papercut in local dev. Production behavior is unchanged.

## Test plan
- [ ] `npm run dev`, log in, click **Preview Pull** on `/admin` — succeeds (no 403).
- [ ] Restart the backend container, click Preview Pull again without re-auth — still succeeds.
- [ ] Verify in DevTools that production builds (`NODE_ENV=production`) still send `X-CSRF-Token` on Admin requests and that protected routes 403 without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)