### PR TITLE
QBO OAuth hardening for Intuit production review (PR A)

### DIFF
--- a/env.example
+++ b/env.example
@@ -55,6 +55,8 @@ QBO_CLIENT_ID=your_qbo_client_id_here
 QBO_CLIENT_SECRET=your_qbo_client_secret_here
 QBO_ENVIRONMENT=sandbox
 QBO_REDIRECT_URI=http://localhost:3001/api/qbo/callback
-QBO_ACCESS_TOKEN=your_qbo_access_token_here
-QBO_REFRESH_TOKEN=your_qbo_refresh_token_here
-QBO_REALM_ID=your_qbo_company_realm_id_here 
+# 32-byte AES key (hex). Generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# OAuth tokens are encrypted at rest with this key in the qbo_credentials table.
+# Rotating the key invalidates stored tokens — the user will need to re-authorize.
+QBO_TOKEN_ENCRYPTION_KEY=replace_with_64_hex_chars 

--- a/server/drizzle/0013_legal_warhawk.sql
+++ b/server/drizzle/0013_legal_warhawk.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "qbo_credentials" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"realm_id" text NOT NULL,
+	"access_token_encrypted" text NOT NULL,
+	"refresh_token_encrypted" text NOT NULL,
+	"access_token_expires_at" timestamp NOT NULL,
+	"refresh_token_expires_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);

--- a/server/drizzle/meta/0013_snapshot.json
+++ b/server/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1432 @@
+{
+  "id": "856b3653-75ce-45b7-8a03-96a2ac7aa112",
+  "prevId": "59645bb1-eac6-4098-a9d8-2c33b595126e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.client_notes": {
+      "name": "client_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "client_notes_client_id_clients_id_fk": {
+          "name": "client_notes_client_id_clients_id_fk",
+          "tableFrom": "client_notes",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo_zone": {
+          "name": "geo_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_recurring_maintenance": {
+          "name": "is_recurring_maintenance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maintenance_interval_weeks": {
+          "name": "maintenance_interval_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_hours_per_visit": {
+          "name": "maintenance_hours_per_visit",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_rate": {
+          "name": "maintenance_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_date": {
+          "name": "last_maintenance_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_maintenance_target": {
+          "name": "next_maintenance_target",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_level": {
+          "name": "priority_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_flexibility": {
+          "name": "schedule_flexibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_days": {
+          "name": "preferred_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_time": {
+          "name": "preferred_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_notes": {
+          "name": "special_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_client_id_unique": {
+          "name": "clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regular_workdays": {
+          "name": "regular_workdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_address": {
+          "name": "home_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_hours_per_day": {
+          "name": "min_hours_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_hours_per_day": {
+          "name": "max_hours_per_day",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_level": {
+          "name": "capability_level",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employees_employee_id_unique": {
+          "name": "employees_employee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "employee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_charge_id": {
+          "name": "other_charge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_item_id": {
+          "name": "qbo_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_line_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_work_activity_id_work_activities_id_fk": {
+          "name": "invoice_line_items_work_activity_id_work_activities_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_other_charge_id_other_charges_id_fk": {
+          "name": "invoice_line_items_other_charge_id_other_charges_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "other_charges",
+          "columnsFrom": [
+            "other_charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk": {
+          "name": "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "qbo_items",
+          "columnsFrom": [
+            "qbo_item_id"
+          ],
+          "columnsTo": [
+            "qbo_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_invoice_id": {
+          "name": "qbo_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qbo_customer_id": {
+          "name": "qbo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_sync_at": {
+          "name": "qbo_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_qbo_invoice_id_unique": {
+          "name": "invoices_qbo_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_invoice_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_active_idx": {
+          "name": "notifications_active_idx",
+          "columns": [
+            {
+              "expression": "dismissed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.other_charges": {
+      "name": "other_charges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_type": {
+          "name": "charge_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_rate": {
+          "name": "unit_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "other_charges_work_activity_id_work_activities_id_fk": {
+          "name": "other_charges_work_activity_id_work_activities_id_fk",
+          "tableFrom": "other_charges",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plant_list": {
+      "name": "plant_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plant_list_work_activity_id_work_activities_id_fk": {
+          "name": "plant_list_work_activity_id_work_activities_id_fk",
+          "tableFrom": "plant_list",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_credentials": {
+      "name": "qbo_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_items": {
+      "name": "qbo_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_id": {
+          "name": "qbo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "income_account_ref": {
+          "name": "income_account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "qbo_items_qbo_id_unique": {
+          "name": "qbo_items_qbo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activities": {
+      "name": "work_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_type": {
+          "name": "work_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable_hours": {
+          "name": "billable_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_time_minutes": {
+          "name": "travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_travel_time_minutes": {
+          "name": "adjusted_travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "break_time_minutes": {
+          "name": "break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_break_time_minutes": {
+          "name": "adjusted_break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_billable_time_minutes": {
+          "name": "non_billable_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasks": {
+          "name": "tasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_page_id": {
+          "name": "notion_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notion_sync_at": {
+          "name": "last_notion_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'web_app'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_activities_project_id_projects_id_fk": {
+          "name": "work_activities_project_id_projects_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activities_client_id_clients_id_fk": {
+          "name": "work_activities_client_id_clients_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "work_activities_notion_page_id_unique": {
+          "name": "work_activities_notion_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notion_page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activity_employees": {
+      "name": "work_activity_employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wae_wa_emp_uidx": {
+          "name": "wae_wa_emp_uidx",
+          "columns": [
+            {
+              "expression": "work_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_activity_employees_work_activity_id_work_activities_id_fk": {
+          "name": "work_activity_employees_work_activity_id_work_activities_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activity_employees_employee_id_employees_id_fk": {
+          "name": "work_activity_employees_employee_id_employees_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779676434017,
       "tag": "0012_normal_reaper",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779747023875,
+      "tag": "0013_legal_warhawk",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/encryption.test.ts
+++ b/server/src/__tests__/encryption.test.ts
@@ -1,0 +1,75 @@
+import { encryptToken, decryptToken, generateEncryptionKey } from '../utils/encryption';
+
+describe('encryption', () => {
+  const validKey = generateEncryptionKey();
+  const otherKey = generateEncryptionKey();
+
+  beforeEach(() => {
+    process.env.QBO_TOKEN_ENCRYPTION_KEY = validKey;
+  });
+
+  afterEach(() => {
+    delete process.env.QBO_TOKEN_ENCRYPTION_KEY;
+  });
+
+  it('round-trips a token', () => {
+    const plaintext = 'qbo-access-token-abc123';
+    const encrypted = encryptToken(plaintext);
+    expect(decryptToken(encrypted)).toBe(plaintext);
+  });
+
+  it('produces a different ciphertext on each call (random IV)', () => {
+    const plaintext = 'qbo-access-token-abc123';
+    const a = encryptToken(plaintext);
+    const b = encryptToken(plaintext);
+    expect(a).not.toBe(b);
+  });
+
+  it('produces output in the documented v1 format', () => {
+    const encrypted = encryptToken('hello');
+    const parts = encrypted.split(':');
+    expect(parts).toHaveLength(4);
+    expect(parts[0]).toBe('v1');
+  });
+
+  it('fails to decrypt with a different key', () => {
+    const encrypted = encryptToken('secret');
+    process.env.QBO_TOKEN_ENCRYPTION_KEY = otherKey;
+    expect(() => decryptToken(encrypted)).toThrow();
+  });
+
+  it('fails to decrypt tampered ciphertext (GCM auth tag check)', () => {
+    const encrypted = encryptToken('secret');
+    const parts = encrypted.split(':');
+    const tamperedCiphertext = Buffer.from(parts[3], 'base64');
+    tamperedCiphertext[0] ^= 0xff;
+    parts[3] = tamperedCiphertext.toString('base64');
+    expect(() => decryptToken(parts.join(':'))).toThrow();
+  });
+
+  it('rejects unknown format versions', () => {
+    const encrypted = encryptToken('secret');
+    const parts = encrypted.split(':');
+    parts[0] = 'v2';
+    expect(() => decryptToken(parts.join(':'))).toThrow(/Invalid encrypted token format/);
+  });
+
+  it('rejects truncated input', () => {
+    expect(() => decryptToken('v1:abc:def')).toThrow(/Invalid encrypted token format/);
+  });
+
+  it('throws a helpful error when key is missing', () => {
+    delete process.env.QBO_TOKEN_ENCRYPTION_KEY;
+    expect(() => encryptToken('x')).toThrow(/QBO_TOKEN_ENCRYPTION_KEY/);
+  });
+
+  it('rejects a key that is the wrong length', () => {
+    process.env.QBO_TOKEN_ENCRYPTION_KEY = 'abcd';
+    expect(() => encryptToken('x')).toThrow(/32 bytes/);
+  });
+
+  it('handles unicode and long values', () => {
+    const plaintext = '🌱'.repeat(1000) + '中文 émojis';
+    expect(decryptToken(encryptToken(plaintext))).toBe(plaintext);
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -144,6 +144,19 @@ export const clientNotes = pgTable('client_notes', {
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
+// QuickBooks Online credentials (singleton — one row enforced by id default).
+// Tokens are encrypted at rest with AES-256-GCM; see utils/encryption.ts.
+export const qboCredentials = pgTable('qbo_credentials', {
+  id: integer('id').primaryKey().default(1),
+  realmId: text('realm_id').notNull(),
+  accessTokenEncrypted: text('access_token_encrypted').notNull(),
+  refreshTokenEncrypted: text('refresh_token_encrypted').notNull(),
+  accessTokenExpiresAt: timestamp('access_token_expires_at').notNull(),
+  refreshTokenExpiresAt: timestamp('refresh_token_expires_at'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
 // QuickBooks Online Items table
 export const qboItems = pgTable('qbo_items', {
   id: serial('id').primaryKey(),

--- a/server/src/middleware/noStore.ts
+++ b/server/src/middleware/noStore.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Forbid caching of responses that handle authentication or third-party
+ * credentials. Intuit's QBO app security review requires `no-cache, no-store`
+ * (not `private`) on any SSL page that returns sensitive data.
+ */
+export function noStore(_req: Request, res: Response, next: NextFunction): void {
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+  next();
+}

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -1,93 +1,70 @@
 import { Router } from 'express';
+import { randomBytes } from 'crypto';
 import { services } from '../services/container';
 import { requireAuth } from '../middleware/auth';
 import { invoices, invoiceLineItems, workActivities } from '../db';
 import { eq, and } from 'drizzle-orm';
 
+// Augment Express session with our OAuth state nonce.
+declare module 'express-session' {
+  interface SessionData {
+    qboOauthState?: string;
+  }
+}
+
 const router = Router();
 const qbService = services.quickBooksService;
 const invoiceService = services.invoiceService;
 
+// Frontend route the OAuth popup lands on after the callback. The React page
+// detects ?qbo=connected / ?qbo=error and posts a message to the opener.
+const POPUP_LANDING_PATH = '/quickbooks';
+
+function popupLandingUrl(req: any, params: Record<string, string>): string {
+  const base = `${req.protocol}://${req.get('host')}${POPUP_LANDING_PATH}`;
+  const query = new URLSearchParams(params).toString();
+  return `${base}?${query}`;
+}
+
 /**
- * Handle OAuth callback (must be public, not require auth)
+ * OAuth callback (public — Intuit redirects the browser here after the user
+ * authorizes the app). Validates the state nonce against the session, exchanges
+ * the code for tokens, and 302-redirects to the React app. We must NOT return
+ * HTML here: Intuit forbids HTML responses on endpoints that receive auth
+ * tokens in URL params because subsequent requests would leak the code in the
+ * Referer header.
  */
 router.get('/callback', async (req, res) => {
+  const state = typeof req.query.state === 'string' ? req.query.state : '';
+  const expectedState = req.session?.qboOauthState;
+  // Consume the nonce regardless of outcome so it cannot be replayed.
+  if (req.session) delete req.session.qboOauthState;
+
+  if (!expectedState || !state || state !== expectedState) {
+    return res.redirect(302, popupLandingUrl(req, { qbo: 'error', reason: 'invalid_state' }));
+  }
+
   try {
-    const callbackUrl = req.url;
-    const tokens = await qbService.handleOAuthCallback(callbackUrl);
-    
-    // Store tokens in environment variables for this session
-    // In production, you might want to store these in a database or secure vault
-    process.env.QBO_ACCESS_TOKEN = tokens.accessToken;
-    process.env.QBO_REFRESH_TOKEN = tokens.refreshToken;
-    process.env.QBO_REALM_ID = tokens.realmId;
-    
-    // Reinitialize the QuickBooks service with new tokens
-    await qbService.reinitialize();
-    
-    // Return HTML page that posts success message to parent window
-    res.send(`
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>QuickBooks Authentication</title>
-        </head>
-        <body>
-          <h2>Authentication Successful!</h2>
-          <p>You can close this window now.</p>
-          <script>
-            if (window.opener) {
-              window.opener.postMessage({
-                type: 'QB_AUTH_SUCCESS',
-                message: 'Authentication successful and tokens stored'
-              }, window.location.origin);
-            }
-            setTimeout(() => {
-              window.close();
-            }, 2000);
-          </script>
-        </body>
-      </html>
-    `);
+    await qbService.handleOAuthCallback(req.url);
+    return res.redirect(302, popupLandingUrl(req, { qbo: 'connected' }));
   } catch (error) {
-    console.error('OAuth callback error:', error);
-    
-    // Return HTML page that posts error message to parent window
-    res.send(`
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>QuickBooks Authentication Error</title>
-        </head>
-        <body>
-          <h2>Authentication Failed</h2>
-          <p>There was an error connecting to QuickBooks. Please try again.</p>
-          <script>
-            if (window.opener) {
-              window.opener.postMessage({
-                type: 'QB_AUTH_ERROR',
-                error: 'Authentication failed'
-              }, window.location.origin);
-            }
-            setTimeout(() => {
-              window.close();
-            }, 2000);
-          </script>
-        </body>
-      </html>
-    `);
+    console.error('OAuth callback error:', error instanceof Error ? error.message : error);
+    return res.redirect(302, popupLandingUrl(req, { qbo: 'error', reason: 'token_exchange_failed' }));
   }
 });
 
-// Apply authentication middleware to all other routes
+// Authentication required for all other routes
 router.use(requireAuth);
 
 /**
- * Get OAuth authorization URL
+ * Generate an OAuth authorization URL with a per-request state nonce stored
+ * in the session. The callback verifies the returned state to prevent CSRF.
  */
 router.get('/auth/url', async (req, res) => {
   try {
-    const authUrl = qbService.getAuthUrl();
+    const state = randomBytes(32).toString('hex');
+    req.session.qboOauthState = state;
+    const authUrl = qbService.getAuthUrl(state);
     res.json({ authUrl });
   } catch (error) {
     console.error('Error getting auth URL:', error);
@@ -96,19 +73,16 @@ router.get('/auth/url', async (req, res) => {
 });
 
 /**
- * Check if access token is valid
+ * Report whether the app has valid, non-expired QBO credentials stored.
  */
 router.get('/auth/status', async (req, res) => {
   try {
-    const isValid = qbService.isAccessTokenValid();
-    
-    // Check if credentials are configured
-    const credentials = process.env.QBO_CLIENT_ID && process.env.QBO_CLIENT_SECRET;
-    
-    res.json({ 
+    const isValid = await qbService.isAccessTokenValid();
+    const credentialsConfigured = !!(process.env.QBO_CLIENT_ID && process.env.QBO_CLIENT_SECRET);
+    res.json({
       isValid,
-      credentialsConfigured: !!credentials,
-      error: !credentials ? 'QuickBooks credentials not configured' : null
+      credentialsConfigured,
+      error: credentialsConfigured ? null : 'QuickBooks credentials not configured',
     });
   } catch (error) {
     console.error('Error checking token status:', error);
@@ -117,7 +91,8 @@ router.get('/auth/status', async (req, res) => {
 });
 
 /**
- * Refresh access token
+ * Manually trigger a token refresh. Normally not needed — QuickBooksService
+ * auto-refreshes before each API call — but useful as an admin override.
  */
 router.post('/auth/refresh', async (req, res) => {
   try {
@@ -130,8 +105,18 @@ router.post('/auth/refresh', async (req, res) => {
 });
 
 /**
- * Sync QBO Items to local database
+ * Disconnect QuickBooks — revoke tokens at Intuit and remove from local DB.
  */
+router.post('/auth/disconnect', async (req, res) => {
+  try {
+    await qbService.disconnect();
+    res.json({ message: 'Disconnected from QuickBooks' });
+  } catch (error) {
+    console.error('Error disconnecting QuickBooks:', error);
+    res.status(500).json({ error: 'Failed to disconnect' });
+  }
+});
+
 router.post('/items/sync', async (req, res) => {
   try {
     await invoiceService.syncQBOItems();
@@ -142,9 +127,6 @@ router.post('/items/sync', async (req, res) => {
   }
 });
 
-/**
- * Sync QBO Customers to local database
- */
 router.post('/customers/sync', async (req, res) => {
   try {
     await invoiceService.syncQBOCustomers();
@@ -155,9 +137,6 @@ router.post('/customers/sync', async (req, res) => {
   }
 });
 
-/**
- * Get all QBO Items
- */
 router.get('/items', async (req, res) => {
   try {
     const items = await invoiceService.getQBOItems();
@@ -168,9 +147,6 @@ router.get('/items', async (req, res) => {
   }
 });
 
-/**
- * Create invoice from previously-previewed (and possibly edited) line items.
- */
 router.post('/invoices', async (req, res) => {
   try {
     const { clientId, lineItems, workActivityIds, dueDate, memo } = req.body;
@@ -190,57 +166,47 @@ router.post('/invoices', async (req, res) => {
         ? workActivityIds.filter((id: unknown): id is number => typeof id === 'number')
         : undefined,
       dueDate,
-      memo
+      memo,
     });
 
     res.json({
       success: true,
       result,
-      message: 'Invoice created successfully'
+      message: 'Invoice created successfully',
     });
   } catch (error) {
     console.error('Error creating invoice:', error);
     res.status(500).json({
       error: 'Failed to create invoice',
-      details: error instanceof Error ? error.message : 'Unknown error'
+      details: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 });
 
-/**
- * Get invoices for a client
- */
 router.get('/invoices/client/:clientId', async (req, res) => {
   try {
     const clientId = parseInt(req.params.clientId);
     if (isNaN(clientId)) {
       return res.status(400).json({ error: 'Invalid client ID' });
     }
-
-    const invoices = await invoiceService.getInvoicesForClient(clientId);
-    res.json(invoices);
+    const invoiceList = await invoiceService.getInvoicesForClient(clientId);
+    res.json(invoiceList);
   } catch (error) {
     console.error('Error fetching client invoices:', error);
     res.status(500).json({ error: 'Failed to fetch invoices' });
   }
 });
 
-/**
- * Get all invoices
- */
 router.get('/invoices', async (req, res) => {
   try {
-    const invoices = await invoiceService.getAllInvoices();
-    res.json(invoices);
+    const invoiceList = await invoiceService.getAllInvoices();
+    res.json(invoiceList);
   } catch (error) {
     console.error('Error fetching invoices:', error);
     res.status(500).json({ error: 'Failed to fetch invoices' });
   }
 });
 
-/**
- * Get invoice details with line items
- */
 router.get('/invoices/:invoiceId', async (req, res) => {
   try {
     const invoiceId = parseInt(req.params.invoiceId);
@@ -248,7 +214,6 @@ router.get('/invoices/:invoiceId', async (req, res) => {
       return res.status(400).json({ error: 'Invalid invoice ID' });
     }
 
-    // Get invoice details
     const invoice = await invoiceService.db
       .select()
       .from(invoices)
@@ -259,32 +224,24 @@ router.get('/invoices/:invoiceId', async (req, res) => {
       return res.status(404).json({ error: 'Invoice not found' });
     }
 
-    // Get line items
     const lineItems = await invoiceService.db
       .select()
       .from(invoiceLineItems)
       .where(eq(invoiceLineItems.invoiceId, invoiceId));
 
-    res.json({
-      invoice: invoice[0],
-      lineItems: lineItems
-    });
+    res.json({ invoice: invoice[0], lineItems });
   } catch (error) {
     console.error('Error fetching invoice details:', error);
     res.status(500).json({ error: 'Failed to fetch invoice details' });
   }
 });
 
-/**
- * Sync invoice status from QuickBooks
- */
 router.post('/invoices/:invoiceId/sync', async (req, res) => {
   try {
     const invoiceId = parseInt(req.params.invoiceId);
     if (isNaN(invoiceId)) {
       return res.status(400).json({ error: 'Invalid invoice ID' });
     }
-
     await invoiceService.syncInvoiceStatus(invoiceId);
     res.json({ message: 'Invoice status synced successfully' });
   } catch (error) {
@@ -293,25 +250,17 @@ router.post('/invoices/:invoiceId/sync', async (req, res) => {
   }
 });
 
-/**
- * Get work activities that can be invoiced for a client
- */
 router.get('/clients/:clientId/invoiceable-activities', async (req, res) => {
   try {
     const clientId = parseInt(req.params.clientId);
     if (isNaN(clientId)) {
       return res.status(400).json({ error: 'Invalid client ID' });
     }
-
     const activities = await invoiceService.db
       .select()
       .from(workActivities)
-      .where(and(
-        eq(workActivities.clientId, clientId),
-        eq(workActivities.status, 'completed')
-      ))
+      .where(and(eq(workActivities.clientId, clientId), eq(workActivities.status, 'completed')))
       .orderBy(workActivities.date);
-
     res.json(activities);
   } catch (error) {
     console.error('Error fetching invoiceable activities:', error);
@@ -319,89 +268,69 @@ router.get('/clients/:clientId/invoiceable-activities', async (req, res) => {
   }
 });
 
-/**
- * Preview the exact invoice line items that would be sent to QBO.
- * Uses the same builder and AI enhancement as creation so the preview cannot
- * diverge from what gets created.
- */
 router.post('/invoices/preview', async (req, res) => {
   try {
     const { clientId, workActivityIds, includeOtherCharges, useAIGeneration } = req.body;
-
     if (!clientId || !workActivityIds || !Array.isArray(workActivityIds) || workActivityIds.length === 0) {
-      return res.status(400).json({
-        error: 'clientId and workActivityIds (array) are required'
-      });
+      return res.status(400).json({ error: 'clientId and workActivityIds (array) are required' });
     }
-
     const result = await invoiceService.previewInvoice({
       clientId,
       workActivityIds,
       includeOtherCharges: includeOtherCharges !== false,
-      useAIGeneration: useAIGeneration === true
+      useAIGeneration: useAIGeneration === true,
     });
-
     res.json(result);
   } catch (error) {
     console.error('Error generating invoice preview:', error);
     res.status(500).json({
       error: 'Failed to generate invoice preview',
-      details: error instanceof Error ? error.message : 'Unknown error'
+      details: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 });
 
 /**
- * Seed QuickBooks sandbox with sample data
+ * Seed sandbox QuickBooks data. Dev-only: refuses to run in production.
  */
 router.post('/seed', async (req, res) => {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(403).json({ error: 'Seeding is disabled in production' });
+  }
   try {
     const { default: QBOSeedDataGenerator } = await import('../scripts/seedQBOData');
     const seedGenerator = new QBOSeedDataGenerator();
-    
     const startTime = Date.now();
     await seedGenerator.generateAllSeedData();
     const duration = Date.now() - startTime;
-    
-    res.json({ 
+    res.json({
       success: true,
       message: 'QuickBooks sandbox data seeded successfully. Created customers, service items, and sample invoices.',
-      duration 
+      duration,
     });
   } catch (error) {
     console.error('Error seeding QuickBooks data:', error);
     const errorMessage = error instanceof Error ? error.message : 'Failed to seed QuickBooks data';
-    res.status(500).json({ 
-      success: false,
-      error: errorMessage 
-    });
+    res.status(500).json({ success: false, error: errorMessage });
   }
 });
 
-// Delete invoice
 router.delete('/invoices/:invoiceId', async (req, res) => {
   try {
     const invoiceId = parseInt(req.params.invoiceId);
-    
     if (isNaN(invoiceId)) {
       return res.status(400).json({ error: 'Invalid invoice ID' });
     }
-    
     console.log(`Deleting invoice ID: ${invoiceId}`);
-    
     await invoiceService.deleteInvoice(invoiceId);
-    
-    res.json({ 
-      success: true, 
-      message: 'Invoice deleted successfully'
-    });
+    res.json({ success: true, message: 'Invoice deleted successfully' });
   } catch (error) {
     console.error('Error deleting invoice:', error);
-    res.status(500).json({ 
-      error: 'Failed to delete invoice', 
-      details: error instanceof Error ? error.message : 'Unknown error' 
+    res.status(500).json({
+      error: 'Failed to delete invoice',
+      details: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 });
 
-export default router; 
+export default router;

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -21,7 +21,13 @@ const invoiceService = services.invoiceService;
 const POPUP_LANDING_PATH = '/quickbooks';
 
 function popupLandingUrl(req: any, params: Record<string, string>): string {
-  const base = `${req.protocol}://${req.get('host')}${POPUP_LANDING_PATH}`;
+  // In dev the React app runs on a different port than the API (3000 vs 3001),
+  // so we cannot use req.get('host'). FRONTEND_URL is the canonical source of
+  // truth; fall back to the request host only in production where the SPA and
+  // API share an origin.
+  const frontendBase =
+    process.env.FRONTEND_URL || `${req.protocol}://${req.get('host')}`;
+  const base = `${frontendBase.replace(/\/$/, '')}${POPUP_LANDING_PATH}`;
   const query = new URLSearchParams(params).toString();
   return `${base}?${query}`;
 }
@@ -47,8 +53,16 @@ router.get('/callback', async (req, res) => {
   try {
     await qbService.handleOAuthCallback(req.url);
     return res.redirect(302, popupLandingUrl(req, { qbo: 'connected' }));
-  } catch (error) {
-    console.error('OAuth callback error:', error instanceof Error ? error.message : error);
+  } catch (error: any) {
+    // intuit-oauth wraps the failing HTTP response; surface the underlying
+    // body/status so the actual cause (bad redirect_uri, expired code,
+    // sandbox/prod mismatch, etc.) shows up in the server log.
+    console.error('OAuth token exchange failed:', {
+      message: error?.message,
+      originalMessage: error?.originalMessage,
+      intuit_tid: error?.intuit_tid,
+      authResponse: error?.authResponse?.response?.body || error?.authResponse?.body,
+    });
     return res.redirect(302, popupLandingUrl(req, { qbo: 'error', reason: 'token_exchange_failed' }));
   }
 });

--- a/server/src/scripts/seedQBOData.ts
+++ b/server/src/scripts/seedQBOData.ts
@@ -390,15 +390,8 @@ class QBOSeedDataGenerator {
     const invoiceSvc = invoiceService || this.invoiceService;
     
     try {
-      // If using provided service, make sure our instance is also initialized with tokens
-      if (qbService && !this.qbService.isAccessTokenValid()) {
-        // Reinitialize our instance to get the tokens from environment
-        this.qbService = new QuickBooksService();
-        this.invoiceService = new InvoiceService();
-      }
-      
       // Check if we're authenticated
-      if (!qbSvc.isAccessTokenValid()) {
+      if (!(await qbSvc.isAccessTokenValid())) {
         console.error('❌ QuickBooks not authenticated. Please run OAuth flow first.');
         return;
       }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -39,6 +39,7 @@ import reportsRouter from './routes/reports';
 import dataExportRouter from './routes/dataExport';
 import notificationsRouter from './routes/notifications';
 import { requireAuth } from './middleware/auth';
+import { noStore } from './middleware/noStore';
 
 // Load environment variables from root directory .env file
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
@@ -174,8 +175,10 @@ const anthropicService = services.anthropicService;
 const authService = new AuthService();
 const cronService = new CronService();
 
-// Mount authentication routes (before other routes)
-app.use('/api/auth', authRouter);
+// Mount authentication routes (before other routes).
+// noStore prevents caching of any auth / session-bearing response — per Intuit's
+// app security review and OWASP guidance for endpoints that handle credentials.
+app.use('/api/auth', noStore, authRouter);
 
 // Routes
 app.get('/api/health', (req, res) => {
@@ -201,7 +204,7 @@ app.use('/api/notion', notionRouter); // Public routes for embedded usage
 app.use('/api/notion-sync', requireAuth, createNotionSyncRouter(anthropicService)); // Notion sync routes
 app.use('/api/admin', adminRouter); // Admin routes handle their own auth
 app.use('/api/data-export', dataExportRouter); // Uses its own bearer token auth
-app.use('/api/qbo', quickbooksRouter); // QuickBooks Online routes
+app.use('/api/qbo', noStore, quickbooksRouter); // QuickBooks Online routes
 // app.use('/api/natural-language-sql', naturalLanguageSQLRouter); // DISABLED — see §1.1 above
 app.use('/api/natural-language-sql', (_req, res) =>
   res.status(503).json({ error: 'Natural language SQL endpoint is disabled pending security review.' })

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -71,15 +71,12 @@ export class InvoiceService extends DatabaseService {
   }
 
   /**
-   * Ensure QuickBooks service is initialized with latest tokens
+   * No-op shim retained for now. QuickBooksService loads tokens lazily and
+   * refreshes them automatically before each API call, so callers do not
+   * need to initialize anything up-front.
    */
   private async ensureQBServiceInitialized(): Promise<void> {
-    try {
-      await this.qbService.reinitialize();
-    } catch (error) {
-      console.error('Failed to reinitialize QuickBooks service:', error);
-      throw new Error('QuickBooks service not properly initialized. Please check your authentication.');
-    }
+    // intentionally empty
   }
 
   /**

--- a/server/src/services/QuickBooksService.ts
+++ b/server/src/services/QuickBooksService.ts
@@ -1,22 +1,25 @@
 /// <reference path="../types/quickbooks.d.ts" />
 
-// Temporary type declarations to bypass strict typing
-declare const QuickBooks: any;
-declare const OAuthClient: any;
-
 import QuickBooksLib from 'node-quickbooks';
 import OAuthClientLib from 'intuit-oauth';
 import { DatabaseService } from './DatabaseService';
-import { qboItems, invoices, invoiceLineItems } from '../db';
+import { qboItems, qboCredentials, invoices, invoiceLineItems } from '../db';
 import { eq } from 'drizzle-orm';
+import { encryptToken, decryptToken } from '../utils/encryption';
 
-export interface QBOCredentials {
-  accessToken: string;
-  refreshToken: string;
-  realmId: string;
+export interface QBOAppConfig {
   clientId: string;
   clientSecret: string;
   environment: 'sandbox' | 'production';
+  redirectUri: string;
+}
+
+export interface QBOTokens {
+  accessToken: string;
+  refreshToken: string;
+  realmId: string;
+  accessTokenExpiresAt: Date;
+  refreshTokenExpiresAt: Date | null;
 }
 
 export interface QBOItem {
@@ -25,10 +28,7 @@ export interface QBOItem {
   Description?: string;
   Type: string;
   UnitPrice?: number;
-  IncomeAccountRef?: {
-    value: string;
-    name: string;
-  };
+  IncomeAccountRef?: { value: string; name: string };
   Active: boolean;
 }
 
@@ -41,213 +41,282 @@ export interface QBOInvoice {
   Balance: number;
   EmailStatus: string;
   PrintStatus: string;
-  CustomerRef: {
-    value: string;
-    name: string;
-  };
+  CustomerRef: { value: string; name: string };
   Line: Array<{
     Id: string;
     LineNum: number;
     Amount: number;
     DetailType: string;
     SalesItemLineDetail?: {
-      ItemRef: {
-        value: string;
-        name: string;
-      };
+      ItemRef: { value: string; name: string };
       Qty: number;
       UnitPrice: number;
     };
   }>;
 }
 
+// Refresh the access token if it expires within this many seconds. Intuit
+// access tokens last 1 hour; refreshing 5 minutes early avoids racing the
+// expiry on any single in-flight request.
+const REFRESH_LEEWAY_SECONDS = 5 * 60;
+
 export class QuickBooksService extends DatabaseService {
   private qbo: any;
   private oauthClient: any;
+  private cachedExpiresAt: Date | null = null;
 
   constructor() {
     super();
-    this.initializeClients();
+    this.initializeOAuthClient();
   }
 
-  /**
-   * Reinitialize the QuickBooks clients (public method for token updates)
-   */
-  async reinitialize(): Promise<void> {
-    this.initializeClients();
-  }
-
-  private initializeClients() {
-    const credentials = this.getCredentials();
-    
-    // Initialize OAuth client
-    this.oauthClient = new OAuthClientLib({
-      clientId: credentials.clientId,
-      clientSecret: credentials.clientSecret,
-      environment: credentials.environment,
-      redirectUri: process.env.QBO_REDIRECT_URI || 'http://localhost:3001/api/qbo/callback',
-    });
-
-    // If we have stored tokens, load them into the OAuth client
-    if (credentials.accessToken && credentials.refreshToken && credentials.realmId) {
-      try {
-        this.oauthClient.setToken({
-          token_type: 'bearer',
-          access_token: credentials.accessToken,
-          refresh_token: credentials.refreshToken,
-          expires_in: 3600, // Default expiry
-          x_refresh_token_expires_in: 8726400,
-          realmId: credentials.realmId
-        });
-      } catch (error) {
-        console.warn('Failed to set existing tokens in OAuth client:', error);
-      }
-    }
-
-    // Initialize QuickBooks client if we have tokens
-    if (credentials.accessToken && credentials.realmId) {
-      this.qbo = new QuickBooksLib(
-        credentials.clientId,
-        credentials.clientSecret,
-        credentials.accessToken,
-        false, // no token secret for OAuth 2.0
-        credentials.realmId,
-        credentials.environment === 'sandbox', // use sandbox
-        false, // enable debugging
-        null, // minor version
-        '2.0', // OAuth version
-        credentials.refreshToken
-      );
-    }
-  }
-
-  private getCredentials(): QBOCredentials {
+  private getAppConfig(): QBOAppConfig {
     return {
       clientId: process.env.QBO_CLIENT_ID || '',
       clientSecret: process.env.QBO_CLIENT_SECRET || '',
-      accessToken: process.env.QBO_ACCESS_TOKEN || '',
-      refreshToken: process.env.QBO_REFRESH_TOKEN || '',
-      realmId: process.env.QBO_REALM_ID || '',
       environment: (process.env.QBO_ENVIRONMENT as 'sandbox' | 'production') || 'sandbox',
+      redirectUri: process.env.QBO_REDIRECT_URI || 'http://localhost:3001/api/qbo/callback',
+    };
+  }
+
+  private initializeOAuthClient() {
+    const config = this.getAppConfig();
+    if (!config.clientId || !config.clientSecret) {
+      // OAuth client cannot be constructed without app credentials; defer.
+      return;
+    }
+    this.oauthClient = new OAuthClientLib({
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      environment: config.environment,
+      redirectUri: config.redirectUri,
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Credential persistence (encrypted at rest in qbo_credentials table)
+  // ------------------------------------------------------------------
+
+  private async loadTokensFromDb(): Promise<QBOTokens | null> {
+    const rows = await this.db.select().from(qboCredentials).limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      accessToken: decryptToken(row.accessTokenEncrypted),
+      refreshToken: decryptToken(row.refreshTokenEncrypted),
+      realmId: row.realmId,
+      accessTokenExpiresAt: row.accessTokenExpiresAt,
+      refreshTokenExpiresAt: row.refreshTokenExpiresAt,
+    };
+  }
+
+  private async saveTokensToDb(tokens: QBOTokens): Promise<void> {
+    const row = {
+      id: 1,
+      realmId: tokens.realmId,
+      accessTokenEncrypted: encryptToken(tokens.accessToken),
+      refreshTokenEncrypted: encryptToken(tokens.refreshToken),
+      accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+      refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
+      updatedAt: new Date(),
+    };
+    await this.db
+      .insert(qboCredentials)
+      .values({ ...row, createdAt: new Date() })
+      .onConflictDoUpdate({ target: qboCredentials.id, set: row });
+    this.cachedExpiresAt = tokens.accessTokenExpiresAt;
+  }
+
+  private async clearTokensInDb(): Promise<void> {
+    await this.db.delete(qboCredentials).where(eq(qboCredentials.id, 1));
+    this.cachedExpiresAt = null;
+  }
+
+  /**
+   * Convert an Intuit token response into a QBOTokens with absolute expiries.
+   * The library returns expires_in / x_refresh_token_expires_in as seconds
+   * from now; we store absolute timestamps so we can persist them.
+   */
+  private toQBOTokens(token: any): QBOTokens {
+    const now = Date.now();
+    return {
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token,
+      realmId: token.realmId,
+      accessTokenExpiresAt: new Date(now + (token.expires_in ?? 3600) * 1000),
+      refreshTokenExpiresAt: token.x_refresh_token_expires_in
+        ? new Date(now + token.x_refresh_token_expires_in * 1000)
+        : null,
     };
   }
 
   /**
-   * Get OAuth authorization URL
+   * Push tokens into the in-memory OAuth client and rebuild the QB API client.
+   * Computes a synthetic expires_in so the library's own expiry tracking stays
+   * accurate when we restore from DB.
    */
-  getAuthUrl(): string {
-    const credentials = this.getCredentials();
-    
-    // Check if required credentials are present
-    if (!credentials.clientId || !credentials.clientSecret) {
-      throw new Error('QuickBooks credentials not configured. Please set QBO_CLIENT_ID and QBO_CLIENT_SECRET in your environment variables.');
+  private hydrateClients(tokens: QBOTokens) {
+    if (!this.oauthClient) {
+      this.initializeOAuthClient();
+      if (!this.oauthClient) {
+        throw new Error('Cannot hydrate QuickBooks client: app credentials are missing');
+      }
     }
-    
+    const config = this.getAppConfig();
+    const expiresInSec = Math.max(
+      0,
+      Math.floor((tokens.accessTokenExpiresAt.getTime() - Date.now()) / 1000)
+    );
+    const refreshExpiresInSec = tokens.refreshTokenExpiresAt
+      ? Math.max(0, Math.floor((tokens.refreshTokenExpiresAt.getTime() - Date.now()) / 1000))
+      : 8726400;
+    this.oauthClient.setToken({
+      token_type: 'bearer',
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      expires_in: expiresInSec,
+      x_refresh_token_expires_in: refreshExpiresInSec,
+      realmId: tokens.realmId,
+    });
+    this.qbo = new QuickBooksLib(
+      config.clientId,
+      config.clientSecret,
+      tokens.accessToken,
+      false,
+      tokens.realmId,
+      config.environment === 'sandbox',
+      false,
+      null,
+      '2.0',
+      tokens.refreshToken
+    );
+    this.cachedExpiresAt = tokens.accessTokenExpiresAt;
+  }
+
+  /**
+   * Ensure an authenticated QB client is available and the access token is
+   * fresh. Called before every API operation. Loads from DB on first use,
+   * refreshes if within the leeway window of expiry.
+   */
+  private async ensureClient(): Promise<void> {
+    if (!this.qbo) {
+      const tokens = await this.loadTokensFromDb();
+      if (!tokens) {
+        throw new Error('QuickBooks is not connected. Authorize the app first.');
+      }
+      this.hydrateClients(tokens);
+    }
+    const expiresAt = this.cachedExpiresAt;
+    if (expiresAt && expiresAt.getTime() - Date.now() < REFRESH_LEEWAY_SECONDS * 1000) {
+      await this.refreshTokens();
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // OAuth flow
+  // ------------------------------------------------------------------
+
+  /**
+   * Get OAuth authorization URL. State is supplied by the caller (a
+   * per-request nonce stored in the session) so the callback can verify
+   * it and reject forged callbacks. See routes/quickbooks.ts.
+   */
+  getAuthUrl(state: string): string {
+    const config = this.getAppConfig();
+    if (!config.clientId || !config.clientSecret) {
+      throw new Error('QuickBooks credentials not configured. Please set QBO_CLIENT_ID and QBO_CLIENT_SECRET.');
+    }
+    if (!this.oauthClient) {
+      this.initializeOAuthClient();
+    }
     if (!this.oauthClient) {
       throw new Error('QuickBooks OAuth client not initialized properly.');
     }
-    
-    try {
-      return this.oauthClient.authorizeUri({
-        scope: [OAuthClientLib.scopes.Accounting],
-        state: 'qbo_auth',
-      });
-    } catch (error) {
-      console.error('Error generating OAuth URL:', error);
-      throw new Error('Failed to generate QuickBooks authorization URL. Please check your QuickBooks credentials.');
+    if (!state) {
+      throw new Error('OAuth state nonce is required');
     }
+    return this.oauthClient.authorizeUri({
+      scope: [OAuthClientLib.scopes.Accounting],
+      state,
+    });
   }
 
   /**
-   * Handle OAuth callback and get tokens
+   * Exchange the OAuth callback URL for tokens and persist them encrypted.
    */
-  async handleOAuthCallback(callbackUrl: string): Promise<any> {
-    try {
-      const authResponse = await this.oauthClient.createToken(callbackUrl);
-      const token = authResponse.getToken();
-      
-      // Store the token in the OAuth client for future use
-      this.oauthClient.setToken(authResponse);
-      
-      return {
-        accessToken: token.access_token,
-        refreshToken: token.refresh_token,
-        realmId: token.realmId,
-        expiresIn: token.expires_in,
-      };
-    } catch (error) {
-      console.error('OAuth callback error:', error);
-      throw error;
+  async handleOAuthCallback(callbackUrl: string): Promise<void> {
+    if (!this.oauthClient) {
+      this.initializeOAuthClient();
     }
+    if (!this.oauthClient) {
+      throw new Error('QuickBooks OAuth client not initialized properly.');
+    }
+    const authResponse = await this.oauthClient.createToken(callbackUrl);
+    const tokens = this.toQBOTokens(authResponse.getToken());
+    await this.saveTokensToDb(tokens);
+    this.hydrateClients(tokens);
   }
 
   /**
-   * Refresh access token
+   * Refresh the access token using the stored refresh token, persist the
+   * new tokens, and rebuild the QB API client.
    */
   async refreshTokens(): Promise<void> {
-    try {
-      const authResponse = await this.oauthClient.refresh();
-      const token = authResponse.getToken();
-      
-      // Update tokens - in production, store these securely
-      process.env.QBO_ACCESS_TOKEN = token.access_token;
-      process.env.QBO_REFRESH_TOKEN = token.refresh_token;
-      
-      // Update the OAuth client's token state
-      this.oauthClient.setToken(authResponse);
-      
-      // Reinitialize the QB client with new tokens
-      this.initializeClients();
-    } catch (error) {
-      console.error('Token refresh error:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Check if access token is valid
-   */
-  isAccessTokenValid(): boolean {
-    const credentials = this.getCredentials();
-    
-    if (!credentials.clientId || !credentials.clientSecret) {
-      return false;
-    }
-    
     if (!this.oauthClient) {
-      return false;
+      const stored = await this.loadTokensFromDb();
+      if (!stored) {
+        throw new Error('Cannot refresh: no stored QuickBooks credentials');
+      }
+      this.hydrateClients(stored);
     }
-    
-    try {
-      return this.oauthClient.isAccessTokenValid();
-    } catch (error) {
-      console.error('Error checking token validity:', error);
-      return false;
-    }
+    const authResponse = await this.oauthClient.refresh();
+    const tokens = this.toQBOTokens(authResponse.getToken());
+    await this.saveTokensToDb(tokens);
+    this.hydrateClients(tokens);
   }
 
   /**
-   * Sync QBO Items to local database
+   * True when the app has stored, non-expired QBO credentials it can use.
    */
-  async syncItems(): Promise<void> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
+  async isAccessTokenValid(): Promise<boolean> {
+    const config = this.getAppConfig();
+    if (!config.clientId || !config.clientSecret) return false;
+    const tokens = await this.loadTokensFromDb();
+    if (!tokens) return false;
+    return tokens.accessTokenExpiresAt.getTime() > Date.now();
+  }
 
+  /**
+   * Disconnect the QuickBooks integration: revoke at Intuit if possible and
+   * remove the encrypted credentials from the database.
+   */
+  async disconnect(): Promise<void> {
+    try {
+      if (this.oauthClient && this.qbo) {
+        await this.oauthClient.revoke();
+      }
+    } catch (error) {
+      // Best-effort; clearing local credentials is the important part.
+      console.warn('QuickBooks token revoke failed; clearing local credentials anyway:', error);
+    }
+    this.qbo = null;
+    await this.clearTokensInDb();
+  }
+
+  // ------------------------------------------------------------------
+  // QuickBooks API operations — each ensures a fresh client first.
+  // ------------------------------------------------------------------
+
+  async syncItems(): Promise<void> {
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.findItems({}, async (err: any, items: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-
+        if (err) return reject(err);
         try {
           const qboItemList = items.QueryResponse?.Item || [];
-          
           for (const item of qboItemList) {
             await this.upsertItem(item);
           }
-          
           console.log(`Synced ${qboItemList.length} items from QuickBooks`);
           resolve();
         } catch (error) {
@@ -257,9 +326,6 @@ export class QuickBooksService extends DatabaseService {
     });
   }
 
-  /**
-   * Upsert QBO Item to local database
-   */
   private async upsertItem(qboItem: QBOItem): Promise<void> {
     const itemData = {
       qboId: qboItem.Id,
@@ -272,34 +338,18 @@ export class QuickBooksService extends DatabaseService {
       lastSyncAt: new Date(),
       updatedAt: new Date(),
     };
-
-    // Check if item exists
     const existingItem = await this.db
       .select()
       .from(qboItems)
       .where(eq(qboItems.qboId, qboItem.Id))
       .limit(1);
-
     if (existingItem.length > 0) {
-      // Update existing item
-      await this.db
-        .update(qboItems)
-        .set(itemData)
-        .where(eq(qboItems.qboId, qboItem.Id));
+      await this.db.update(qboItems).set(itemData).where(eq(qboItems.qboId, qboItem.Id));
     } else {
-      // Insert new item
-      await this.db
-        .insert(qboItems)
-        .values({
-          ...itemData,
-          createdAt: new Date(),
-        });
+      await this.db.insert(qboItems).values({ ...itemData, createdAt: new Date() });
     }
   }
 
-  /**
-   * Get all synced QBO Items
-   */
   async getItems(): Promise<any[]> {
     return await this.db
       .select()
@@ -308,209 +358,109 @@ export class QuickBooksService extends DatabaseService {
       .orderBy(qboItems.name);
   }
 
-  /**
-   * Create invoice in QuickBooks
-   */
   async createInvoice(invoiceData: any): Promise<any> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.createInvoice(invoiceData, (err: any, invoice: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+        if (err) return reject(err);
         resolve(invoice);
       });
     });
   }
 
-  /**
-   * Get invoice from QuickBooks
-   */
   async getInvoice(invoiceId: string): Promise<any> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.getInvoice(invoiceId, (err: any, invoice: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+        if (err) return reject(err);
         resolve(invoice);
       });
     });
   }
 
-  /**
-   * Find invoices for a customer
-   */
   async findInvoicesByCustomer(customerId: string): Promise<any[]> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
-      this.qbo.findInvoices({
-        CustomerRef: customerId
-      }, (err: any, invoices: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(invoices.QueryResponse?.Invoice || []);
+      this.qbo.findInvoices({ CustomerRef: customerId }, (err: any, invoicesResp: any) => {
+        if (err) return reject(err);
+        resolve(invoicesResp.QueryResponse?.Invoice || []);
       });
     });
   }
 
-  /**
-   * Create customer in QuickBooks
-   */
   async createCustomer(customerData: any): Promise<any> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.createCustomer(customerData, (err: any, customer: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+        if (err) return reject(err);
         resolve(customer);
       });
     });
   }
 
-  /**
-   * Create item in QuickBooks
-   */
   async createItem(itemData: any): Promise<any> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.createItem(itemData, (err: any, item: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+        if (err) return reject(err);
         resolve(item);
       });
     });
   }
 
-  /**
-   * Get income accounts
-   */
   async getIncomeAccounts(): Promise<any[]> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
-      this.qbo.findAccounts({
-        AccountType: 'Income'
-      }, (err: any, accounts: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+      this.qbo.findAccounts({ AccountType: 'Income' }, (err: any, accounts: any) => {
+        if (err) return reject(err);
         resolve(accounts.QueryResponse?.Account || []);
       });
     });
   }
 
-  /**
-   * Get all customers
-   */
   async getAllCustomers(): Promise<any[]> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.findCustomers({}, (err: any, customers: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        
+        if (err) return reject(err);
         const customerList = customers.QueryResponse?.Customer || [];
         console.log(`getAllCustomers: Found ${customerList.length} customers`);
-        
         resolve(customerList);
       });
     });
   }
 
-  /**
-   * Find customer by name
-   */
   async findCustomerByName(name: string): Promise<any> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
-      // Get all customers and filter by name (more reliable than direct search)
       this.qbo.findCustomers({}, (err: any, customers: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        
+        if (err) return reject(err);
         const customerList = customers.QueryResponse?.Customer || [];
         console.log(`findCustomerByName: Searching for "${name}" among ${customerList.length} customers`);
-        
-        // Debug: Show first few customer names
         console.log(`First 5 customer names:`, customerList.slice(0, 5).map((c: any) => `"${c.DisplayName}"`).join(', '));
-        
-        // Case-insensitive search for exact match
         const foundCustomer = customerList.find((customer: any) => {
           const customerName = customer.DisplayName?.toLowerCase() || '';
           const searchName = name.toLowerCase();
           return customer.DisplayName && customerName === searchName;
         });
-        
         resolve(foundCustomer || null);
       });
     });
   }
 
-  /**
-   * Sync QBO Customers to local database
-   */
   async syncCustomers(): Promise<void> {
-    if (!this.qbo) {
-      throw new Error('QuickBooks client not initialized');
-    }
-
+    await this.ensureClient();
     return new Promise((resolve, reject) => {
       this.qbo.findCustomers({}, async (err: any, customers: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-
+        if (err) return reject(err);
         try {
           const qboCustomerList = customers.QueryResponse?.Customer || [];
-          
           console.log(`Found ${qboCustomerList.length} customers in QuickBooks`);
-          
-          // Import customers into local database
           const { ClientService } = await import('./ClientService');
           const clientService = new ClientService();
-          
           for (const customer of qboCustomerList) {
             await this.upsertCustomer(customer, clientService);
           }
-          
           console.log(`Synced ${qboCustomerList.length} customers from QuickBooks`);
           resolve();
         } catch (error) {
@@ -520,25 +470,18 @@ export class QuickBooksService extends DatabaseService {
     });
   }
 
-  /**
-   * Upsert a customer from QuickBooks to local database
-   */
   private async upsertCustomer(qboCustomer: any, clientService: any): Promise<void> {
     try {
-      // Check if customer already exists locally by name
       const existingClient = await clientService.getClientByName(qboCustomer.DisplayName);
-      
       if (!existingClient) {
-        // Create new local client from QuickBooks customer
         const newClient = {
           clientId: `qbo-${qboCustomer.Id}`,
           name: qboCustomer.DisplayName,
           address: qboCustomer.BillAddr?.Line1 || '',
-          geoZone: '', // Can be filled in later
+          geoZone: '',
           isRecurringMaintenance: false,
-          activeStatus: qboCustomer.Active ? 'active' : 'inactive'
+          activeStatus: qboCustomer.Active ? 'active' : 'inactive',
         };
-        
         await clientService.createClient(newClient);
         console.log(`Created local client from QuickBooks: ${qboCustomer.DisplayName}`);
       } else {
@@ -546,7 +489,6 @@ export class QuickBooksService extends DatabaseService {
       }
     } catch (error) {
       console.error(`Error upserting customer ${qboCustomer.DisplayName}:`, error);
-      // Continue with other customers
     }
   }
-} 
+}

--- a/server/src/types/quickbooks.d.ts
+++ b/server/src/types/quickbooks.d.ts
@@ -53,6 +53,8 @@ declare module 'intuit-oauth' {
     refresh(): Promise<any>;
     isAccessTokenValid(): boolean;
     getToken(): any;
+    setToken(token: any): void;
+    revoke(): Promise<any>;
   }
 
   const OAuthClient: OAuthClientConstructor;

--- a/server/src/utils/encryption.ts
+++ b/server/src/utils/encryption.ts
@@ -1,0 +1,60 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+// AES-256-GCM. 12-byte IV is the standard for GCM; 16-byte auth tag.
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+const FORMAT_VERSION = 'v1';
+
+function loadKey(): Buffer {
+  const hex = process.env.QBO_TOKEN_ENCRYPTION_KEY;
+  if (!hex) {
+    throw new Error(
+      'QBO_TOKEN_ENCRYPTION_KEY is not set. Generate one with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"'
+    );
+  }
+  const key = Buffer.from(hex, 'hex');
+  if (key.length !== KEY_LENGTH) {
+    throw new Error(
+      `QBO_TOKEN_ENCRYPTION_KEY must be ${KEY_LENGTH} bytes (${KEY_LENGTH * 2} hex chars); got ${key.length} bytes`
+    );
+  }
+  return key;
+}
+
+export function encryptToken(plaintext: string): string {
+  const key = loadKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [
+    FORMAT_VERSION,
+    iv.toString('base64'),
+    authTag.toString('base64'),
+    ciphertext.toString('base64'),
+  ].join(':');
+}
+
+export function decryptToken(encoded: string): string {
+  const key = loadKey();
+  const parts = encoded.split(':');
+  if (parts.length !== 4 || parts[0] !== FORMAT_VERSION) {
+    throw new Error('Invalid encrypted token format');
+  }
+  const iv = Buffer.from(parts[1], 'base64');
+  const authTag = Buffer.from(parts[2], 'base64');
+  const ciphertext = Buffer.from(parts[3], 'base64');
+  if (iv.length !== IV_LENGTH || authTag.length !== AUTH_TAG_LENGTH) {
+    throw new Error('Invalid encrypted token format');
+  }
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}
+
+export function generateEncryptionKey(): string {
+  return randomBytes(KEY_LENGTH).toString('hex');
+}

--- a/src/components/QuickBooksIntegration.tsx
+++ b/src/components/QuickBooksIntegration.tsx
@@ -51,6 +51,34 @@ const QuickBooksIntegration: React.FC = () => {
   const [success, setSuccess] = useState<string | null>(null);
 
   useEffect(() => {
+    // OAuth callback now 302-redirects the popup here with ?qbo=connected
+    // or ?qbo=error&reason=... — relay to the opener (if any) and close.
+    const params = new URLSearchParams(window.location.search);
+    const qboStatus = params.get('qbo');
+    if (qboStatus) {
+      if (window.opener) {
+        if (qboStatus === 'connected') {
+          window.opener.postMessage(
+            { type: 'QB_AUTH_SUCCESS', message: 'Authentication successful' },
+            window.location.origin
+          );
+        } else {
+          window.opener.postMessage(
+            { type: 'QB_AUTH_ERROR', error: params.get('reason') || 'Authentication failed' },
+            window.location.origin
+          );
+        }
+        window.close();
+        return;
+      }
+      // Not in a popup — show inline feedback and clean the URL.
+      if (qboStatus === 'connected') {
+        setSuccess('Successfully connected to QuickBooks!');
+      } else {
+        setError(params.get('reason') || 'QuickBooks authentication failed');
+      }
+      window.history.replaceState({}, '', window.location.pathname);
+    }
     checkAuthStatus();
     fetchQBOItems();
   }, []);


### PR DESCRIPTION
## Summary

Addresses the three hard blockers from [Intuit's QBO app security requirements](https://developer.intuit.com/app/developer/qbo/docs/go-live/publish-app/security-requirements) so the integration can pass production review:

1. **Encrypted, persistent token storage.** Tokens were in \`process.env\` (lost on restart, plaintext). New \`qbo_credentials\` table stores them AES-256-GCM-encrypted with a key from \`QBO_TOKEN_ENCRYPTION_KEY\`. \`QuickBooksService\` loads them lazily and auto-refreshes within 5 minutes of expiry, so the app no longer requires manual re-OAuth after deploys or the hourly access-token TTL.

2. **OAuth state nonce.** State was the hardcoded literal \`'qbo_auth'\` — no CSRF protection on the callback. \`routes/quickbooks.ts\` now generates a 32-byte random nonce per request, stores it in the session, and rejects the callback if it doesn't match. Nonce is consumed on every callback so it can't be replayed.

3. **302 redirect on callback (no HTML on token-bearing endpoint).** Intuit forbids HTML responses on endpoints that receive auth tokens in URL parameters because the code can leak via \`Referer\` headers. Callback now 302-redirects to \`/quickbooks?qbo=connected\` (or \`?qbo=error&reason=...\`); the React page detects the query param and posts the result to \`window.opener\` if in a popup, preserving the existing UX.

## Other changes

- \`noStore\` middleware on \`/api/auth/*\` and \`/api/qbo/*\` adds \`Cache-Control: no-store, no-cache, must-revalidate, private\` per Intuit's caching rule.
- New \`POST /api/qbo/auth/disconnect\` revokes at Intuit and wipes the local credentials row.
- \`POST /api/qbo/seed\` now 403s in production.
- \`env.example\` documents \`QBO_TOKEN_ENCRYPTION_KEY\` (with key-generation command) and drops the \`QBO_ACCESS_TOKEN\` / \`QBO_REFRESH_TOKEN\` / \`QBO_REALM_ID\` entries since tokens no longer live in env.
- Migration \`0013_legal_warhawk.sql\` adds the \`qbo_credentials\` table.
- 10 unit tests for the encryption util (round-trip, IV randomness, GCM auth-tag tampering, wrong-key rejection, format versioning, helpful errors on missing/wrong-length keys, unicode).

## Deploy steps

1. Generate the encryption key: \`node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"\`
2. Set \`QBO_TOKEN_ENCRYPTION_KEY\` in Railway env (64 hex chars).
3. Deploy and run \`npm run db:migrate:prod\`.
4. Re-OAuth from \`/quickbooks\` — any existing connection in env-based storage will not survive the cutover (the old env vars are no longer read).
5. Rotating \`QBO_TOKEN_ENCRYPTION_KEY\` later invalidates stored tokens and forces a re-OAuth.

## Test plan

- [x] \`npm run type-check\` clean (server + frontend)
- [x] 10 encryption unit tests pass
- [x] Manual: OAuth round-trip in dev sandbox — \`GET /api/qbo/auth/url\` → click through Intuit → popup lands on \`/quickbooks?qbo=connected\` → \`postMessage\` to opener → \`/api/qbo/auth/status\` returns \`{ isValid: true }\`
- [x] Manual: Restart server → state survives (\`isValid: true\` without re-OAuth)
- [x] Manual: Tamper with \`state\` in callback URL → 302 redirect to \`?qbo=error&reason=invalid_state\`
- [ ] Manual: \`curl -i /api/qbo/auth/status\` shows \`Cache-Control: no-store, ...\`

## Out of scope (separate PR)

Frontend \`/quickbooks\` route is still mounted unconditionally in \`App.tsx\` and \`POST /api/qbo/seed\` is publicly callable by any authenticated user. Both addressed in PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)