### PR TITLE
Show QuickBooks nav link in production (PR B)

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -91,9 +91,7 @@ const Navigation: React.FC = () => {
       items: [
         { path: '/ask-data', label: 'Ask the assistant', Icon: Sparkles },
         { path: '/notion-sync', label: 'Notion sync', Icon: RefreshCw },
-        ...(process.env.NODE_ENV !== 'production'
-          ? [{ path: '/quickbooks', label: 'QuickBooks', Icon: Banknote }]
-          : []),
+        { path: '/quickbooks', label: 'QuickBooks', Icon: Banknote },
       ],
     },
     {


### PR DESCRIPTION
## Summary

The QuickBooks nav link was hidden in production as a temporary safeguard while the integration was unreviewed. The hardening in #66 (encrypted token storage, OAuth state nonce, 302 redirect callback, \`no-store\` caching) addresses Intuit's security requirements, so the page can be a first-class nav entry now.

## Note on scope

Original PR B plan included gating the \`/quickbooks\` React route, but that route has to be reachable in production — #66's OAuth callback 302-redirects the popup to \`/quickbooks?qbo=connected\`. So the route stays unconditional and only the nav visibility changes.

Seed endpoint protection (the other PR B item) already landed in #66 — \`POST /api/qbo/seed\` now 403s when \`NODE_ENV=production\`.

## Test plan

- [x] \`npm run type-check\` clean
- [ ] In prod, the QuickBooks link appears under Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)