### PR TITLE
Add EULA and Privacy Policy for QBO production keys

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,15 @@
+title: Blossom and Bough
+description: Legal documents for the Blossom and Bough business management app.
+
+# Only the legal/ folder should be published. Everything else under docs/
+# is internal planning material and must stay out of GitHub Pages output.
+exclude:
+  - README.md
+  - billable-hours-calculation.md
+  - reporting-needs.md
+  - plans
+  - design
+  - features
+  - setup
+
+theme: jekyll-theme-minimal

--- a/docs/legal/eula.md
+++ b/docs/legal/eula.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: End-User License Agreement
+---
+
+# End-User License Agreement
+
+**Effective date:** May 25, 2026
+
+This End-User License Agreement ("Agreement") governs your use of the Blossom and Bough business management application (the "App"), operated by Blossom and Bough ("we", "us", "our"). By accessing or using the App you agree to this Agreement. If you do not agree, do not use the App.
+
+## 1. License
+
+We grant you a limited, non-exclusive, non-transferable, revocable license to access and use the App solely for managing your landscaping business operations, including scheduling, client management, work activity tracking, and integration with third-party services you authorize (such as QuickBooks Online, Google Workspace, and Notion).
+
+## 2. Acceptable use
+
+You agree not to:
+
+- Reverse engineer, decompile, or attempt to extract the source code of the App, except to the extent this restriction is prohibited by law.
+- Use the App to violate any applicable law or the terms of any integrated third-party service.
+- Attempt to gain unauthorized access to the App, its underlying systems, or other users' data.
+
+## 3. Third-party services
+
+The App integrates with third-party services including Intuit QuickBooks Online, Google (Calendar, Sheets, Maps, OAuth), Notion, and Anthropic. Your use of those services is governed by their own terms. We are not responsible for the availability, accuracy, or behavior of third-party services.
+
+## 4. No warranty
+
+THE APP IS PROVIDED "AS IS" AND "AS AVAILABLE", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE APP WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE.
+
+## 5. Limitation of liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL WE BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE APP.
+
+## 6. Termination
+
+We may suspend or terminate your access to the App at any time, with or without notice, for any reason, including breach of this Agreement. You may stop using the App at any time. Provisions that by their nature should survive termination (including disclaimers and limitations of liability) will survive.
+
+## 7. Changes to this Agreement
+
+We may update this Agreement from time to time. Continued use of the App after a change takes effect constitutes acceptance of the updated Agreement.
+
+## 8. Contact
+
+Questions about this Agreement should be sent to **mynock51@gmail.com**.

--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Legal
+---
+
+# Blossom and Bough — Legal
+
+- [End-User License Agreement](./eula)
+- [Privacy Policy](./privacy)

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: Privacy Policy
+---
+
+# Privacy Policy
+
+**Effective date:** May 25, 2026
+
+This Privacy Policy describes how Blossom and Bough ("we", "us", "our") collects, uses, and protects information in connection with the Blossom and Bough business management application (the "App").
+
+## 1. Who this applies to
+
+The App is an internal business management tool used by Blossom and Bough to operate its landscaping business. Authorized users are limited to the business owner and staff via an email allowlist. The App is not offered to the general public.
+
+## 2. Information we collect
+
+We collect and store the following categories of information in our own database to operate the App:
+
+- **Business records you enter:** client profiles, employee profiles, work activities, projects, scheduling notes, and billing data.
+- **Authentication data:** the Google account email of authorized users (via Google OAuth).
+- **Data from connected services that you authorize:**
+  - **Intuit QuickBooks Online** — customers, items, invoices, line items, and related accounting metadata necessary to create and reconcile invoices for work performed.
+  - **Google Workspace** — calendar events, spreadsheet rows you import, and travel-time results from Google Maps.
+  - **Notion** — pages and content you sync to or from Notion.
+  - **Anthropic** — message content sent to the Claude API for AI-assisted scheduling and invoice drafting.
+
+## 3. How we use information
+
+We use the information we collect only to operate the App for the business: scheduling work, tracking time and billing, drafting and syncing invoices to QuickBooks Online, syncing notes to and from Notion, and producing internal reports.
+
+## 4. How we share information
+
+We do not sell information. We share information only with the third-party services you have authorized, and only as necessary to deliver the features you use:
+
+- **Intuit QuickBooks Online** — to read accounting data you authorize and to create or update invoices on your behalf.
+- **Google** — for authentication (OAuth), calendar sync, and Maps/Sheets features.
+- **Notion** — to read and write pages on your behalf.
+- **Anthropic** — when AI features are used, the relevant prompt content is sent to the Claude API.
+- **Hosting providers** — used to host the App and its database.
+
+We may also disclose information if required by law or to protect the rights, property, or safety of Blossom and Bough or others.
+
+## 5. QuickBooks Online data
+
+When you connect the App to QuickBooks Online, we store the OAuth tokens necessary to call the QuickBooks Online API and a local copy of the accounting records you choose to sync (customers, items, invoices, line items) so the App can present and reconcile that data. We use this data solely to provide the App's invoicing and reporting features. We do not use QuickBooks data for advertising and do not share it with third parties other than as described in this policy.
+
+## 6. Data retention
+
+We retain information for as long as the App is in use by the business. You may request deletion of specific records, your OAuth connection, or your entire dataset by contacting us at the address below. Disconnecting an integration in the App's settings will remove the stored OAuth tokens for that integration.
+
+## 7. Security
+
+We use commercially reasonable measures to protect information, including encrypted transport (HTTPS), authentication-gated access, and access controls on the underlying database. No system is completely secure; we cannot guarantee absolute security.
+
+## 8. Children
+
+The App is not directed to children under 13 and we do not knowingly collect personal information from children.
+
+## 9. Changes to this Policy
+
+We may update this Policy from time to time. The "Effective date" above will reflect the most recent revision.
+
+## 10. Contact
+
+Questions about this Policy or requests to access or delete your information should be sent to **mynock51@gmail.com**.


### PR DESCRIPTION
## Summary

Intuit's production-keys checklist requires public URLs for an end-user license agreement and a privacy policy before releasing production credentials for the QuickBooks Online integration. This PR adds both as Jekyll-rendered pages under \`docs/legal/\`, published via GitHub Pages, so the source lives in this repo without exposing public routes in the React app.

- \`docs/legal/eula.md\` — boilerplate EULA for an internal-use business app.
- \`docs/legal/privacy.md\` — privacy policy with a dedicated QuickBooks Online section (Intuit's reviewer looks for this specifically).
- \`docs/legal/index.md\` — landing page linking to both.
- \`docs/_config.yml\` — Jekyll config that **excludes** all other \`docs/\` subfolders (\`plans\`, \`design\`, \`features\`, \`setup\`) and stray markdown files so only \`legal/\` is published.

Both documents use \`mynock51@gmail.com\` as the contact and an effective date of 2026-05-25.

## After merge

1. Settings → Pages → Source: **Deploy from a branch**, Branch: **main / /docs**. Save.
2. Wait ~1 minute for the first Pages build to complete.
3. Verify the URLs resolve:
   - https://mynock.github.io/blossom-and-bough-assistant/legal/eula
   - https://mynock.github.io/blossom-and-bough-assistant/legal/privacy
4. **Verify that internal docs are NOT published.** Sanity-check that paths like \`/plans/07-backend-architecture\` return 404.
5. Paste the two URLs into the Intuit Developer dashboard's production-keys checklist.

## Test plan

- [ ] Pages build succeeds in the Actions tab after merge
- [ ] \`/legal/eula\` and \`/legal/privacy\` render
- [ ] \`/plans/\`, \`/design/\`, \`/features/\`, \`/setup/\` return 404
- [ ] Intuit accepts the URLs in the production-keys flow

## Caveats

The text is reasonable boilerplate for an internal-use app that connects to QBO + Google + Notion + Anthropic. It is not legal advice. If the app is ever offered to outside customers, the documents should be reviewed by a lawyer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)