### PR TITLE
Mark Plan 2.5 (FK on-delete + soft delete) as won't-do

### DIFF
--- a/docs/plans/02-data-integrity.md
+++ b/docs/plans/02-data-integrity.md
@@ -68,13 +68,25 @@ Zero transactions across the entire codebase + several silent-corruption risks i
   3. Update `WorkActivityService` insert paths to use `.onConflictDoUpdate({ target: [workActivityId, employeeId], set: { hours, ... } })`.
 - **Verify**: Insert same `(workActivityId, employeeId)` twice → second call updates, doesn't create duplicate.
 
-## 2.5 — Make FK on-delete behavior explicit (Finding #12)
+## 2.5 — Make FK on-delete behavior explicit (Finding #12) — 🚫 Won't do
+
+**Decision**: skip this sub-plan. The original problem statement and approach are preserved below as a historical record, but no work is scheduled.
+
+**Rationale**:
+
+1. **Scale**: the app has ~2 users (business owner + dev/ops consultant). Destructive-delete scenarios where a stale row would silently corrupt downstream data are vanishingly rare in practice.
+2. **Current behavior is safe**: all FKs use `ON DELETE NO ACTION`, which fails loudly when a delete would violate referential integrity. That's the desired behavior — a thrown error is much better than silent cascade or orphaned rows. The risk this sub-plan was meant to address ("someone switches to `CASCADE` to silence the error") is a code-review concern, not an architectural one.
+3. **Cross-cutting cost**: introducing `deleted_at` on `clients`, `employees`, `projects`, and `invoices` would touch *every* active query against those tables — every list, every join, every report — and add a permanent maintenance tax (forget the `isNull(deletedAt)` filter once and you leak deleted data into reports). Not justified at current scale.
+4. **Revisit trigger**: if multi-user/role separation lands (i.e. Finding #7 gets addressed), reopen this. At that point soft-delete becomes more defensible because (a) more humans means more accidental deletes, and (b) audit/recovery needs grow.
+
+---
+
+### Original problem statement (historical)
 
 - **Files**: `server/src/db/schema.ts` (all 13 FK columns)
 - **Problem**: All FKs use `ON DELETE NO ACTION`. `ClientService.deleteClient`, `EmployeeService.deleteEmployee`, `ProjectService.deleteProject` just call `db.delete()` and rely on the FK to throw. If anyone "fixes" this by switching to `CASCADE` to silence the error, a single client delete wipes their invoice history.
-- **Approach**: Per-FK intent:
+- **Approach (not executed)**: Per-FK intent:
   - **`CASCADE`** (true junction/child): `work_activity_employees.work_activity_id`, `other_charges.work_activity_id`, `plant_list.work_activity_id`, `invoice_line_items.invoice_id`.
   - **`RESTRICT`/`NO ACTION`** (preserve business entity): `work_activities.client_id`, `invoices.client_id`, `projects.client_id`, `work_activity_employees.employee_id`.
   - **`SET NULL`** (preserve historical row): `invoice_line_items.qbo_item_id`, `invoice_line_items.work_activity_id`.
   - Add a `deleted_at timestamp` column to `clients`, `employees`, `projects`, `invoices` and convert their `delete*` service methods to UPDATE-set-deleted-at. Filter every active query by `isNull(table.deletedAt)`.
-- **Verify**: Delete a client with no children → succeeds, sets `deleted_at`. Delete a client with invoices → still succeeds (soft delete). All active queries hide soft-deleted rows.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,12 +8,14 @@ A multi-agent architectural review of the codebase surfaced 32 substantial findi
 
 Finding #7 ("all authenticated users are admins") is intentionally omitted from these plans — the app is only used by ~2 people, so role-separation isn't worth doing yet.
 
+Finding #12 (FK on-delete behavior, Plan 2.5) is intentionally skipped — see `02-data-integrity.md` for rationale. Same scale reasoning: `NO ACTION` fails loudly today, and a `deleted_at`-everywhere change isn't justified at ~2 users.
+
 ## Index
 
 | # | Plan | Findings | Effort | Tier | Status |
 |---|---|---|---|---|---|
 | 1 | [Security Hardening](./01-security-hardening.md) | #1, #2, #3, #4, #5, #6 | 2–3 days | 🚨 Urgent | 🟡 In review ([#54](https://github.com/mynock/blossom-and-bough-assistant/pull/54)) |
-| 2 | [Data Integrity & Schema](./02-data-integrity.md) | #8, #9, #10, #11, #12 | 1.5 weeks | 🚨 Urgent | ⚪ Not started |
+| 2 | [Data Integrity & Schema](./02-data-integrity.md) | #8, #9, #10, #11, ~~#12~~ | 1.5 weeks | 🚨 Urgent | 🟢 2.1–2.4 merged · 2.5 🚫 won't do |
 | 3 | [Background Job Reliability](./03-background-jobs.md) | #13 | 1 week | 📉 Medium | ⚪ Not started |
 | 4 | [Query Performance](./04-query-performance.md) | #14, #15, #19 | 1 week | 📉 Urgent-soon | ⚪ Not started |
 | 5 | [Integration Efficiency](./05-integration-efficiency.md) | #16, #17, #18 | 4–5 days | 📉 Medium | ⚪ Not started |
@@ -32,7 +34,7 @@ Finding #7 ("all authenticated users are admins") is intentionally omitted from 
 Plan 1 (Security) ──── independent ──── ship anytime
 Plan 2 (Data Integrity)
   ├─ 2.1 (transactions) ── independent ── ship first
-  └─ 2.2-2.5 ─────── independent migrations
+  └─ 2.2-2.4 ─────── independent migrations (2.5 won't do)
 Plan 3 (Background Jobs) ── independent ── ship anytime
 Plan 4 (Query Perf)
   ├─ 4.1 (indexes) ── ship first
@@ -56,7 +58,7 @@ Plan 11 (Hygiene)
 
 1. **Week 1 — stop the bleeding**: Plan 1 (all), Plan 2.1 (transactions), Plan 11 (hygiene)
 2. **Week 2 — make it fast**: Plan 4 (all), Plan 5.1 (Anthropic caching)
-3. **Week 3 — make it correct long-term**: Plan 2.2–2.5 (types + constraints), Plan 5.2 (Notion sync), Plan 5.3 (QBO)
+3. **Week 3 — make it correct long-term**: Plan 2.2–2.4 (types + constraints), Plan 5.2 (Notion sync), Plan 5.3 (QBO)
 4. **Week 4 — frontend foundation**: Plan 8.2 → Plan 8.1, Plan 6
 5. **Weeks 5–6 — backend architecture**: Plan 7.5 → Plan 7.1, then 7.2, 7.3, 7.4, 7.6, 7.7
 6. **Weeks 7–8 — testing foundation**: Plan 10


### PR DESCRIPTION
## Summary

- Marks Plan 2.5 (Finding #12 — FK on-delete behavior + soft delete) as 🚫 won't do.
- Doc-only change: no code, schema, or migration touched.
- Updates `docs/plans/README.md` (status row, dependency graph, execution order, Context note alongside the existing Finding #7 note) and replaces the body of `docs/plans/02-data-integrity.md#2.5` with a rationale block (historical problem statement preserved).

## Rationale

1. **Scale**: ~2 users — destructive-delete scenarios are vanishingly rare.
2. **Current behavior is safe**: `ON DELETE NO ACTION` fails loudly, which is the desired outcome. The original concern ("someone switches to `CASCADE` to silence the error") is a code-review concern, not architectural.
3. **Cross-cutting cost**: `deleted_at` on clients/employees/projects/invoices would touch every active query against those tables — permanent maintenance tax for marginal benefit at this scale.
4. **Revisit trigger**: if multi-user/role separation lands (Finding #7), reopen.

## Test plan

- [x] No code changes — no tests, type-checks, or migrations to run.
- [x] Grep for remaining `2.5` references in `docs/` — all intentional (won't-do annotations + unrelated `form-data <2.5.4` version string in plan 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)