### PR TITLE
Plan 10 / B4 — Run the full backend Jest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,16 +92,16 @@ jobs:
         npm run db:generate
         npm run db:push
         
-    - name: Run billable hours regression tests
+    - name: Run all backend tests (with coverage)
+      # Plan 10 / B4: full Jest suite now that route smoke tests and Notion
+      # pure-function tests are in place. The dedicated Billable Hours
+      # Regression workflow (.github/workflows/billable-hours-tests.yml) still
+      # runs independently on paths that affect billable-hours logic and
+      # produces per-suite JUnit output; this step is the broader gate.
       run: |
         cd server
-        npm run test:billable-hours
-        
-    - name: Generate test coverage
-      run: |
-        cd server
-        npm run test:coverage -- src/__tests__/billableHours
-        
+        npm run test:coverage
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
## Summary

Flips CI's backend job from the billable-hours subset to the full Jest suite. One step swap; no infra changes.

## What changed

`.github/workflows/ci.yml` — combined the previous two test steps:

  - ~~`npm run test:billable-hours`~~
  - ~~`npm run test:coverage -- src/__tests__/billableHours`~~

into a single:

  - `npm run test:coverage` (full suite + coverage)

## Why now

Plan 10 / B1 (route smoke tests) and Plan 10 / B2 (NotionSyncService pure-function tests) are now in the suite — they shouldn't sit untested in CI.

## Notes for reviewer

- **Postgres service already provisioned**: the existing `services: postgres` block (lines 51-64) was already in place for the billable-hours job, so no CI infra changes — just a step swap.
- **`billable-hours-tests.yml` workflow left alone**: it's a separate, path-filtered regression workflow that emits per-suite JUnit output; complementary to this broader gate.
- **No coverage threshold gate added**: deferred until real numbers stabilize, per the plan.
- **This PR's CI run** exercises only the tests in `main` today; once B1 (#62) and B2 (#61) merge, the route + pure-function suites also run on every backend PR.

## Test plan

- [x] `.github/workflows/ci.yml` diff is a single-step swap; the existing Postgres service block is unchanged.
- [ ] Reviewer: confirm CI passes on this PR; merge order should be **B2 → B1 → B4** (or any order — B4 is independent of B1/B2 at the branch level; the suite just grows once they merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)