### PR TITLE
Import existing QBO invoices and associate them with work activities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Agent-facing guidance that complements `CLAUDE.md`. Keep this short and rule-shaped — patterns that are easy to miss because they only fail in production, not locally.
+
+## Frontend: every state-changing request must use `secureFetch`
+
+`server/src/server.ts` mounts `doubleCsrfProtection` globally. In **production**, every non-GET/HEAD/OPTIONS request must carry an `X-CSRF-Token` header or the server returns 403. CSRF is silently bypassed in dev (MemoryStore sessions don't survive backend restarts), so a bare `fetch()` will *appear to work locally* and then break in prod.
+
+**Rule**: when writing or reviewing frontend code, any `fetch()` with `method` `POST`, `PUT`, `PATCH`, or `DELETE` against `/api/...` must use `secureFetch` from `src/services/csrf.ts`.
+
+```ts
+// ❌ Wrong — works in dev, 403s in prod.
+await fetch('/api/qbo/invoices/sync-all', { method: 'POST', body: ... });
+
+// ✅ Right — attaches X-CSRF-Token + credentials.
+import { secureFetch } from '../services/csrf';
+await secureFetch('/api/qbo/invoices/sync-all', { method: 'POST', body: ... });
+```
+
+`secureFetch` also adds `credentials: 'include'`, so you don't need to pass that separately.
+
+Exceptions: routes explicitly listed in `skipCsrfProtection` in `server/src/server.ts` (`/api/health`, `/api/csrf-token`, `/api/auth/*`, `/api/notion/*`, `/api/cron/*`, `/api/data-export*`). Everything else needs the token.
+
+## Backend: pass `tx` through service composition
+
+`DatabaseService` exports `DbOrTx`. Service methods that need to participate in a caller's transaction should accept `tx?: DbOrTx` and `conn = tx ?? this.db` (see `WorkActivityService.setStatus` for the pattern). Avoid raw `tx.insert(...)` from outside a service — add the `tx?` overload to the owning service instead.

--- a/server/drizzle/0014_magenta_rogue.sql
+++ b/server/drizzle/0014_magenta_rogue.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "clients" ADD COLUMN "qbo_customer_id" text;--> statement-breakpoint
+ALTER TABLE "invoice_line_items" ADD COLUMN "match_status" text DEFAULT 'unmatched' NOT NULL;--> statement-breakpoint
+ALTER TABLE "invoice_line_items" ADD COLUMN "match_score" real;--> statement-breakpoint
+ALTER TABLE "invoice_line_items" ADD COLUMN "match_candidates" jsonb;--> statement-breakpoint
+ALTER TABLE "clients" ADD CONSTRAINT "clients_qbo_customer_id_unique" UNIQUE("qbo_customer_id");

--- a/server/drizzle/0015_invoice_matcher_indexes.sql
+++ b/server/drizzle/0015_invoice_matcher_indexes.sql
@@ -1,0 +1,28 @@
+-- Indexes supporting QBO invoice import / matcher hot paths.
+--
+-- 1) Composite index for the per-invoice candidate query in
+--    InvoiceImportService.matchInvoiceLines and rematchInvoice. Without this,
+--    a sync of N invoices triggers N seq scans of work_activities.
+CREATE INDEX IF NOT EXISTS "work_activities_matcher_idx"
+  ON "work_activities" ("client_id", "status", "date");
+
+-- 2) Speeds up the WHERE match_status='needs_review' scan in getReviewQueue.
+--    Partial keeps it small since most line items are 'auto' or 'manual'.
+CREATE INDEX IF NOT EXISTS "invoice_line_items_review_queue_idx"
+  ON "invoice_line_items" ("invoice_id")
+  WHERE "match_status" = 'needs_review';
+
+-- 3) Speeds up the double-link cross-invoice check in relinkLineItem and the
+--    orphan check in revertOrphanedActivities. Partial — only meaningful rows.
+CREATE INDEX IF NOT EXISTS "invoice_line_items_work_activity_idx"
+  ON "invoice_line_items" ("work_activity_id")
+  WHERE "work_activity_id" IS NOT NULL;
+
+-- 4) DB-enforced single-claim invariant: a work activity can only be linked
+--    to one invoice_line_item in ('auto','manual') status at a time. Prevents
+--    the SELECT-then-UPDATE race in relinkLineItem from silently creating
+--    double-links. The application-level check in relinkLineItem still issues
+--    the 409 warning for the common UX case; this index is the safety net.
+CREATE UNIQUE INDEX IF NOT EXISTS "invoice_line_items_work_activity_single_claim_uidx"
+  ON "invoice_line_items" ("work_activity_id")
+  WHERE "work_activity_id" IS NOT NULL AND "match_status" IN ('auto', 'manual');

--- a/server/drizzle/meta/0014_snapshot.json
+++ b/server/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1464 @@
+{
+  "id": "7d9c0bcb-915f-4270-91d1-04f5f7fbd0a1",
+  "prevId": "856b3653-75ce-45b7-8a03-96a2ac7aa112",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.client_notes": {
+      "name": "client_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "client_notes_client_id_clients_id_fk": {
+          "name": "client_notes_client_id_clients_id_fk",
+          "tableFrom": "client_notes",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo_zone": {
+          "name": "geo_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_recurring_maintenance": {
+          "name": "is_recurring_maintenance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maintenance_interval_weeks": {
+          "name": "maintenance_interval_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_hours_per_visit": {
+          "name": "maintenance_hours_per_visit",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_rate": {
+          "name": "maintenance_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_date": {
+          "name": "last_maintenance_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_maintenance_target": {
+          "name": "next_maintenance_target",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_level": {
+          "name": "priority_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_flexibility": {
+          "name": "schedule_flexibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_days": {
+          "name": "preferred_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_time": {
+          "name": "preferred_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_notes": {
+          "name": "special_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "qbo_customer_id": {
+          "name": "qbo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_client_id_unique": {
+          "name": "clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "clients_qbo_customer_id_unique": {
+          "name": "clients_qbo_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regular_workdays": {
+          "name": "regular_workdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_address": {
+          "name": "home_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_hours_per_day": {
+          "name": "min_hours_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_hours_per_day": {
+          "name": "max_hours_per_day",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_level": {
+          "name": "capability_level",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employees_employee_id_unique": {
+          "name": "employees_employee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "employee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_charge_id": {
+          "name": "other_charge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_item_id": {
+          "name": "qbo_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unmatched'"
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_line_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_work_activity_id_work_activities_id_fk": {
+          "name": "invoice_line_items_work_activity_id_work_activities_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_other_charge_id_other_charges_id_fk": {
+          "name": "invoice_line_items_other_charge_id_other_charges_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "other_charges",
+          "columnsFrom": [
+            "other_charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk": {
+          "name": "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "qbo_items",
+          "columnsFrom": [
+            "qbo_item_id"
+          ],
+          "columnsTo": [
+            "qbo_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_invoice_id": {
+          "name": "qbo_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qbo_customer_id": {
+          "name": "qbo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_sync_at": {
+          "name": "qbo_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_qbo_invoice_id_unique": {
+          "name": "invoices_qbo_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_invoice_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_active_idx": {
+          "name": "notifications_active_idx",
+          "columns": [
+            {
+              "expression": "dismissed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.other_charges": {
+      "name": "other_charges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_type": {
+          "name": "charge_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_rate": {
+          "name": "unit_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "other_charges_work_activity_id_work_activities_id_fk": {
+          "name": "other_charges_work_activity_id_work_activities_id_fk",
+          "tableFrom": "other_charges",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plant_list": {
+      "name": "plant_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plant_list_work_activity_id_work_activities_id_fk": {
+          "name": "plant_list_work_activity_id_work_activities_id_fk",
+          "tableFrom": "plant_list",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_credentials": {
+      "name": "qbo_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_items": {
+      "name": "qbo_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_id": {
+          "name": "qbo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "income_account_ref": {
+          "name": "income_account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "qbo_items_qbo_id_unique": {
+          "name": "qbo_items_qbo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activities": {
+      "name": "work_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_type": {
+          "name": "work_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable_hours": {
+          "name": "billable_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_time_minutes": {
+          "name": "travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_travel_time_minutes": {
+          "name": "adjusted_travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "break_time_minutes": {
+          "name": "break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_break_time_minutes": {
+          "name": "adjusted_break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_billable_time_minutes": {
+          "name": "non_billable_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasks": {
+          "name": "tasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_page_id": {
+          "name": "notion_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notion_sync_at": {
+          "name": "last_notion_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'web_app'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_activities_project_id_projects_id_fk": {
+          "name": "work_activities_project_id_projects_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activities_client_id_clients_id_fk": {
+          "name": "work_activities_client_id_clients_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "work_activities_notion_page_id_unique": {
+          "name": "work_activities_notion_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notion_page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activity_employees": {
+      "name": "work_activity_employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wae_wa_emp_uidx": {
+          "name": "wae_wa_emp_uidx",
+          "columns": [
+            {
+              "expression": "work_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_activity_employees_work_activity_id_work_activities_id_fk": {
+          "name": "work_activity_employees_work_activity_id_work_activities_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activity_employees_employee_id_employees_id_fk": {
+          "name": "work_activity_employees_employee_id_employees_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/0015_snapshot.json
+++ b/server/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1541 @@
+{
+  "id": "8b993587-8530-4206-808e-40ac9c6266bb",
+  "prevId": "7d9c0bcb-915f-4270-91d1-04f5f7fbd0a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.client_notes": {
+      "name": "client_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "client_notes_client_id_clients_id_fk": {
+          "name": "client_notes_client_id_clients_id_fk",
+          "tableFrom": "client_notes",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo_zone": {
+          "name": "geo_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_recurring_maintenance": {
+          "name": "is_recurring_maintenance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maintenance_interval_weeks": {
+          "name": "maintenance_interval_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_hours_per_visit": {
+          "name": "maintenance_hours_per_visit",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_rate": {
+          "name": "maintenance_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_date": {
+          "name": "last_maintenance_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_maintenance_target": {
+          "name": "next_maintenance_target",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_level": {
+          "name": "priority_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_flexibility": {
+          "name": "schedule_flexibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_days": {
+          "name": "preferred_days",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_time": {
+          "name": "preferred_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_notes": {
+          "name": "special_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "qbo_customer_id": {
+          "name": "qbo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_client_id_unique": {
+          "name": "clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        },
+        "clients_qbo_customer_id_unique": {
+          "name": "clients_qbo_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regular_workdays": {
+          "name": "regular_workdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_address": {
+          "name": "home_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_hours_per_day": {
+          "name": "min_hours_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_hours_per_day": {
+          "name": "max_hours_per_day",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_level": {
+          "name": "capability_level",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_status": {
+          "name": "active_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employees_employee_id_unique": {
+          "name": "employees_employee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "employee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_charge_id": {
+          "name": "other_charge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_item_id": {
+          "name": "qbo_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_status": {
+          "name": "match_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unmatched'"
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_candidates": {
+          "name": "match_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoice_line_items_review_queue_idx": {
+          "name": "invoice_line_items_review_queue_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"match_status\" = 'needs_review'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_line_items_work_activity_idx": {
+          "name": "invoice_line_items_work_activity_idx",
+          "columns": [
+            {
+              "expression": "work_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"work_activity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_line_items_work_activity_single_claim_uidx": {
+          "name": "invoice_line_items_work_activity_single_claim_uidx",
+          "columns": [
+            {
+              "expression": "work_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_line_items\".\"work_activity_id\" IS NOT NULL AND \"invoice_line_items\".\"match_status\" IN ('auto', 'manual')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_line_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_work_activity_id_work_activities_id_fk": {
+          "name": "invoice_line_items_work_activity_id_work_activities_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_other_charge_id_other_charges_id_fk": {
+          "name": "invoice_line_items_other_charge_id_other_charges_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "other_charges",
+          "columnsFrom": [
+            "other_charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk": {
+          "name": "invoice_line_items_qbo_item_id_qbo_items_qbo_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "qbo_items",
+          "columnsFrom": [
+            "qbo_item_id"
+          ],
+          "columnsTo": [
+            "qbo_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_invoice_id": {
+          "name": "qbo_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qbo_customer_id": {
+          "name": "qbo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qbo_sync_at": {
+          "name": "qbo_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_qbo_invoice_id_unique": {
+          "name": "invoices_qbo_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_invoice_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_active_idx": {
+          "name": "notifications_active_idx",
+          "columns": [
+            {
+              "expression": "dismissed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.other_charges": {
+      "name": "other_charges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_type": {
+          "name": "charge_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_rate": {
+          "name": "unit_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "other_charges_work_activity_id_work_activities_id_fk": {
+          "name": "other_charges_work_activity_id_work_activities_id_fk",
+          "tableFrom": "other_charges",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plant_list": {
+      "name": "plant_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plant_list_work_activity_id_work_activities_id_fk": {
+          "name": "plant_list_work_activity_id_work_activities_id_fk",
+          "tableFrom": "plant_list",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_credentials": {
+      "name": "qbo_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "realm_id": {
+          "name": "realm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qbo_items": {
+      "name": "qbo_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "qbo_id": {
+          "name": "qbo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "income_account_ref": {
+          "name": "income_account_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "qbo_items_qbo_id_unique": {
+          "name": "qbo_items_qbo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "qbo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activities": {
+      "name": "work_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_type": {
+          "name": "work_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable_hours": {
+          "name": "billable_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_time_minutes": {
+          "name": "travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_travel_time_minutes": {
+          "name": "adjusted_travel_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "break_time_minutes": {
+          "name": "break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjusted_break_time_minutes": {
+          "name": "adjusted_break_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_billable_time_minutes": {
+          "name": "non_billable_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasks": {
+          "name": "tasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notion_page_id": {
+          "name": "notion_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notion_sync_at": {
+          "name": "last_notion_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by": {
+          "name": "last_updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'web_app'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "work_activities_matcher_idx": {
+          "name": "work_activities_matcher_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_activities_project_id_projects_id_fk": {
+          "name": "work_activities_project_id_projects_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activities_client_id_clients_id_fk": {
+          "name": "work_activities_client_id_clients_id_fk",
+          "tableFrom": "work_activities",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "work_activities_notion_page_id_unique": {
+          "name": "work_activities_notion_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notion_page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_activity_employees": {
+      "name": "work_activity_employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_activity_id": {
+          "name": "work_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wae_wa_emp_uidx": {
+          "name": "wae_wa_emp_uidx",
+          "columns": [
+            {
+              "expression": "work_activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_activity_employees_work_activity_id_work_activities_id_fk": {
+          "name": "work_activity_employees_work_activity_id_work_activities_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "work_activities",
+          "columnsFrom": [
+            "work_activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_activity_employees_employee_id_employees_id_fk": {
+          "name": "work_activity_employees_employee_id_employees_id_fk",
+          "tableFrom": "work_activity_employees",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779747023875,
       "tag": "0013_legal_warhawk",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1779922781640,
+      "tag": "0014_magenta_rogue",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1779922781640,
       "tag": "0014_magenta_rogue",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1780000000000,
+      "tag": "0015_invoice_matcher_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/invoiceImportService.test.ts
+++ b/server/src/__tests__/invoiceImportService.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  classifyLine,
+  hasTokenOverlap,
+  scoreCandidate,
+  shiftDate,
+  tokenize,
+  toMatchCandidate,
+  workTypeMatchesQBOItem,
+  type ScoringActivity,
+  type ScoringLine
+} from '../services/InvoiceImportService';
+
+// NOTE: DB-backed integration tests for relinkLineItem / rematchInvoice / sync
+// are intentionally skipped here — the local test_user role isn't reliably
+// available (see MEMORY.md re: billableHours.*.test.ts integration setup).
+// The state machine is exercised via manual verification per the plan.
+
+const baseActivity = (overrides: Partial<ScoringActivity> = {}): ScoringActivity => ({
+  id: 1,
+  date: '2025-05-01',
+  workType: 'maintenance',
+  billableHours: 3,
+  notes: 'Trimmed hedges and pulled weeds in the front bed.',
+  tasks: null,
+  ...overrides
+});
+
+const baseLine = (overrides: Partial<ScoringLine> = {}): ScoringLine => ({
+  description: 'Trimmed hedges and pulled weeds',
+  qty: 3,
+  qboItemName: 'Garden maintenance',
+  ...overrides
+});
+
+describe('tokenize', () => {
+  it('lowercases, splits on non-word chars, drops stopwords and short tokens', () => {
+    const out = tokenize('The QUICK brown/fox jumped, and the lazy dog!');
+    // 'the' stopword, 'and' stopword dropped. Tokens of len<3 dropped.
+    expect(out).toEqual(['quick', 'brown', 'fox', 'jumped', 'lazy', 'dog']);
+  });
+
+  it('returns empty for null/empty', () => {
+    expect(tokenize(null)).toEqual([]);
+    expect(tokenize('')).toEqual([]);
+  });
+});
+
+describe('hasTokenOverlap', () => {
+  it('returns true when ≥2 significant tokens overlap', () => {
+    expect(hasTokenOverlap('trimmed hedges in front', 'hedges trimmed quickly')).toBe(true);
+  });
+
+  it('returns false when fewer than 2 overlap', () => {
+    expect(hasTokenOverlap('trimmed hedges', 'mowed lawn')).toBe(false);
+    expect(hasTokenOverlap('only hedges', 'hedges alone')).toBe(false); // only 1 overlap
+  });
+
+  it('ignores stopwords and short tokens', () => {
+    // 'the' and 'a' are stopwords; 'in' too short. Only 'thing' overlaps.
+    expect(hasTokenOverlap('the a thing', 'a the thing')).toBe(false);
+  });
+});
+
+describe('workTypeMatchesQBOItem', () => {
+  it('matches mapped names case-insensitively', () => {
+    expect(workTypeMatchesQBOItem('maintenance', 'Garden maintenance')).toBe(true);
+    expect(workTypeMatchesQBOItem('MAINTENANCE', 'garden maintenance')).toBe(true);
+  });
+
+  it('returns false for unmapped workType', () => {
+    expect(workTypeMatchesQBOItem('weeding', 'Garden maintenance')).toBe(false);
+  });
+
+  it('returns false for null/missing item name', () => {
+    expect(workTypeMatchesQBOItem('maintenance', null)).toBe(false);
+    expect(workTypeMatchesQBOItem('maintenance', undefined)).toBe(false);
+  });
+});
+
+describe('shiftDate', () => {
+  it('subtracts and adds days', () => {
+    expect(shiftDate('2025-05-10', -7)).toBe('2025-05-03');
+    expect(shiftDate('2025-05-10', 3)).toBe('2025-05-13');
+  });
+});
+
+describe('scoreCandidate', () => {
+  it('returns ~0 with no overlap, no hours match, far away', () => {
+    const activity = baseActivity({
+      billableHours: 1.5,
+      notes: 'mowed and edged',
+      tasks: null,
+      date: '2025-01-01',
+      workType: 'unmapped'
+    });
+    const line = baseLine({
+      qty: 999,
+      description: 'completely unrelated repair work',
+      qboItemName: 'Some other item'
+    });
+    const { score } = scoreCandidate(activity, line, '2025-12-31');
+    // 0 hours, 0 token, ~0 proximity (>>90 days), 0 workType.
+    expect(score).toBeLessThan(0.1);
+  });
+
+  it('+3 hours bonus when within ±0.25', () => {
+    const activity = baseActivity({
+      billableHours: 3,
+      notes: 'something',
+      tasks: null,
+      date: '2025-05-01',
+      workType: 'unmapped'
+    });
+    const line = baseLine({
+      qty: 3.2,
+      description: 'no overlap zzz',
+      qboItemName: 'Unmapped item'
+    });
+    // Same day → proximity +1.0; hours match within 0.25 → +3. No tokens, no workType.
+    const { score } = scoreCandidate(activity, line, '2025-05-01');
+    expect(score).toBeCloseTo(4.0, 5);
+  });
+
+  it('does NOT give hours bonus when outside ±0.25', () => {
+    const activity = baseActivity({
+      billableHours: 3,
+      notes: '',
+      tasks: null,
+      date: '2025-05-01',
+      workType: 'unmapped'
+    });
+    const line = baseLine({
+      qty: 3.5,
+      description: 'no overlap',
+      qboItemName: 'Unmapped'
+    });
+    const { score } = scoreCandidate(activity, line, '2025-05-01');
+    // Only proximity +1.0; no hours match (diff 0.5 > 0.25).
+    expect(score).toBeCloseTo(1.0, 5);
+  });
+
+  it('+2 token overlap when ≥2 significant tokens shared', () => {
+    const activity = baseActivity({
+      billableHours: null,
+      notes: 'pruned roses and weeded',
+      tasks: null,
+      date: '2025-05-01',
+      workType: 'unmapped'
+    });
+    const line = baseLine({
+      qty: null,
+      description: 'pruned roses today',
+      qboItemName: 'Unmapped'
+    });
+    // +2 tokens, +1.0 same-day proximity.
+    const { score } = scoreCandidate(activity, line, '2025-05-01');
+    expect(score).toBeCloseTo(3.0, 5);
+  });
+
+  it('+2 workType bonus when workType maps to QBO item', () => {
+    const activity = baseActivity({
+      billableHours: null,
+      notes: '',
+      tasks: null,
+      date: '2025-05-01',
+      workType: 'maintenance'
+    });
+    const line = baseLine({
+      qty: null,
+      description: 'completely unrelated zzz',
+      qboItemName: 'Garden maintenance'
+    });
+    // +2 workType, +1.0 same-day proximity.
+    const { score } = scoreCandidate(activity, line, '2025-05-01');
+    expect(score).toBeCloseTo(3.0, 5);
+  });
+
+  it('proximity scales to ~1.0 same-day, ~0.5 at 45 days, ~0 at 90+ days', () => {
+    const activityBase = {
+      id: 1,
+      workType: 'unmapped',
+      billableHours: null,
+      notes: '',
+      tasks: null
+    };
+    const line = baseLine({ qty: null, description: 'no overlap', qboItemName: 'Unmapped' });
+
+    const sameDay = scoreCandidate({ ...activityBase, date: '2025-05-01' }, line, '2025-05-01');
+    expect(sameDay.score).toBeCloseTo(1.0, 5);
+
+    const halfWay = scoreCandidate({ ...activityBase, date: '2025-03-17' }, line, '2025-05-01'); // 45 days
+    expect(halfWay.score).toBeCloseTo(0.5, 1);
+
+    const farPast = scoreCandidate({ ...activityBase, date: '2025-02-01' }, line, '2025-05-01'); // ~89 days
+    expect(farPast.score).toBeGreaterThan(0);
+    expect(farPast.score).toBeLessThan(0.05);
+
+    const exact90 = scoreCandidate({ ...activityBase, date: '2025-01-31' }, line, '2025-05-01'); // 90 days
+    expect(exact90.score).toBeCloseTo(0, 5);
+  });
+});
+
+describe('classifyLine', () => {
+  const mk = (id: number, score: number) => ({
+    activity: baseActivity({ id }),
+    score,
+    reason: `score ${score}`
+  });
+
+  it('returns unmatched when no candidates', () => {
+    const c = classifyLine([]);
+    expect(c.status).toBe('unmatched');
+    expect(c.workActivityId).toBeNull();
+    expect(c.matchScore).toBeNull();
+    expect(c.matchCandidates).toBeNull();
+  });
+
+  it('returns auto when top score ≥ HIGH (5)', () => {
+    const c = classifyLine([mk(1, 5.0), mk(2, 3.0)]);
+    expect(c.status).toBe('auto');
+    expect(c.workActivityId).toBe(1);
+    expect(c.matchScore).toBe(5);
+    expect(c.matchCandidates).toBeNull();
+  });
+
+  it('returns needs_review when MIN ≤ top < HIGH, with top-3 candidates', () => {
+    const c = classifyLine([mk(1, 4.5), mk(2, 3.0), mk(3, 2.5), mk(4, 2.1)]);
+    expect(c.status).toBe('needs_review');
+    expect(c.workActivityId).toBeNull();
+    expect(c.matchScore).toBe(4.5);
+    expect(c.matchCandidates).toHaveLength(3);
+    expect(c.matchCandidates![0].workActivityId).toBe(1);
+    expect(c.matchCandidates![1].workActivityId).toBe(2);
+    expect(c.matchCandidates![2].workActivityId).toBe(3);
+  });
+
+  it('returns unmatched when top < MIN (2)', () => {
+    const c = classifyLine([mk(1, 1.5), mk(2, 0.5)]);
+    expect(c.status).toBe('unmatched');
+    expect(c.workActivityId).toBeNull();
+    expect(c.matchScore).toBeNull();
+    expect(c.matchCandidates).toBeNull();
+  });
+
+  it('breaks ties by activity id ASC', () => {
+    const c = classifyLine([mk(7, 5.0), mk(2, 5.0), mk(4, 5.0)]);
+    expect(c.status).toBe('auto');
+    expect(c.workActivityId).toBe(2);
+  });
+});
+
+describe('toMatchCandidate', () => {
+  it('truncates notes snippet to 200 chars', () => {
+    const longNote = 'x'.repeat(500);
+    const activity = baseActivity({ notes: longNote });
+    const out = toMatchCandidate(activity, { score: 3, reason: 'r' });
+    expect(out.notesSnippet).toHaveLength(200);
+  });
+
+  it('falls back to tasks when notes is empty', () => {
+    const activity = baseActivity({ notes: null, tasks: 'do the thing' });
+    const out = toMatchCandidate(activity, { score: 3, reason: 'r' });
+    expect(out.notesSnippet).toBe('do the thing');
+  });
+});
+
+// -----------------------------------------------------------------------
+// Within-invoice dedup test
+// -----------------------------------------------------------------------
+// Verifies the dedup contract: callers process lines in descending top-score
+// order and remove the claimed activity from the pool for subsequent lines.
+// This mirrors what InvoiceImportService.matchInvoiceLines does.
+describe('within-invoice dedup', () => {
+  it('does not assign the same activity to two lines on the same invoice', () => {
+    const activityA = baseActivity({ id: 100, billableHours: 3 });
+    const activityB = baseActivity({ id: 200, billableHours: 3 });
+    const invoiceDate = '2025-05-01';
+
+    const line1: ScoringLine = {
+      description: 'Trimmed hedges',
+      qty: 3,
+      qboItemName: 'Garden maintenance'
+    };
+    const line2: ScoringLine = {
+      description: 'Pulled weeds',
+      qty: 3,
+      qboItemName: 'Garden maintenance'
+    };
+
+    const scoredLine1 = [activityA, activityB].map((a) => ({
+      activity: a,
+      ...scoreCandidate(a, line1, invoiceDate)
+    }));
+    const scoredLine2 = [activityA, activityB].map((a) => ({
+      activity: a,
+      ...scoreCandidate(a, line2, invoiceDate)
+    }));
+
+    // Both lines have similar top scores. Process line1 first (caller's order),
+    // dedup activityA, then classify line2 on the filtered pool.
+    const decision1 = classifyLine(scoredLine1);
+    expect(decision1.status).toBe('auto');
+    const claimed = new Set<number>([decision1.workActivityId!]);
+
+    const filtered2 = scoredLine2.filter((s) => !claimed.has(s.activity.id));
+    const decision2 = classifyLine(filtered2);
+    expect(decision2.status).toBe('auto');
+    expect(decision2.workActivityId).not.toBe(decision1.workActivityId);
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -67,12 +67,24 @@ export const projects = pgTable('projects', {
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
+// Status values for work_activities.status. The matcher's candidate query
+// (InvoiceImportService) filters on status='completed', and setStatus flips
+// it to 'invoiced' when a line item claims an activity. Notion-sync imports
+// land in 'needs_review' until an operator confirms them. Typed so callers
+// can't pass a stale or misspelled value.
+export type WorkActivityStatus =
+  | 'planned'
+  | 'in_progress'
+  | 'needs_review'
+  | 'completed'
+  | 'invoiced';
+
 // Work Activities table
 export const workActivities = pgTable('work_activities', {
   id: serial('id').primaryKey(),
   workType: text('work_type').notNull(), // maintenance, install, errand, office work, etc.
   date: dateText('date').notNull(),
-  status: text('status').notNull(), // planned, in_progress, completed, invoiced
+  status: text('status').$type<WorkActivityStatus>().notNull(), // planned, in_progress, completed, invoiced
   startTime: time('start_time'),
   endTime: time('end_time'),
   billableHours: hours('billable_hours'),
@@ -92,7 +104,13 @@ export const workActivities = pgTable('work_activities', {
   lastUpdatedBy: text('last_updated_by').$type<'web_app' | 'notion_sync'>().default('web_app'), // Who made the last update
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()
-});
+}, (t) => ({
+  // Drives InvoiceImportService's per-invoice candidate query
+  // (clientId + status='completed' + date BETWEEN windowStart AND invoiceDate).
+  // Without this, each invoice in a sync run triggers a seq scan over the
+  // full work_activities table.
+  matcherIdx: index('work_activities_matcher_idx').on(t.clientId, t.status, t.date)
+}));
 
 // Work Activity Employees junction table
 export const workActivityEmployees = pgTable('work_activity_employees', {
@@ -189,6 +207,20 @@ export const invoices = pgTable('invoices', {
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
+// JSON shape persisted in invoice_line_items.match_candidates. Kept in schema
+// so the column can be typed at the source instead of cast at every read/write.
+export type MatchCandidateJSON = {
+  workActivityId: number;
+  score: number;
+  reason: string;
+  date: string;
+  workType: string;
+  billableHours: number | null;
+  notesSnippet: string;
+};
+
+export type MatchStatus = 'auto' | 'manual' | 'needs_review' | 'unmatched';
+
 // Invoice Line Items table
 export const invoiceLineItems = pgTable('invoice_line_items', {
   id: serial('id').primaryKey(),
@@ -200,12 +232,31 @@ export const invoiceLineItems = pgTable('invoice_line_items', {
   quantity: real('quantity').notNull(),
   rate: money('rate').notNull(), // Rate at time of invoice
   amount: money('amount').notNull(), // Total line amount
-  matchStatus: text('match_status').notNull().default('unmatched'), // 'auto' | 'manual' | 'needs_review' | 'unmatched'
+  matchStatus: text('match_status').$type<MatchStatus>().notNull().default('unmatched'),
   matchScore: real('match_score'), // Nullable: winning candidate's score for debugging/sorting
-  matchCandidates: jsonb('match_candidates'), // Nullable: top-3 candidates { workActivityId, score, reason }; cleared when status → 'manual'
+  // Nullable: top-3 candidates; cleared when status flips to 'manual'.
+  matchCandidates: jsonb('match_candidates').$type<MatchCandidateJSON[]>(),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()
-});
+}, (t) => ({
+  // Drives getReviewQueue's WHERE match_status='needs_review' scan.
+  reviewQueueIdx: index('invoice_line_items_review_queue_idx')
+    .on(t.invoiceId)
+    .where(sql`${t.matchStatus} = 'needs_review'`),
+  // Speeds up the double-link check in relinkLineItem and the orphan check
+  // in revertOrphanedActivities. Partial so we only index meaningful rows.
+  workActivityIdx: index('invoice_line_items_work_activity_idx')
+    .on(t.workActivityId)
+    .where(sql`${t.workActivityId} IS NOT NULL`),
+  // Enforces single-claim invariant at the DB level: a work activity can only
+  // be linked to one line item with match_status IN ('auto','manual') at a
+  // time. Prevents the SELECT-then-UPDATE race in relinkLineItem from silently
+  // creating double-links. 'needs_review' and 'unmatched' rows are excluded
+  // because their workActivityId is always NULL.
+  workActivitySingleClaimUidx: uniqueIndex('invoice_line_items_work_activity_single_claim_uidx')
+    .on(t.workActivityId)
+    .where(sql`${t.workActivityId} IS NOT NULL AND ${t.matchStatus} IN ('auto', 'manual')`)
+}));
 
 // Settings table for application configuration
 export const settings = pgTable('settings', {
@@ -229,7 +280,7 @@ export const notifications = pgTable('notifications', {
   sourceUrl: text('source_url'), // external link, e.g. Notion page URL
   entityType: text('entity_type'), // 'employee' | 'client' | 'work_activity' | 'cron_run'
   entityId: integer('entity_id'),
-  metadata: jsonb('metadata'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>(),
   readAt: timestamp('read_at'),
   dismissedAt: timestamp('dismissed_at'),
   createdAt: timestamp('created_at').notNull().defaultNow()

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -34,6 +34,7 @@ export const clients = pgTable('clients', {
   preferredTime: text('preferred_time'),
   specialNotes: text('special_notes'),
   activeStatus: text('active_status').notNull().default('active'),
+  qboCustomerId: text('qbo_customer_id').unique(), // Nullable: populated during QBO customer sync; used as primary join key for invoice import
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
@@ -199,6 +200,9 @@ export const invoiceLineItems = pgTable('invoice_line_items', {
   quantity: real('quantity').notNull(),
   rate: money('rate').notNull(), // Rate at time of invoice
   amount: money('amount').notNull(), // Total line amount
+  matchStatus: text('match_status').notNull().default('unmatched'), // 'auto' | 'manual' | 'needs_review' | 'unmatched'
+  matchScore: real('match_score'), // Nullable: winning candidate's score for debugging/sorting
+  matchCandidates: jsonb('match_candidates'), // Nullable: top-3 candidates { workActivityId, score, reason }; cleared when status → 'manual'
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -221,35 +221,6 @@ router.get('/invoices', async (req, res) => {
   }
 });
 
-router.get('/invoices/:invoiceId', async (req, res) => {
-  try {
-    const invoiceId = parseInt(req.params.invoiceId);
-    if (isNaN(invoiceId)) {
-      return res.status(400).json({ error: 'Invalid invoice ID' });
-    }
-
-    const invoice = await invoiceService.db
-      .select()
-      .from(invoices)
-      .where(eq(invoices.id, invoiceId))
-      .limit(1);
-
-    if (!invoice[0]) {
-      return res.status(404).json({ error: 'Invoice not found' });
-    }
-
-    const lineItems = await invoiceService.db
-      .select()
-      .from(invoiceLineItems)
-      .where(eq(invoiceLineItems.invoiceId, invoiceId));
-
-    res.json({ invoice: invoice[0], lineItems });
-  } catch (error) {
-    console.error('Error fetching invoice details:', error);
-    res.status(500).json({ error: 'Failed to fetch invoice details' });
-  }
-});
-
 /**
  * Fetch all QBO invoices and import / reconcile them against the local DB.
  * Per-invoice errors are captured inside the SyncResult.errors array; only
@@ -342,6 +313,35 @@ router.patch('/invoices/:invoiceId/line-items/:lineItemId', async (req, res) => 
   } catch (error) {
     console.error('Error relinking line item:', error);
     res.status(500).json({ error: 'Failed to relink line item' });
+  }
+});
+
+router.get('/invoices/:invoiceId', async (req, res) => {
+  try {
+    const invoiceId = parseInt(req.params.invoiceId);
+    if (isNaN(invoiceId)) {
+      return res.status(400).json({ error: 'Invalid invoice ID' });
+    }
+
+    const invoice = await invoiceService.db
+      .select()
+      .from(invoices)
+      .where(eq(invoices.id, invoiceId))
+      .limit(1);
+
+    if (!invoice[0]) {
+      return res.status(404).json({ error: 'Invoice not found' });
+    }
+
+    const lineItems = await invoiceService.db
+      .select()
+      .from(invoiceLineItems)
+      .where(eq(invoiceLineItems.invoiceId, invoiceId));
+
+    res.json({ invoice: invoice[0], lineItems });
+  } catch (error) {
+    console.error('Error fetching invoice details:', error);
+    res.status(500).json({ error: 'Failed to fetch invoice details' });
   }
 });
 

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -229,13 +229,19 @@ router.get('/invoices', async (req, res) => {
  */
 router.post('/invoices/sync-all', async (req, res) => {
   try {
-    const { since } = req.body ?? {};
+    const { since, dryRun } = req.body ?? {};
     if (since !== undefined) {
       if (typeof since !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(since)) {
         return res.status(400).json({ error: 'since must be a date string in YYYY-MM-DD format' });
       }
     }
-    const result = await services.invoiceImportService.syncAllInvoices({ since });
+    if (dryRun !== undefined && typeof dryRun !== 'boolean') {
+      return res.status(400).json({ error: 'dryRun must be a boolean' });
+    }
+    const result = await services.invoiceImportService.syncAllInvoices({
+      since,
+      dryRun: dryRun === true
+    });
     res.json(result);
   } catch (error) {
     console.error('Error syncing all invoices:', error);

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -295,11 +295,21 @@ router.patch('/invoices/:invoiceId/line-items/:lineItemId', async (req, res) => 
       return res.status(400).json({ error: 'workActivityId must be a number or null' });
     }
 
-    const validSources = ['review', 'detail'] as const;
+    const existingLine = await invoiceService.db
+      .select({ invoiceId: invoiceLineItems.invoiceId })
+      .from(invoiceLineItems)
+      .where(eq(invoiceLineItems.id, lineItemId))
+      .limit(1);
+
+    if (!existingLine[0]) {
+      return res.status(404).json({ error: 'Line item not found' });
+    }
+    if (existingLine[0].invoiceId !== invoiceId) {
+      return res.status(404).json({ error: 'Line item does not belong to this invoice' });
+    }
+
     const resolvedSource: 'review' | 'detail' =
-      typeof source === 'string' && (validSources as readonly string[]).includes(source)
-        ? (source as 'review' | 'detail')
-        : 'review';
+      source === 'detail' ? 'detail' : 'review';
 
     const result = await services.invoiceImportService.relinkLineItem(lineItemId, workActivityId, {
       source: resolvedSource,

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -410,11 +410,12 @@ router.post('/invoices/preview', async (req, res) => {
 });
 
 /**
- * Seed sandbox QuickBooks data. Dev-only: refuses to run in production.
+ * Seed sandbox QuickBooks data. Dev-only: only runs when NODE_ENV is explicitly
+ * 'development'. Refuses in production, staging, test, or undefined envs.
  */
 router.post('/seed', async (req, res) => {
-  if (process.env.NODE_ENV === 'production') {
-    return res.status(403).json({ error: 'Seeding is disabled in production' });
+  if (process.env.NODE_ENV !== 'development') {
+    return res.status(403).json({ error: 'Seeding is only available in development' });
   }
   try {
     const { default: QBOSeedDataGenerator } = await import('../scripts/seedQBOData');

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -250,6 +250,101 @@ router.get('/invoices/:invoiceId', async (req, res) => {
   }
 });
 
+/**
+ * Fetch all QBO invoices and import / reconcile them against the local DB.
+ * Per-invoice errors are captured inside the SyncResult.errors array; only
+ * blanket failures (e.g. QBO token expired before any work begins) bubble up
+ * to the catch block and return 500.
+ */
+router.post('/invoices/sync-all', async (req, res) => {
+  try {
+    const { since } = req.body ?? {};
+    if (since !== undefined) {
+      if (typeof since !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(since)) {
+        return res.status(400).json({ error: 'since must be a date string in YYYY-MM-DD format' });
+      }
+    }
+    const result = await services.invoiceImportService.syncAllInvoices({ since });
+    res.json(result);
+  } catch (error) {
+    console.error('Error syncing all invoices:', error);
+    res.status(500).json({ error: 'Failed to sync invoices' });
+  }
+});
+
+/**
+ * Return the current review queue: invoices with line items whose match status
+ * is 'needs_review' or 'unmatched', along with their candidates.
+ */
+router.get('/invoices/review-queue', async (req, res) => {
+  try {
+    const queue = await services.invoiceImportService.getReviewQueue();
+    res.json(queue);
+  } catch (error) {
+    console.error('Error fetching review queue:', error);
+    res.status(500).json({ error: 'Failed to fetch review queue' });
+  }
+});
+
+/**
+ * Re-run the auto-matcher for a single invoice's line items, preserving any
+ * manual user decisions. Returns match-status counts for the invoice.
+ */
+router.post('/invoices/:invoiceId/rematch', async (req, res) => {
+  try {
+    const invoiceId = parseInt(req.params.invoiceId);
+    if (isNaN(invoiceId)) {
+      return res.status(400).json({ error: 'Invalid invoice ID' });
+    }
+    const result = await services.invoiceImportService.rematchInvoice(invoiceId);
+    res.json(result);
+  } catch (error) {
+    console.error('Error rematching invoice:', error);
+    res.status(500).json({ error: 'Failed to rematch invoice' });
+  }
+});
+
+/**
+ * Manually link (or unlink) a line item to a work activity. Returns 409 when
+ * the activity is already linked to another invoice and `force` was not set.
+ */
+router.patch('/invoices/:invoiceId/line-items/:lineItemId', async (req, res) => {
+  try {
+    const invoiceId = parseInt(req.params.invoiceId);
+    if (isNaN(invoiceId)) {
+      return res.status(400).json({ error: 'Invalid invoice ID' });
+    }
+    const lineItemId = parseInt(req.params.lineItemId);
+    if (isNaN(lineItemId)) {
+      return res.status(400).json({ error: 'Invalid line item ID' });
+    }
+
+    const { workActivityId, force, source } = req.body ?? {};
+    if (workActivityId !== null && typeof workActivityId !== 'number') {
+      return res.status(400).json({ error: 'workActivityId must be a number or null' });
+    }
+
+    const validSources = ['review', 'detail'] as const;
+    const resolvedSource: 'review' | 'detail' =
+      typeof source === 'string' && (validSources as readonly string[]).includes(source)
+        ? (source as 'review' | 'detail')
+        : 'review';
+
+    const result = await services.invoiceImportService.relinkLineItem(lineItemId, workActivityId, {
+      source: resolvedSource,
+      force: force === true,
+    });
+
+    if ('warning' in result) {
+      return res.status(409).json(result);
+    }
+    res.json(result);
+  } catch (error) {
+    console.error('Error relinking line item:', error);
+    res.status(500).json({ error: 'Failed to relink line item' });
+  }
+});
+
 router.post('/invoices/:invoiceId/sync', async (req, res) => {
   try {
     const invoiceId = parseInt(req.params.invoiceId);

--- a/server/src/services/ClientService.ts
+++ b/server/src/services/ClientService.ts
@@ -41,6 +41,7 @@ export class ClientService extends BaseCrudService<typeof clients, Client, NewCl
         preferredTime: clients.preferredTime,
         specialNotes: clients.specialNotes,
         activeStatus: clients.activeStatus,
+        qboCustomerId: clients.qboCustomerId,
         createdAt: clients.createdAt,
         updatedAt: clients.updatedAt,
         // Work activity statistics

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -532,6 +532,10 @@ export class InvoiceImportService extends DatabaseService {
             .update(clients)
             .set({ qboCustomerId, updatedAt: new Date() })
             .where(eq(clients.id, byName[0].id));
+        } else if (byName[0].qboCustomerId !== qboCustomerId) {
+          console.warn(
+            `Client "${customerName.trim()}" (id=${byName[0].id}) already has qboCustomerId="${byName[0].qboCustomerId}" but invoice references qboCustomerId="${qboCustomerId}" — leaving existing mapping in place. Possible duplicate client.`
+          );
         }
         return byName[0].id;
       }
@@ -689,7 +693,7 @@ export class InvoiceImportService extends DatabaseService {
         return cd === ld || cd.includes(ld) || ld.includes(cd);
       };
       const amountMatches = (charge: OtherCharge) =>
-        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - amount) < 0.01;
+        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - amount) <= 0.01;
       const hits = candidateCharges.filter((c) => matchesDesc(c) && amountMatches(c));
       if (hits.length === 1) {
         materialMatches.push({
@@ -871,7 +875,7 @@ export class InvoiceImportService extends DatabaseService {
         return cd === ld || cd.includes(ld) || ld.includes(cd);
       };
       const amountMatches = (charge: OtherCharge) =>
-        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - ml.amount) < 0.01;
+        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - ml.amount) <= 0.01;
       const hits = candidateCharges.filter((c) => matchesDesc(c) && amountMatches(c));
       if (hits.length === 1) {
         materialDecisions.set(ml.lineId, { status: 'auto', otherChargeId: hits[0].id });

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -8,12 +8,14 @@ import {
   workActivities,
   notifications,
   type WorkActivity,
-  type OtherCharge
+  type OtherCharge,
+  type MatchCandidateJSON
 } from '../db';
 import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne } from 'drizzle-orm';
-import { services } from './container';
-import type { QBOInvoice } from './QuickBooksService';
-import { workTypeMapping } from './InvoiceService';
+import type { QBOInvoice, QuickBooksService } from './QuickBooksService';
+import { workTypeMapping, type InvoiceService } from './InvoiceService';
+import type { WorkActivityService } from './WorkActivityService';
+import type { NotificationService } from './NotificationService';
 
 // ---------------------------------------------------------------------------
 // Scoring thresholds — top of file so they're easy to tune.
@@ -61,15 +63,9 @@ export type ReviewQueueEntry = {
   candidates: MatchCandidate[] | null;
 };
 
-export type MatchCandidate = {
-  workActivityId: number;
-  score: number;
-  reason: string;
-  date: string;
-  workType: string;
-  billableHours: number | null;
-  notesSnippet: string;
-};
+// Re-export the persisted JSON shape under the in-service name for callers
+// that already import MatchCandidate from here.
+export type MatchCandidate = MatchCandidateJSON;
 
 export type RelinkSuccess = { ok: true };
 export type RelinkWarning = {
@@ -281,21 +277,49 @@ export function classifyLine(
 // Service
 // ---------------------------------------------------------------------------
 
-type LaborMatch = {
-  lineIndex: number;
+// Output of the matcher for a single labor line.
+type LaborDecision = {
   status: 'auto' | 'needs_review' | 'unmatched';
   workActivityId: number | null;
   matchScore: number | null;
   matchCandidates: MatchCandidate[] | null;
 };
 
-type MaterialMatch = {
-  lineIndex: number;
+// Output of the matcher for a single material line.
+type MaterialDecision = {
   status: 'auto' | 'unmatched';
   otherChargeId: number | null;
 };
 
+// Input shape for `runMatcher` — abstracts over whether the line came from
+// a live QBO invoice (key = lineIndex) or a persisted DB row (key = lineId).
+type NormalizedLine<K> = {
+  key: K;
+  qboItemId: string | null;
+  description: string;
+  qty: number | null;
+  amount: number;
+};
+
+type MatcherOutput<K> = {
+  laborDecisions: Map<K, LaborDecision>;
+  materialDecisions: Map<K, MaterialDecision>;
+};
+
 export class InvoiceImportService extends DatabaseService {
+  // Collaborators injected via the container — see services/container.ts.
+  // Holding references locally instead of reaching back into the container
+  // each call makes the service testable in isolation and avoids the
+  // module-level circular import the singleton pattern would introduce.
+  constructor(
+    private readonly quickBooksService: QuickBooksService,
+    private readonly invoiceService: InvoiceService,
+    private readonly workActivityService: WorkActivityService,
+    private readonly notificationService: NotificationService
+  ) {
+    super();
+  }
+
   // -----------------------------------------------------------------------
   // Public: syncAllInvoices
   // -----------------------------------------------------------------------
@@ -321,7 +345,7 @@ export class InvoiceImportService extends DatabaseService {
 
     let qboInvoices: QBOInvoice[];
     try {
-      qboInvoices = await services.quickBooksService.getAllInvoices();
+      qboInvoices = await this.quickBooksService.getAllInvoices();
     } catch (error) {
       result.errors.push({
         type: 'qbo_fetch_failed',
@@ -374,7 +398,7 @@ export class InvoiceImportService extends DatabaseService {
       await this.db
         .update(invoices)
         .set({
-          status: services.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+          status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
           totalAmount: qboInvoice.TotalAmt,
           dueDate: qboInvoice.DueDate || null,
           qboSyncAt: new Date(),
@@ -386,12 +410,16 @@ export class InvoiceImportService extends DatabaseService {
     }
 
     // INSERT path: persist invoice + line items + run matcher.
-    let matcherResult: {
-      laborMatches: LaborMatch[];
-      materialMatches: MaterialMatch[];
-    };
+    let matcherResult: MatcherOutput<number>;
     try {
-      matcherResult = await this.matchInvoiceLines(qboInvoice, clientId);
+      const lines: NormalizedLine<number>[] = qboInvoice.Line.map((line, lineIndex) => ({
+        key: lineIndex,
+        qboItemId: line.SalesItemLineDetail?.ItemRef?.value ?? null,
+        description: line.Description || '',
+        qty: line.SalesItemLineDetail?.Qty ?? null,
+        amount: line.Amount
+      }));
+      matcherResult = await this.runMatcher(lines, clientId, qboInvoice.TxnDate);
     } catch (error) {
       result.errors.push({
         type: 'matcher_failed',
@@ -399,16 +427,7 @@ export class InvoiceImportService extends DatabaseService {
         message: error instanceof Error ? error.message : String(error)
       });
       // Still insert the invoice with unmatched lines so the user has a record.
-      matcherResult = {
-        laborMatches: qboInvoice.Line.map((_line, lineIndex) => ({
-          lineIndex,
-          status: 'unmatched' as const,
-          workActivityId: null,
-          matchScore: null,
-          matchCandidates: null
-        })),
-        materialMatches: []
-      };
+      matcherResult = { laborDecisions: new Map(), materialDecisions: new Map() };
     }
 
     await this.db.transaction(async (tx) => {
@@ -419,7 +438,7 @@ export class InvoiceImportService extends DatabaseService {
           qboCustomerId: qboInvoice.CustomerRef.value,
           clientId,
           invoiceNumber: qboInvoice.DocNumber,
-          status: services.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+          status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
           totalAmount: qboInvoice.TotalAmt,
           invoiceDate: qboInvoice.TxnDate,
           dueDate: qboInvoice.DueDate || null,
@@ -428,47 +447,23 @@ export class InvoiceImportService extends DatabaseService {
         .returning();
       const localInvoiceId = inserted[0].id;
 
-      // Build line item rows from the QBO invoice. We index by lineIndex so
-      // we can layer matcher results on top regardless of whether each line
-      // was treated as labor or material.
-      const laborByIndex = new Map(matcherResult.laborMatches.map((m) => [m.lineIndex, m]));
-      const materialByIndex = new Map(matcherResult.materialMatches.map((m) => [m.lineIndex, m]));
-
+      // Build line item rows from the QBO invoice. Decisions are keyed by
+      // lineIndex; labor and material maps are mutually exclusive per line.
       const lineRows = qboInvoice.Line.map((line, lineIndex) => {
-        const labor = laborByIndex.get(lineIndex);
-        const material = materialByIndex.get(lineIndex);
-        const qboItemId = line.SalesItemLineDetail?.ItemRef?.value || null;
-        const qty = line.SalesItemLineDetail?.Qty ?? 0;
-        const rate = line.SalesItemLineDetail?.UnitPrice ?? 0;
-
-        let matchStatus: string = 'unmatched';
-        let workActivityId: number | null = null;
-        let otherChargeId: number | null = null;
-        let matchScore: number | null = null;
-        let matchCandidates: MatchCandidate[] | null = null;
-
-        if (labor) {
-          matchStatus = labor.status;
-          workActivityId = labor.workActivityId;
-          matchScore = labor.matchScore;
-          matchCandidates = labor.matchCandidates;
-        } else if (material) {
-          matchStatus = material.status;
-          otherChargeId = material.otherChargeId;
-        }
-
+        const labor = matcherResult.laborDecisions.get(lineIndex);
+        const material = matcherResult.materialDecisions.get(lineIndex);
         return {
           invoiceId: localInvoiceId,
-          workActivityId,
-          otherChargeId,
-          qboItemId,
+          workActivityId: labor?.workActivityId ?? null,
+          otherChargeId: material?.otherChargeId ?? null,
+          qboItemId: line.SalesItemLineDetail?.ItemRef?.value || null,
           description: line.Description || '',
-          quantity: qty,
-          rate,
+          quantity: line.SalesItemLineDetail?.Qty ?? 0,
+          rate: line.SalesItemLineDetail?.UnitPrice ?? 0,
           amount: line.Amount,
-          matchStatus,
-          matchScore,
-          matchCandidates: matchCandidates as any
+          matchStatus: labor?.status ?? material?.status ?? ('unmatched' as const),
+          matchScore: labor?.matchScore ?? null,
+          matchCandidates: labor?.matchCandidates ?? null
         };
       });
 
@@ -478,25 +473,20 @@ export class InvoiceImportService extends DatabaseService {
 
       // Flip status for any 'auto'-matched labor activities (materials don't
       // flip activity status — they live on already-completed activities).
-      const autoActivityIds = matcherResult.laborMatches
-        .filter((m) => m.status === 'auto' && m.workActivityId != null)
-        .map((m) => m.workActivityId as number);
+      const autoActivityIds: number[] = [];
+      for (const decision of matcherResult.laborDecisions.values()) {
+        if (decision.status === 'auto' && decision.workActivityId != null) {
+          autoActivityIds.push(decision.workActivityId);
+        }
+      }
       if (autoActivityIds.length > 0) {
-        await services.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
+        await this.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
       }
     });
 
     result.imported++;
-
-    for (const m of matcherResult.laborMatches) {
-      if (m.status === 'auto') result.autoMatched++;
-      else if (m.status === 'needs_review') result.needsReview++;
-      else result.unmatched++;
-    }
-    for (const m of matcherResult.materialMatches) {
-      if (m.status === 'auto') result.autoMatched++;
-      else result.unmatched++;
-    }
+    tallyLabor(matcherResult.laborDecisions, result);
+    tallyMaterial(matcherResult.materialDecisions, result);
   }
 
   /**
@@ -545,7 +535,7 @@ export class InvoiceImportService extends DatabaseService {
       qboInvoiceId: qboInvoice.Id,
       message
     });
-    await services.notificationService.notifyQBOUnmatchedClient({
+    await this.notificationService.notifyQBOUnmatchedClient({
       qboInvoiceId: qboInvoice.Id,
       qboInvoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
       qboCustomerId,
@@ -559,17 +549,25 @@ export class InvoiceImportService extends DatabaseService {
   // -----------------------------------------------------------------------
 
   /**
-   * Load candidate work activities + their charges and run the matcher for
-   * every line on the invoice. Implements within-invoice dedup for labor.
+   * Core matcher pipeline used by both initial sync (lines keyed by lineIndex)
+   * and rematch (lines keyed by lineId).
+   *
+   * For each line:
+   *   - Inventory / NonInventory items → material matching (description + amount fuzzy).
+   *   - Service / unknown items → labor matching (scoring against candidate activities).
+   *
+   * Within-invoice dedup: labor lines are processed in descending top-score
+   * order so the strongest match wins, and claimed activities are removed
+   * from the candidate pool of subsequent lines.
    */
-  private async matchInvoiceLines(
-    qboInvoice: QBOInvoice,
-    clientId: number
-  ): Promise<{ laborMatches: LaborMatch[]; materialMatches: MaterialMatch[] }> {
-    const invoiceDate = qboInvoice.TxnDate;
+  private async runMatcher<K>(
+    lines: NormalizedLine<K>[],
+    clientId: number,
+    invoiceDate: string
+  ): Promise<MatcherOutput<K>> {
     const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
 
-    // Candidate activities: same client, completed, within 90d window.
+    // Candidate activities: same client, completed, within window.
     const candidateActivities = (await this.db
       .select()
       .from(workActivities)
@@ -581,14 +579,11 @@ export class InvoiceImportService extends DatabaseService {
           lte(workActivities.date, invoiceDate)
         )
       )) as WorkActivity[];
+    const scoringActivities = candidateActivities.map(toScoringActivity);
 
-    // Classify lines into labor vs material using qbo_items.type.
+    // Resolve qbo_items types/names for the lines.
     const qboItemIds = Array.from(
-      new Set(
-        qboInvoice.Line
-          .map((l) => l.SalesItemLineDetail?.ItemRef?.value)
-          .filter((v): v is string => !!v)
-      )
+      new Set(lines.map((l) => l.qboItemId).filter((v): v is string => !!v))
     );
     const itemRows = qboItemIds.length
       ? await this.db.select().from(qboItems).where(inArray(qboItems.qboId, qboItemIds))
@@ -596,69 +591,52 @@ export class InvoiceImportService extends DatabaseService {
     const itemTypeById = new Map(itemRows.map((it) => [it.qboId, it.type]));
     const itemNameById = new Map(itemRows.map((it) => [it.qboId, it.name]));
 
-    // Score every line ↔ candidate pair for labor lines.
+    // Partition lines into labor vs material.
     const laborLines: Array<{
-      lineIndex: number;
+      key: K;
       scored: Array<{ activity: ScoringActivity; score: number; reason: string }>;
     }> = [];
-    const materialLines: Array<{
-      lineIndex: number;
-      qboLine: QBOInvoice['Line'][number];
-    }> = [];
+    const materialLines: Array<{ key: K; description: string; amount: number }> = [];
 
-    qboInvoice.Line.forEach((line, lineIndex) => {
-      const qboItemId = line.SalesItemLineDetail?.ItemRef?.value;
-      const itemType = qboItemId ? itemTypeById.get(qboItemId) : undefined;
-      const itemName = qboItemId ? itemNameById.get(qboItemId) : undefined;
-
+    for (const line of lines) {
+      const itemType = line.qboItemId ? itemTypeById.get(line.qboItemId) : undefined;
+      const itemName = line.qboItemId ? itemNameById.get(line.qboItemId) : undefined;
       if (itemType === 'Inventory' || itemType === 'NonInventory') {
-        materialLines.push({ lineIndex, qboLine: line });
-        return;
+        materialLines.push({ key: line.key, description: line.description, amount: line.amount });
+        continue;
       }
-      // Default to labor (Service or unknown).
       const scoringLine: ScoringLine = {
-        description: line.Description || '',
-        qty: line.SalesItemLineDetail?.Qty ?? null,
+        description: line.description,
+        qty: line.qty,
         qboItemName: itemName ?? null
       };
-      const scored = candidateActivities.map((activity) => ({
-        activity: toScoringActivity(activity),
-        ...scoreCandidate(toScoringActivity(activity), scoringLine, invoiceDate)
+      const scored = scoringActivities.map((sa) => ({
+        activity: sa,
+        ...scoreCandidate(sa, scoringLine, invoiceDate)
       }));
-      laborLines.push({ lineIndex, scored });
-    });
+      laborLines.push({ key: line.key, scored });
+    }
 
-    // Within-invoice dedup: process labor lines in descending top-score order
-    // so the strongest match wins ties, and remove claimed activities from the
-    // candidate pool of subsequent lines.
-    const claimedActivityIds = new Set<number>();
-    const laborMatches: LaborMatch[] = [];
-
-    // First, compute each line's current top score (before dedup) for ordering.
+    // Labor within-invoice dedup, descending top-score order.
     const orderedByTopScore = [...laborLines].sort((a, b) => {
       const ta = a.scored.length ? Math.max(...a.scored.map((s) => s.score)) : 0;
       const tb = b.scored.length ? Math.max(...b.scored.map((s) => s.score)) : 0;
       return tb - ta;
     });
 
-    for (const { lineIndex, scored } of orderedByTopScore) {
+    const claimedActivityIds = new Set<number>();
+    const laborDecisions = new Map<K, LaborDecision>();
+    for (const { key, scored } of orderedByTopScore) {
       const filtered = scored.filter((s) => !claimedActivityIds.has(s.activity.id));
-      const classification = classifyLine(filtered);
-      if (classification.status === 'auto' && classification.workActivityId != null) {
-        claimedActivityIds.add(classification.workActivityId);
+      const decision = classifyLine(filtered);
+      if (decision.status === 'auto' && decision.workActivityId != null) {
+        claimedActivityIds.add(decision.workActivityId);
       }
-      laborMatches.push({
-        lineIndex,
-        status: classification.status,
-        workActivityId: classification.workActivityId,
-        matchScore: classification.matchScore,
-        matchCandidates: classification.matchCandidates
-      });
+      laborDecisions.set(key, decision);
     }
 
-    // Material matching: for each material line, look for an other_charges row
-    // among candidate activities' charges whose description matches and whose
-    // totalCost is within $0.01. Auto-match only when exactly one such row exists.
+    // Material matching: candidate charges from the candidate activities.
+    // Auto-match only when exactly one charge matches both description and amount.
     const candidateActivityIds = candidateActivities.map((a) => a.id);
     const candidateCharges: OtherCharge[] = candidateActivityIds.length
       ? ((await this.db
@@ -667,36 +645,21 @@ export class InvoiceImportService extends DatabaseService {
           .where(inArray(otherCharges.workActivityId, candidateActivityIds))) as OtherCharge[])
       : [];
 
-    const materialMatches: MaterialMatch[] = [];
-    for (const { lineIndex, qboLine } of materialLines) {
-      const desc = (qboLine.Description || '').trim();
-      const amount = qboLine.Amount;
-      const matchesDesc = (charge: OtherCharge) => {
-        if (!desc) return false;
-        const cd = charge.description?.toLowerCase() || '';
-        const ld = desc.toLowerCase();
-        // ILIKE-ish: exact, contains, or contained-by.
-        return cd === ld || cd.includes(ld) || ld.includes(cd);
-      };
-      const amountMatches = (charge: OtherCharge) =>
-        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - amount) <= 0.01;
-      const hits = candidateCharges.filter((c) => matchesDesc(c) && amountMatches(c));
-      if (hits.length === 1) {
-        materialMatches.push({
-          lineIndex,
-          status: 'auto',
-          otherChargeId: hits[0].id
-        });
-      } else {
-        materialMatches.push({
-          lineIndex,
-          status: 'unmatched',
-          otherChargeId: null
-        });
-      }
+    const materialDecisions = new Map<K, MaterialDecision>();
+    for (const ml of materialLines) {
+      const desc = ml.description.trim();
+      const hits = desc
+        ? candidateCharges.filter((c) => matchCharge(c, desc, ml.amount))
+        : [];
+      materialDecisions.set(
+        ml.key,
+        hits.length === 1
+          ? { status: 'auto', otherChargeId: hits[0].id }
+          : { status: 'unmatched', otherChargeId: null }
+      );
     }
 
-    return { laborMatches, materialMatches };
+    return { laborDecisions, materialDecisions };
   }
 
   // -----------------------------------------------------------------------
@@ -745,128 +708,19 @@ export class InvoiceImportService extends DatabaseService {
       )
     );
 
-    // Build a synthetic QBOInvoice purely to feed the matcher.
-    const itemQboIds = Array.from(
-      new Set(
-        linesToRematch
-          .map((l) => l.qboItemId)
-          .filter((v): v is string => !!v)
-      )
+    // Run the matcher keyed by line id (vs the initial sync's lineIndex).
+    const normalizedLines: NormalizedLine<number>[] = linesToRematch.map((line) => ({
+      key: line.id,
+      qboItemId: line.qboItemId,
+      description: line.description,
+      qty: line.quantity ?? null,
+      amount: line.amount
+    }));
+    const { laborDecisions, materialDecisions } = await this.runMatcher(
+      normalizedLines,
+      invoice.clientId,
+      invoice.invoiceDate
     );
-    const itemRows = itemQboIds.length
-      ? await this.db.select().from(qboItems).where(inArray(qboItems.qboId, itemQboIds))
-      : [];
-    const itemTypeById = new Map(itemRows.map((it) => [it.qboId, it.type]));
-    const itemNameById = new Map(itemRows.map((it) => [it.qboId, it.name]));
-
-    // Re-score: candidate window from invoice date.
-    const invoiceDate = invoice.invoiceDate;
-    const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
-    const candidateActivities = (await this.db
-      .select()
-      .from(workActivities)
-      .where(
-        and(
-          eq(workActivities.clientId, invoice.clientId),
-          eq(workActivities.status, 'completed'),
-          gte(workActivities.date, windowStart),
-          lte(workActivities.date, invoiceDate)
-        )
-      )) as WorkActivity[];
-
-    // Partition lines into labor vs material based on item type.
-    const laborLines: Array<{
-      lineId: number;
-      qboItemId: string | null;
-      description: string;
-      qty: number | null;
-      scored: Array<{ activity: ScoringActivity; score: number; reason: string }>;
-    }> = [];
-    const materialLines: Array<{
-      lineId: number;
-      description: string;
-      amount: number;
-    }> = [];
-
-    for (const line of linesToRematch) {
-      const itemType = line.qboItemId ? itemTypeById.get(line.qboItemId) : undefined;
-      const itemName = line.qboItemId ? itemNameById.get(line.qboItemId) : undefined;
-      if (itemType === 'Inventory' || itemType === 'NonInventory') {
-        materialLines.push({
-          lineId: line.id,
-          description: line.description,
-          amount: line.amount
-        });
-        continue;
-      }
-      const sLine: ScoringLine = {
-        description: line.description,
-        qty: line.quantity ?? null,
-        qboItemName: itemName ?? null
-      };
-      const scored = candidateActivities.map((activity) => {
-        const sa = toScoringActivity(activity);
-        return { activity: sa, ...scoreCandidate(sa, sLine, invoiceDate) };
-      });
-      laborLines.push({
-        lineId: line.id,
-        qboItemId: line.qboItemId,
-        description: line.description,
-        qty: line.quantity ?? null,
-        scored
-      });
-    }
-
-    // Within-invoice dedup for the rematch — same algorithm as the initial sync.
-    const claimed = new Set<number>();
-    const ordered = [...laborLines].sort((a, b) => {
-      const ta = a.scored.length ? Math.max(...a.scored.map((s) => s.score)) : 0;
-      const tb = b.scored.length ? Math.max(...b.scored.map((s) => s.score)) : 0;
-      return tb - ta;
-    });
-    const laborDecisions = new Map<
-      number,
-      ReturnType<typeof classifyLine>
-    >();
-    for (const ll of ordered) {
-      const filtered = ll.scored.filter((s) => !claimed.has(s.activity.id));
-      const decision = classifyLine(filtered);
-      if (decision.status === 'auto' && decision.workActivityId != null) {
-        claimed.add(decision.workActivityId);
-      }
-      laborDecisions.set(ll.lineId, decision);
-    }
-
-    // Material rematch.
-    const candidateActivityIds = candidateActivities.map((a) => a.id);
-    const candidateCharges: OtherCharge[] = candidateActivityIds.length
-      ? ((await this.db
-          .select()
-          .from(otherCharges)
-          .where(inArray(otherCharges.workActivityId, candidateActivityIds))) as OtherCharge[])
-      : [];
-
-    const materialDecisions = new Map<
-      number,
-      { status: 'auto' | 'unmatched'; otherChargeId: number | null }
-    >();
-    for (const ml of materialLines) {
-      const desc = ml.description.trim();
-      const matchesDesc = (charge: OtherCharge) => {
-        if (!desc) return false;
-        const cd = charge.description?.toLowerCase() || '';
-        const ld = desc.toLowerCase();
-        return cd === ld || cd.includes(ld) || ld.includes(cd);
-      };
-      const amountMatches = (charge: OtherCharge) =>
-        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - ml.amount) <= 0.01;
-      const hits = candidateCharges.filter((c) => matchesDesc(c) && amountMatches(c));
-      if (hits.length === 1) {
-        materialDecisions.set(ml.lineId, { status: 'auto', otherChargeId: hits[0].id });
-      } else {
-        materialDecisions.set(ml.lineId, { status: 'unmatched', otherChargeId: null });
-      }
-    }
 
     // Apply decisions in a single transaction: clear the old lines, write
     // new state, flip activity statuses.
@@ -902,7 +756,7 @@ export class InvoiceImportService extends DatabaseService {
             workActivityId: decision.workActivityId,
             matchStatus: decision.status,
             matchScore: decision.matchScore,
-            matchCandidates: (decision.matchCandidates ?? null) as any,
+            matchCandidates: decision.matchCandidates ?? null,
             updatedAt: new Date()
           })
           .where(eq(invoiceLineItems.id, lineId));
@@ -935,7 +789,7 @@ export class InvoiceImportService extends DatabaseService {
 
       // 5) Flip newly auto-matched activities to 'invoiced'.
       if (newAutoActivityIds.length > 0) {
-        await services.workActivityService.setStatus(newAutoActivityIds, 'invoiced', tx);
+        await this.workActivityService.setStatus(newAutoActivityIds, 'invoiced', tx);
       }
     });
 
@@ -1026,7 +880,7 @@ export class InvoiceImportService extends DatabaseService {
           .where(eq(workActivities.id, workActivityId))
           .limit(1);
         if (current[0] && current[0].status !== 'invoiced') {
-          await services.workActivityService.setStatus([workActivityId], 'invoiced', tx);
+          await this.workActivityService.setStatus([workActivityId], 'invoiced', tx);
         }
       }
 
@@ -1059,7 +913,7 @@ export class InvoiceImportService extends DatabaseService {
             workActivityId,
             lineItemId,
             invoiceIds: allInvoiceIds
-          } as any
+          }
         });
       }
     });
@@ -1106,7 +960,7 @@ export class InvoiceImportService extends DatabaseService {
       quantity: r.quantity,
       rate: r.rate,
       amount: r.amount,
-      candidates: (r.candidates as MatchCandidate[] | null) ?? null
+      candidates: r.candidates ?? null
     }));
   }
 
@@ -1138,7 +992,7 @@ export class InvoiceImportService extends DatabaseService {
     );
     const orphaned = unique.filter((id) => !referenced.has(id));
     if (orphaned.length > 0) {
-      await services.workActivityService.setStatus(orphaned, 'completed', tx);
+      await this.workActivityService.setStatus(orphaned, 'completed', tx);
     }
   }
 }
@@ -1170,4 +1024,36 @@ function toScoringActivity(activity: WorkActivity): ScoringActivity {
     notes: activity.notes ?? null,
     tasks: activity.tasks ?? null
   };
+}
+
+/**
+ * Material-line predicate: description matches fuzzily (exact, contains, or
+ * contained-by, case-insensitive) AND totalCost is within $0.01 of the line.
+ */
+function matchCharge(charge: OtherCharge, desc: string, amount: number): boolean {
+  const cd = charge.description?.toLowerCase() || '';
+  const ld = desc.toLowerCase();
+  if (!(cd === ld || cd.includes(ld) || ld.includes(cd))) return false;
+  return typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - amount) <= 0.01;
+}
+
+function tallyLabor(
+  decisions: Map<unknown, LaborDecision>,
+  result: { autoMatched: number; needsReview: number; unmatched: number }
+): void {
+  for (const d of decisions.values()) {
+    if (d.status === 'auto') result.autoMatched++;
+    else if (d.status === 'needs_review') result.needsReview++;
+    else result.unmatched++;
+  }
+}
+
+function tallyMaterial(
+  decisions: Map<unknown, MaterialDecision>,
+  result: { autoMatched: number; unmatched: number }
+): void {
+  for (const d of decisions.values()) {
+    if (d.status === 'auto') result.autoMatched++;
+    else result.unmatched++;
+  }
 }

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -48,6 +48,31 @@ export type SyncResult = {
     qboInvoiceId?: string;
     message: string;
   }>;
+  // Set to true when the run was a dry run — NO database changes were made.
+  dryRun?: boolean;
+  // Per-invoice breakdown of what WOULD happen. Only populated on dry runs so
+  // the operator can judge match quality before committing real writes.
+  preview?: SyncPreviewInvoice[];
+};
+
+export type SyncPreviewLine = {
+  description: string;
+  amount: number;
+  kind: 'labor' | 'material';
+  status: 'auto' | 'needs_review' | 'unmatched';
+  // For auto/needs_review labor: the top candidate's activity id + score.
+  matchedActivityId: number | null;
+  matchScore: number | null;
+};
+
+export type SyncPreviewInvoice = {
+  qboInvoiceId: string;
+  invoiceNumber: string;
+  customerName: string;
+  // 'import' = new invoice would be created; 'update' = existing invoice's
+  // status/total would refresh (line items untouched); 'skip' = no client match.
+  action: 'import' | 'update' | 'skip';
+  lines: SyncPreviewLine[];
 };
 
 export type ReviewQueueEntry = {
@@ -332,15 +357,21 @@ export class InvoiceImportService extends DatabaseService {
    *
    * Errors on a single invoice never abort the whole sync — they get pushed
    * into `result.errors` and processing continues.
+   *
+   * When `dryRun` is true, NO database writes happen: the matcher still runs
+   * and the same counts are returned, plus a per-invoice `preview`, so the
+   * operator can evaluate match quality before committing.
    */
-  async syncAllInvoices(opts?: { since?: string }): Promise<SyncResult> {
+  async syncAllInvoices(opts?: { since?: string; dryRun?: boolean }): Promise<SyncResult> {
+    const dryRun = opts?.dryRun ?? false;
     const result: SyncResult = {
       imported: 0,
       updated: 0,
       autoMatched: 0,
       needsReview: 0,
       unmatched: 0,
-      errors: []
+      errors: [],
+      ...(dryRun ? { dryRun: true, preview: [] } : {})
     };
 
     let qboInvoices: QBOInvoice[];
@@ -363,9 +394,15 @@ export class InvoiceImportService extends DatabaseService {
     // Without this, matcher results vary with QBO's response order.
     qboInvoices.sort((a, b) => (a.TxnDate || '').localeCompare(b.TxnDate || ''));
 
+    // In a real run, cross-invoice dedup happens because each auto-match flips
+    // the activity to 'invoiced' before the next invoice's candidate query runs.
+    // A dry run commits nothing, so we track claimed ids in memory and exclude
+    // them from later invoices' candidate pools — making the preview faithful.
+    const claimedInRun = dryRun ? new Set<number>() : undefined;
+
     for (const qboInvoice of qboInvoices) {
       try {
-        await this.processInvoice(qboInvoice, result);
+        await this.processInvoice(qboInvoice, result, dryRun, claimedInRun);
       } catch (error) {
         result.errors.push({
           type: 'invoice_persist_failed',
@@ -381,10 +418,29 @@ export class InvoiceImportService extends DatabaseService {
   /**
    * Process one QBO invoice: resolve client, upsert invoice, run matcher for
    * inserts, flip activity statuses inside the same transaction.
+   *
+   * `dryRun` skips every write; `claimedInRun` (dry-run only) tracks activities
+   * already auto-claimed earlier in the run so the preview doesn't double-count.
    */
-  private async processInvoice(qboInvoice: QBOInvoice, result: SyncResult): Promise<void> {
-    const clientId = await this.resolveClientId(qboInvoice, result);
-    if (clientId == null) return;
+  private async processInvoice(
+    qboInvoice: QBOInvoice,
+    result: SyncResult,
+    dryRun: boolean,
+    claimedInRun?: Set<number>
+  ): Promise<void> {
+    const clientId = await this.resolveClientId(qboInvoice, result, dryRun);
+    if (clientId == null) {
+      if (dryRun) {
+        result.preview!.push({
+          qboInvoiceId: qboInvoice.Id,
+          invoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
+          customerName: qboInvoice.CustomerRef.name || '',
+          action: 'skip',
+          lines: []
+        });
+      }
+      return;
+    }
 
     const existing = await this.db
       .select()
@@ -395,17 +451,28 @@ export class InvoiceImportService extends DatabaseService {
     if (existing[0]) {
       // UPDATE path: refresh metadata only; do NOT rewrite line items so we
       // don't blow away 'manual' relinks the user has made since import.
-      await this.db
-        .update(invoices)
-        .set({
-          status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
-          totalAmount: qboInvoice.TotalAmt,
-          dueDate: qboInvoice.DueDate || null,
-          qboSyncAt: new Date(),
-          updatedAt: new Date()
-        })
-        .where(eq(invoices.id, existing[0].id));
+      if (!dryRun) {
+        await this.db
+          .update(invoices)
+          .set({
+            status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+            totalAmount: qboInvoice.TotalAmt,
+            dueDate: qboInvoice.DueDate || null,
+            qboSyncAt: new Date(),
+            updatedAt: new Date()
+          })
+          .where(eq(invoices.id, existing[0].id));
+      }
       result.updated++;
+      if (dryRun) {
+        result.preview!.push({
+          qboInvoiceId: qboInvoice.Id,
+          invoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
+          customerName: qboInvoice.CustomerRef.name || '',
+          action: 'update',
+          lines: []
+        });
+      }
       return;
     }
 
@@ -419,7 +486,7 @@ export class InvoiceImportService extends DatabaseService {
         qty: line.SalesItemLineDetail?.Qty ?? null,
         amount: line.Amount
       }));
-      matcherResult = await this.runMatcher(lines, clientId, qboInvoice.TxnDate);
+      matcherResult = await this.runMatcher(lines, clientId, qboInvoice.TxnDate, claimedInRun);
     } catch (error) {
       result.errors.push({
         type: 'matcher_failed',
@@ -430,59 +497,67 @@ export class InvoiceImportService extends DatabaseService {
       matcherResult = { laborDecisions: new Map(), materialDecisions: new Map() };
     }
 
-    await this.db.transaction(async (tx) => {
-      const inserted = await tx
-        .insert(invoices)
-        .values({
-          qboInvoiceId: qboInvoice.Id,
-          qboCustomerId: qboInvoice.CustomerRef.value,
-          clientId,
-          invoiceNumber: qboInvoice.DocNumber,
-          status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
-          totalAmount: qboInvoice.TotalAmt,
-          invoiceDate: qboInvoice.TxnDate,
-          dueDate: qboInvoice.DueDate || null,
-          qboSyncAt: new Date()
-        })
-        .returning();
-      const localInvoiceId = inserted[0].id;
-
-      // Build line item rows from the QBO invoice. Decisions are keyed by
-      // lineIndex; labor and material maps are mutually exclusive per line.
-      const lineRows = qboInvoice.Line.map((line, lineIndex) => {
-        const labor = matcherResult.laborDecisions.get(lineIndex);
-        const material = matcherResult.materialDecisions.get(lineIndex);
-        return {
-          invoiceId: localInvoiceId,
-          workActivityId: labor?.workActivityId ?? null,
-          otherChargeId: material?.otherChargeId ?? null,
-          qboItemId: line.SalesItemLineDetail?.ItemRef?.value || null,
-          description: line.Description || '',
-          quantity: line.SalesItemLineDetail?.Qty ?? 0,
-          rate: line.SalesItemLineDetail?.UnitPrice ?? 0,
-          amount: line.Amount,
-          matchStatus: labor?.status ?? material?.status ?? ('unmatched' as const),
-          matchScore: labor?.matchScore ?? null,
-          matchCandidates: labor?.matchCandidates ?? null
-        };
-      });
-
-      if (lineRows.length > 0) {
-        await tx.insert(invoiceLineItems).values(lineRows);
+    // Activities auto-matched on this invoice — flipped to 'invoiced' in a real
+    // run, or recorded as claimed in a dry run so later invoices skip them.
+    const autoActivityIds: number[] = [];
+    for (const decision of matcherResult.laborDecisions.values()) {
+      if (decision.status === 'auto' && decision.workActivityId != null) {
+        autoActivityIds.push(decision.workActivityId);
       }
+    }
 
-      // Flip status for any 'auto'-matched labor activities (materials don't
-      // flip activity status — they live on already-completed activities).
-      const autoActivityIds: number[] = [];
-      for (const decision of matcherResult.laborDecisions.values()) {
-        if (decision.status === 'auto' && decision.workActivityId != null) {
-          autoActivityIds.push(decision.workActivityId);
+    if (dryRun) {
+      autoActivityIds.forEach((id) => claimedInRun?.add(id));
+      result.preview!.push(buildPreviewInvoice(qboInvoice, matcherResult));
+    } else {
+      await this.db.transaction(async (tx) => {
+        const inserted = await tx
+          .insert(invoices)
+          .values({
+            qboInvoiceId: qboInvoice.Id,
+            qboCustomerId: qboInvoice.CustomerRef.value,
+            clientId,
+            invoiceNumber: qboInvoice.DocNumber,
+            status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+            totalAmount: qboInvoice.TotalAmt,
+            invoiceDate: qboInvoice.TxnDate,
+            dueDate: qboInvoice.DueDate || null,
+            qboSyncAt: new Date()
+          })
+          .returning();
+        const localInvoiceId = inserted[0].id;
+
+        // Build line item rows from the QBO invoice. Decisions are keyed by
+        // lineIndex; labor and material maps are mutually exclusive per line.
+        const lineRows = qboInvoice.Line.map((line, lineIndex) => {
+          const labor = matcherResult.laborDecisions.get(lineIndex);
+          const material = matcherResult.materialDecisions.get(lineIndex);
+          return {
+            invoiceId: localInvoiceId,
+            workActivityId: labor?.workActivityId ?? null,
+            otherChargeId: material?.otherChargeId ?? null,
+            qboItemId: line.SalesItemLineDetail?.ItemRef?.value || null,
+            description: line.Description || '',
+            quantity: line.SalesItemLineDetail?.Qty ?? 0,
+            rate: line.SalesItemLineDetail?.UnitPrice ?? 0,
+            amount: line.Amount,
+            matchStatus: labor?.status ?? material?.status ?? ('unmatched' as const),
+            matchScore: labor?.matchScore ?? null,
+            matchCandidates: labor?.matchCandidates ?? null
+          };
+        });
+
+        if (lineRows.length > 0) {
+          await tx.insert(invoiceLineItems).values(lineRows);
         }
-      }
-      if (autoActivityIds.length > 0) {
-        await this.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
-      }
-    });
+
+        // Flip status for any 'auto'-matched labor activities (materials don't
+        // flip activity status — they live on already-completed activities).
+        if (autoActivityIds.length > 0) {
+          await this.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
+        }
+      });
+    }
 
     result.imported++;
     tallyLabor(matcherResult.laborDecisions, result);
@@ -494,7 +569,11 @@ export class InvoiceImportService extends DatabaseService {
    * case-insensitive name match (with opportunistic backfill). Returns null
    * and writes an `unmatched_client` notification when no match is found.
    */
-  private async resolveClientId(qboInvoice: QBOInvoice, result: SyncResult): Promise<number | null> {
+  private async resolveClientId(
+    qboInvoice: QBOInvoice,
+    result: SyncResult,
+    dryRun: boolean
+  ): Promise<number | null> {
     const qboCustomerId = qboInvoice.CustomerRef.value;
     const customerName = qboInvoice.CustomerRef.name || '';
 
@@ -515,10 +594,13 @@ export class InvoiceImportService extends DatabaseService {
         .limit(1);
       if (byName[0]) {
         if (!byName[0].qboCustomerId) {
-          await this.db
-            .update(clients)
-            .set({ qboCustomerId, updatedAt: new Date() })
-            .where(eq(clients.id, byName[0].id));
+          // Backfill is a write — skip it on a dry run.
+          if (!dryRun) {
+            await this.db
+              .update(clients)
+              .set({ qboCustomerId, updatedAt: new Date() })
+              .where(eq(clients.id, byName[0].id));
+          }
         } else if (byName[0].qboCustomerId !== qboCustomerId) {
           console.warn(
             `Client "${customerName.trim()}" (id=${byName[0].id}) already has qboCustomerId="${byName[0].qboCustomerId}" but invoice references qboCustomerId="${qboCustomerId}" — leaving existing mapping in place. Possible duplicate client.`
@@ -528,19 +610,21 @@ export class InvoiceImportService extends DatabaseService {
       }
     }
 
-    // 3) No match — record an error + notification.
+    // 3) No match — record an error (and, on a real run, a notification).
     const message = `No local client matches "${customerName}"`;
     result.errors.push({
       type: 'unmatched_client',
       qboInvoiceId: qboInvoice.Id,
       message
     });
-    await this.notificationService.notifyQBOUnmatchedClient({
-      qboInvoiceId: qboInvoice.Id,
-      qboInvoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
-      qboCustomerId,
-      customerName
-    });
+    if (!dryRun) {
+      await this.notificationService.notifyQBOUnmatchedClient({
+        qboInvoiceId: qboInvoice.Id,
+        qboInvoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
+        qboCustomerId,
+        customerName
+      });
+    }
     return null;
   }
 
@@ -559,16 +643,22 @@ export class InvoiceImportService extends DatabaseService {
    * Within-invoice dedup: labor lines are processed in descending top-score
    * order so the strongest match wins, and claimed activities are removed
    * from the candidate pool of subsequent lines.
+   *
+   * `excludeActivityIds` removes activities already claimed earlier in the run.
+   * A real sync achieves this implicitly (claimed activities are flipped to
+   * 'invoiced' and so drop out of the next candidate query); a dry run passes
+   * the set explicitly because it commits nothing.
    */
   private async runMatcher<K>(
     lines: NormalizedLine<K>[],
     clientId: number,
-    invoiceDate: string
+    invoiceDate: string,
+    excludeActivityIds?: Set<number>
   ): Promise<MatcherOutput<K>> {
     const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
 
     // Candidate activities: same client, completed, within window.
-    const candidateActivities = (await this.db
+    const candidateRows = (await this.db
       .select()
       .from(workActivities)
       .where(
@@ -579,6 +669,9 @@ export class InvoiceImportService extends DatabaseService {
           lte(workActivities.date, invoiceDate)
         )
       )) as WorkActivity[];
+    const candidateActivities = excludeActivityIds?.size
+      ? candidateRows.filter((a) => !excludeActivityIds.has(a.id))
+      : candidateRows;
     const scoringActivities = candidateActivities.map(toScoringActivity);
 
     // Resolve qbo_items types/names for the lines.
@@ -1056,4 +1149,34 @@ function tallyMaterial(
     if (d.status === 'auto') result.autoMatched++;
     else result.unmatched++;
   }
+}
+
+/**
+ * Build the per-invoice dry-run preview from a QBO invoice and its matcher
+ * output. Decisions are keyed by line index; a line is labor or material
+ * depending on which map holds it.
+ */
+function buildPreviewInvoice(
+  qboInvoice: QBOInvoice,
+  matcherResult: MatcherOutput<number>
+): SyncPreviewInvoice {
+  const lines: SyncPreviewLine[] = qboInvoice.Line.map((line, lineIndex) => {
+    const labor = matcherResult.laborDecisions.get(lineIndex);
+    const material = matcherResult.materialDecisions.get(lineIndex);
+    return {
+      description: line.Description || '',
+      amount: line.Amount,
+      kind: material ? 'material' : 'labor',
+      status: labor?.status ?? material?.status ?? 'unmatched',
+      matchedActivityId: labor?.workActivityId ?? null,
+      matchScore: labor?.matchScore ?? null
+    };
+  });
+  return {
+    qboInvoiceId: qboInvoice.Id,
+    invoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
+    customerName: qboInvoice.CustomerRef.name || '',
+    action: 'import',
+    lines
+  };
 }

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -53,6 +53,21 @@ export type SyncResult = {
   // Per-invoice breakdown of what WOULD happen. Only populated on dry runs so
   // the operator can judge match quality before committing real writes.
   preview?: SyncPreviewInvoice[];
+  // Cross-invoice collisions: the same work activity strongly matched more than
+  // one invoice in this run. Only populated on dry runs. A real run resolves
+  // these by giving the activity to the older invoice (processed first) and
+  // leaving the newer one to manual review — so these are quality signals worth
+  // eyeballing, not hard failures.
+  duplicateMatches?: DuplicateMatch[];
+};
+
+export type DuplicateMatch = {
+  activityId: number;
+  lineDescription: string;
+  // The newer invoice that would NOT get the activity in a real run.
+  invoiceNumber: string;
+  // The older invoice that claims the activity first.
+  claimedByInvoiceNumber: string;
 };
 
 export type SyncPreviewLine = {
@@ -63,6 +78,9 @@ export type SyncPreviewLine = {
   // For auto/needs_review labor: the top candidate's activity id + score.
   matchedActivityId: number | null;
   matchScore: number | null;
+  // Set when this line's auto-match collides with an activity already claimed
+  // by an earlier (older) invoice in the same run — value is that invoice number.
+  duplicateOf?: string;
 };
 
 export type SyncPreviewInvoice = {
@@ -371,7 +389,7 @@ export class InvoiceImportService extends DatabaseService {
       needsReview: 0,
       unmatched: 0,
       errors: [],
-      ...(dryRun ? { dryRun: true, preview: [] } : {})
+      ...(dryRun ? { dryRun: true, preview: [], duplicateMatches: [] } : {})
     };
 
     let qboInvoices: QBOInvoice[];
@@ -395,10 +413,12 @@ export class InvoiceImportService extends DatabaseService {
     qboInvoices.sort((a, b) => (a.TxnDate || '').localeCompare(b.TxnDate || ''));
 
     // In a real run, cross-invoice dedup happens because each auto-match flips
-    // the activity to 'invoiced' before the next invoice's candidate query runs.
-    // A dry run commits nothing, so we track claimed ids in memory and exclude
-    // them from later invoices' candidate pools — making the preview faithful.
-    const claimedInRun = dryRun ? new Set<number>() : undefined;
+    // the activity to 'invoiced' before the next invoice's candidate query runs,
+    // so the older invoice (processed first) wins. A dry run commits nothing, so
+    // we track who claimed each activity in memory: activityId → claimer invoice
+    // number. Later invoices that also auto-match a claimed activity are flagged
+    // as duplicates rather than silently double-counting it.
+    const claimedInRun = dryRun ? new Map<number, string>() : undefined;
 
     for (const qboInvoice of qboInvoices) {
       try {
@@ -426,7 +446,7 @@ export class InvoiceImportService extends DatabaseService {
     qboInvoice: QBOInvoice,
     result: SyncResult,
     dryRun: boolean,
-    claimedInRun?: Set<number>
+    claimedInRun?: Map<number, string>
   ): Promise<void> {
     const clientId = await this.resolveClientId(qboInvoice, result, dryRun);
     if (clientId == null) {
@@ -486,7 +506,7 @@ export class InvoiceImportService extends DatabaseService {
         qty: line.SalesItemLineDetail?.Qty ?? null,
         amount: line.Amount
       }));
-      matcherResult = await this.runMatcher(lines, clientId, qboInvoice.TxnDate, claimedInRun);
+      matcherResult = await this.runMatcher(lines, clientId, qboInvoice.TxnDate);
     } catch (error) {
       result.errors.push({
         type: 'matcher_failed',
@@ -497,8 +517,31 @@ export class InvoiceImportService extends DatabaseService {
       matcherResult = { laborDecisions: new Map(), materialDecisions: new Map() };
     }
 
-    // Activities auto-matched on this invoice — flipped to 'invoiced' in a real
-    // run, or recorded as claimed in a dry run so later invoices skip them.
+    // Labor lines that auto-matched an activity already claimed by an earlier
+    // (older) invoice in this dry run. Keyed by line index → older claimer.
+    const invoiceNumber = qboInvoice.DocNumber || qboInvoice.Id;
+    const duplicateLines = new Map<number, string>();
+    if (dryRun && claimedInRun) {
+      for (const [lineIndex, decision] of matcherResult.laborDecisions) {
+        if (decision.status !== 'auto' || decision.workActivityId == null) continue;
+        const claimer = claimedInRun.get(decision.workActivityId);
+        if (claimer) {
+          // Already claimed by an older invoice → flag, don't re-claim.
+          duplicateLines.set(lineIndex, claimer);
+          result.duplicateMatches!.push({
+            activityId: decision.workActivityId,
+            lineDescription: qboInvoice.Line[lineIndex]?.Description || '',
+            invoiceNumber,
+            claimedByInvoiceNumber: claimer
+          });
+        } else {
+          // First (oldest) invoice to claim this activity wins it.
+          claimedInRun.set(decision.workActivityId, invoiceNumber);
+        }
+      }
+    }
+
+    // Activities auto-matched on this invoice — flipped to 'invoiced' in a real run.
     const autoActivityIds: number[] = [];
     for (const decision of matcherResult.laborDecisions.values()) {
       if (decision.status === 'auto' && decision.workActivityId != null) {
@@ -507,57 +550,61 @@ export class InvoiceImportService extends DatabaseService {
     }
 
     if (dryRun) {
-      autoActivityIds.forEach((id) => claimedInRun?.add(id));
-      result.preview!.push(buildPreviewInvoice(qboInvoice, matcherResult));
-    } else {
-      await this.db.transaction(async (tx) => {
-        const inserted = await tx
-          .insert(invoices)
-          .values({
-            qboInvoiceId: qboInvoice.Id,
-            qboCustomerId: qboInvoice.CustomerRef.value,
-            clientId,
-            invoiceNumber: qboInvoice.DocNumber,
-            status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
-            totalAmount: qboInvoice.TotalAmt,
-            invoiceDate: qboInvoice.TxnDate,
-            dueDate: qboInvoice.DueDate || null,
-            qboSyncAt: new Date()
-          })
-          .returning();
-        const localInvoiceId = inserted[0].id;
-
-        // Build line item rows from the QBO invoice. Decisions are keyed by
-        // lineIndex; labor and material maps are mutually exclusive per line.
-        const lineRows = qboInvoice.Line.map((line, lineIndex) => {
-          const labor = matcherResult.laborDecisions.get(lineIndex);
-          const material = matcherResult.materialDecisions.get(lineIndex);
-          return {
-            invoiceId: localInvoiceId,
-            workActivityId: labor?.workActivityId ?? null,
-            otherChargeId: material?.otherChargeId ?? null,
-            qboItemId: line.SalesItemLineDetail?.ItemRef?.value || null,
-            description: line.Description || '',
-            quantity: line.SalesItemLineDetail?.Qty ?? 0,
-            rate: line.SalesItemLineDetail?.UnitPrice ?? 0,
-            amount: line.Amount,
-            matchStatus: labor?.status ?? material?.status ?? ('unmatched' as const),
-            matchScore: labor?.matchScore ?? null,
-            matchCandidates: labor?.matchCandidates ?? null
-          };
-        });
-
-        if (lineRows.length > 0) {
-          await tx.insert(invoiceLineItems).values(lineRows);
-        }
-
-        // Flip status for any 'auto'-matched labor activities (materials don't
-        // flip activity status — they live on already-completed activities).
-        if (autoActivityIds.length > 0) {
-          await this.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
-        }
-      });
+      result.preview!.push(buildPreviewInvoice(qboInvoice, matcherResult, duplicateLines));
+      tallyLabor(matcherResult.laborDecisions, result, duplicateLines);
+      tallyMaterial(matcherResult.materialDecisions, result);
+      result.imported++;
+      return;
     }
+
+    // Real run: persist invoice + line items, flip activity statuses atomically.
+    await this.db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(invoices)
+        .values({
+          qboInvoiceId: qboInvoice.Id,
+          qboCustomerId: qboInvoice.CustomerRef.value,
+          clientId,
+          invoiceNumber: qboInvoice.DocNumber,
+          status: this.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+          totalAmount: qboInvoice.TotalAmt,
+          invoiceDate: qboInvoice.TxnDate,
+          dueDate: qboInvoice.DueDate || null,
+          qboSyncAt: new Date()
+        })
+        .returning();
+      const localInvoiceId = inserted[0].id;
+
+      // Build line item rows from the QBO invoice. Decisions are keyed by
+      // lineIndex; labor and material maps are mutually exclusive per line.
+      const lineRows = qboInvoice.Line.map((line, lineIndex) => {
+        const labor = matcherResult.laborDecisions.get(lineIndex);
+        const material = matcherResult.materialDecisions.get(lineIndex);
+        return {
+          invoiceId: localInvoiceId,
+          workActivityId: labor?.workActivityId ?? null,
+          otherChargeId: material?.otherChargeId ?? null,
+          qboItemId: line.SalesItemLineDetail?.ItemRef?.value || null,
+          description: line.Description || '',
+          quantity: line.SalesItemLineDetail?.Qty ?? 0,
+          rate: line.SalesItemLineDetail?.UnitPrice ?? 0,
+          amount: line.Amount,
+          matchStatus: labor?.status ?? material?.status ?? ('unmatched' as const),
+          matchScore: labor?.matchScore ?? null,
+          matchCandidates: labor?.matchCandidates ?? null
+        };
+      });
+
+      if (lineRows.length > 0) {
+        await tx.insert(invoiceLineItems).values(lineRows);
+      }
+
+      // Flip status for any 'auto'-matched labor activities (materials don't
+      // flip activity status — they live on already-completed activities).
+      if (autoActivityIds.length > 0) {
+        await this.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
+      }
+    });
 
     result.imported++;
     tallyLabor(matcherResult.laborDecisions, result);
@@ -644,21 +691,20 @@ export class InvoiceImportService extends DatabaseService {
    * order so the strongest match wins, and claimed activities are removed
    * from the candidate pool of subsequent lines.
    *
-   * `excludeActivityIds` removes activities already claimed earlier in the run.
-   * A real sync achieves this implicitly (claimed activities are flipped to
-   * 'invoiced' and so drop out of the next candidate query); a dry run passes
-   * the set explicitly because it commits nothing.
+   * This matches the full candidate pool every time. Cross-invoice dedup lives
+   * at the caller: a real sync flips claimed activities to 'invoiced' so they
+   * drop out of the next invoice's candidate query; a dry run reconciles claims
+   * in memory (see processInvoice) and flags collisions as duplicate matches.
    */
   private async runMatcher<K>(
     lines: NormalizedLine<K>[],
     clientId: number,
-    invoiceDate: string,
-    excludeActivityIds?: Set<number>
+    invoiceDate: string
   ): Promise<MatcherOutput<K>> {
     const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
 
     // Candidate activities: same client, completed, within window.
-    const candidateRows = (await this.db
+    const candidateActivities = (await this.db
       .select()
       .from(workActivities)
       .where(
@@ -669,9 +715,6 @@ export class InvoiceImportService extends DatabaseService {
           lte(workActivities.date, invoiceDate)
         )
       )) as WorkActivity[];
-    const candidateActivities = excludeActivityIds?.size
-      ? candidateRows.filter((a) => !excludeActivityIds.has(a.id))
-      : candidateRows;
     const scoringActivities = candidateActivities.map(toScoringActivity);
 
     // Resolve qbo_items types/names for the lines.
@@ -1130,11 +1173,16 @@ function matchCharge(charge: OtherCharge, desc: string, amount: number): boolean
   return typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - amount) <= 0.01;
 }
 
-function tallyLabor(
-  decisions: Map<unknown, LaborDecision>,
-  result: { autoMatched: number; needsReview: number; unmatched: number }
+function tallyLabor<K>(
+  decisions: Map<K, LaborDecision>,
+  result: { autoMatched: number; needsReview: number; unmatched: number },
+  // Dry-run only: line keys whose auto-match collides with an older invoice.
+  // These are NOT counted as auto-matched (the older invoice keeps the
+  // activity); they're surfaced via result.duplicateMatches instead.
+  duplicateLines?: Map<K, string>
 ): void {
-  for (const d of decisions.values()) {
+  for (const [key, d] of decisions) {
+    if (duplicateLines?.has(key)) continue;
     if (d.status === 'auto') result.autoMatched++;
     else if (d.status === 'needs_review') result.needsReview++;
     else result.unmatched++;
@@ -1158,7 +1206,8 @@ function tallyMaterial(
  */
 function buildPreviewInvoice(
   qboInvoice: QBOInvoice,
-  matcherResult: MatcherOutput<number>
+  matcherResult: MatcherOutput<number>,
+  duplicateLines?: Map<number, string>
 ): SyncPreviewInvoice {
   const lines: SyncPreviewLine[] = qboInvoice.Line.map((line, lineIndex) => {
     const labor = matcherResult.laborDecisions.get(lineIndex);
@@ -1169,7 +1218,8 @@ function buildPreviewInvoice(
       kind: material ? 'material' : 'labor',
       status: labor?.status ?? material?.status ?? 'unmatched',
       matchedActivityId: labor?.workActivityId ?? null,
-      matchScore: labor?.matchScore ?? null
+      matchScore: labor?.matchScore ?? null,
+      ...(duplicateLines?.has(lineIndex) ? { duplicateOf: duplicateLines.get(lineIndex) } : {})
     };
   });
   return {

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -10,7 +10,7 @@ import {
   type WorkActivity,
   type OtherCharge
 } from '../db';
-import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne, or, sql } from 'drizzle-orm';
+import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne } from 'drizzle-orm';
 import { services } from './container';
 import type { QBOInvoice } from './QuickBooksService';
 import { workTypeMapping } from './InvoiceService';
@@ -281,9 +281,8 @@ export function classifyLine(
 // Service
 // ---------------------------------------------------------------------------
 
-type LabororMatch = {
+type LaborMatch = {
   lineIndex: number;
-  qboLine: QBOInvoice['Line'][number];
   status: 'auto' | 'needs_review' | 'unmatched';
   workActivityId: number | null;
   matchScore: number | null;
@@ -292,7 +291,6 @@ type LabororMatch = {
 
 type MaterialMatch = {
   lineIndex: number;
-  qboLine: QBOInvoice['Line'][number];
   status: 'auto' | 'unmatched';
   otherChargeId: number | null;
 };
@@ -389,7 +387,7 @@ export class InvoiceImportService extends DatabaseService {
 
     // INSERT path: persist invoice + line items + run matcher.
     let matcherResult: {
-      laborMatches: LabororMatch[];
+      laborMatches: LaborMatch[];
       materialMatches: MaterialMatch[];
     };
     try {
@@ -402,9 +400,8 @@ export class InvoiceImportService extends DatabaseService {
       });
       // Still insert the invoice with unmatched lines so the user has a record.
       matcherResult = {
-        laborMatches: qboInvoice.Line.map((line, lineIndex) => ({
+        laborMatches: qboInvoice.Line.map((_line, lineIndex) => ({
           lineIndex,
-          qboLine: line,
           status: 'unmatched' as const,
           workActivityId: null,
           matchScore: null,
@@ -548,21 +545,12 @@ export class InvoiceImportService extends DatabaseService {
       qboInvoiceId: qboInvoice.Id,
       message
     });
-    try {
-      await this.db.insert(notifications).values({
-        type: 'qbo_invoice_unmatched_client',
-        severity: 'warn',
-        title: `Unmatched QBO customer: ${customerName || qboCustomerId}`,
-        body:
-          `QBO invoice #${qboInvoice.DocNumber || qboInvoice.Id} for customer "${customerName}" ` +
-          `could not be linked to a local client. Add a matching client or set qboCustomerId, then re-run sync.`,
-        entityType: null,
-        metadata: { qboInvoiceId: qboInvoice.Id, qboCustomerId, customerName } as any
-      });
-    } catch (notifError) {
-      // Notification failure shouldn't crash the sync.
-      console.warn('Failed to insert unmatched_client notification:', notifError);
-    }
+    await services.notificationService.notifyQBOUnmatchedClient({
+      qboInvoiceId: qboInvoice.Id,
+      qboInvoiceNumber: qboInvoice.DocNumber || qboInvoice.Id,
+      qboCustomerId,
+      customerName
+    });
     return null;
   }
 
@@ -577,7 +565,7 @@ export class InvoiceImportService extends DatabaseService {
   private async matchInvoiceLines(
     qboInvoice: QBOInvoice,
     clientId: number
-  ): Promise<{ laborMatches: LabororMatch[]; materialMatches: MaterialMatch[] }> {
+  ): Promise<{ laborMatches: LaborMatch[]; materialMatches: MaterialMatch[] }> {
     const invoiceDate = qboInvoice.TxnDate;
     const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
 
@@ -611,7 +599,6 @@ export class InvoiceImportService extends DatabaseService {
     // Score every line ↔ candidate pair for labor lines.
     const laborLines: Array<{
       lineIndex: number;
-      qboLine: QBOInvoice['Line'][number];
       scored: Array<{ activity: ScoringActivity; score: number; reason: string }>;
     }> = [];
     const materialLines: Array<{
@@ -638,14 +625,14 @@ export class InvoiceImportService extends DatabaseService {
         activity: toScoringActivity(activity),
         ...scoreCandidate(toScoringActivity(activity), scoringLine, invoiceDate)
       }));
-      laborLines.push({ lineIndex, qboLine: line, scored });
+      laborLines.push({ lineIndex, scored });
     });
 
     // Within-invoice dedup: process labor lines in descending top-score order
     // so the strongest match wins ties, and remove claimed activities from the
     // candidate pool of subsequent lines.
     const claimedActivityIds = new Set<number>();
-    const laborMatches: LabororMatch[] = [];
+    const laborMatches: LaborMatch[] = [];
 
     // First, compute each line's current top score (before dedup) for ordering.
     const orderedByTopScore = [...laborLines].sort((a, b) => {
@@ -654,7 +641,7 @@ export class InvoiceImportService extends DatabaseService {
       return tb - ta;
     });
 
-    for (const { lineIndex, qboLine, scored } of orderedByTopScore) {
+    for (const { lineIndex, scored } of orderedByTopScore) {
       const filtered = scored.filter((s) => !claimedActivityIds.has(s.activity.id));
       const classification = classifyLine(filtered);
       if (classification.status === 'auto' && classification.workActivityId != null) {
@@ -662,7 +649,6 @@ export class InvoiceImportService extends DatabaseService {
       }
       laborMatches.push({
         lineIndex,
-        qboLine,
         status: classification.status,
         workActivityId: classification.workActivityId,
         matchScore: classification.matchScore,
@@ -698,14 +684,12 @@ export class InvoiceImportService extends DatabaseService {
       if (hits.length === 1) {
         materialMatches.push({
           lineIndex,
-          qboLine,
           status: 'auto',
           otherChargeId: hits[0].id
         });
       } else {
         materialMatches.push({
           lineIndex,
-          qboLine,
           status: 'unmatched',
           otherChargeId: null
         });
@@ -1059,6 +1043,9 @@ export class InvoiceImportService extends DatabaseService {
           .limit(1);
         if (thisInvoice[0]) allInvoiceNumbers.unshift(thisInvoice[0].invoiceNumber);
 
+        // Raw insert (not via NotificationService) so this stays atomic with the
+        // line-item update inside the transaction. NotificationService.create
+        // uses its own connection and can't participate in this tx.
         await tx.insert(notifications).values({
           type: 'work_activity_double_linked',
           severity: 'warn',

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -1,0 +1,1182 @@
+import { DatabaseService, type DbOrTx } from './DatabaseService';
+import {
+  clients,
+  invoices,
+  invoiceLineItems,
+  otherCharges,
+  qboItems,
+  workActivities,
+  notifications,
+  type WorkActivity,
+  type OtherCharge
+} from '../db';
+import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne, or, sql } from 'drizzle-orm';
+import { services } from './container';
+import type { QBOInvoice } from './QuickBooksService';
+import { workTypeMapping } from './InvoiceService';
+
+// ---------------------------------------------------------------------------
+// Scoring thresholds — top of file so they're easy to tune.
+// ---------------------------------------------------------------------------
+
+const HIGH_THRESHOLD = 5;
+const MIN_THRESHOLD = 2;
+
+// 90-day candidate window around the invoice date.
+const CANDIDATE_WINDOW_DAYS = 90;
+
+// Stopwords used by the token-overlap scorer. Tiny on purpose — the matcher
+// needs to ignore noise words, not be a full NLP stack.
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'to', 'of', 'for', 'with', 'in', 'on', 'at', 'by', 'from', 'is', 'was'
+]);
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type SyncResult = {
+  imported: number;
+  updated: number;
+  autoMatched: number;
+  needsReview: number;
+  unmatched: number;
+  errors: Array<{
+    type: 'unmatched_client' | 'qbo_fetch_failed' | 'invoice_persist_failed' | 'matcher_failed';
+    qboInvoiceId?: string;
+    message: string;
+  }>;
+};
+
+export type ReviewQueueEntry = {
+  lineItemId: number;
+  invoiceId: number;
+  invoiceNumber: string;
+  invoiceDate: string;
+  clientName: string | null;
+  description: string;
+  quantity: number;
+  rate: number;
+  amount: number;
+  candidates: MatchCandidate[] | null;
+};
+
+export type MatchCandidate = {
+  workActivityId: number;
+  score: number;
+  reason: string;
+  date: string;
+  workType: string;
+  billableHours: number | null;
+  notesSnippet: string;
+};
+
+export type RelinkSuccess = { ok: true };
+export type RelinkWarning = {
+  warning: 'already_linked';
+  existingInvoices: Array<{ invoiceId: number; invoiceNumber: string }>;
+};
+export type RelinkResult = RelinkSuccess | RelinkWarning;
+
+// Minimal shape the matcher needs from a QBO line item. Lets us unit-test
+// the scorer with plain objects instead of full QBO responses.
+export type ScoringLine = {
+  description: string;
+  qty: number | null;
+  qboItemName?: string | null;
+};
+
+// Minimal work-activity shape required by the matcher. Subset of the DB row
+// plus a couple of fields used in scoring/candidate display.
+export type ScoringActivity = {
+  id: number;
+  date: string;
+  workType: string;
+  billableHours: number | null;
+  notes: string | null;
+  tasks: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers — kept as standalone exported functions so they're unit-testable
+// without spinning up the DB.
+// ---------------------------------------------------------------------------
+
+/**
+ * Tokenize a free-text blob into significant lowercase tokens for overlap
+ * scoring. Drops short words and stopwords; splits on any non-word character
+ * (handles punctuation, slashes, newlines, etc.).
+ */
+export function tokenize(text: string | null | undefined): string[] {
+  if (!text) return [];
+  return text
+    .toLowerCase()
+    .split(/\W+/)
+    .filter((tok) => tok.length >= 3 && !STOPWORDS.has(tok));
+}
+
+/**
+ * True when the two strings share at least 2 significant tokens.
+ */
+export function hasTokenOverlap(a: string | null | undefined, b: string | null | undefined): boolean {
+  const ta = new Set(tokenize(a));
+  const tb = tokenize(b);
+  let overlap = 0;
+  for (const tok of tb) {
+    if (ta.has(tok)) {
+      overlap++;
+      if (overlap >= 2) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Absolute calendar-day distance between two YYYY-MM-DD strings.
+ */
+export function daysBetween(a: string, b: string): number {
+  const da = Date.parse(a);
+  const db = Date.parse(b);
+  if (Number.isNaN(da) || Number.isNaN(db)) return 0;
+  return Math.abs(da - db) / (1000 * 60 * 60 * 24);
+}
+
+/**
+ * True if any of the QBO item names mapped to `activity.workType` matches
+ * (case-insensitive equal) the QBO item name on the line.
+ */
+export function workTypeMatchesQBOItem(workType: string, qboItemName: string | null | undefined): boolean {
+  if (!qboItemName) return false;
+  const mapped = workTypeMapping[workType.toLowerCase()];
+  if (!mapped) return false;
+  const target = qboItemName.toLowerCase();
+  return mapped.some((name) => name.toLowerCase() === target);
+}
+
+/**
+ * Score a single candidate work activity against a QBO labor line. Returns the
+ * total score (float) and a short reason string for display in the review UI.
+ *
+ * Scoring rubric:
+ *   +3   hours within ±0.25
+ *   +2   description / notes share ≥2 significant tokens
+ *   +(0..1)  proximity bonus, scaled by date closeness
+ *   +2   workType maps to the QBO item name
+ */
+export function scoreCandidate(
+  activity: ScoringActivity,
+  line: ScoringLine,
+  invoiceDate: string
+): { score: number; reason: string } {
+  const reasons: string[] = [];
+  let score = 0;
+
+  // Hours bonus
+  if (
+    typeof line.qty === 'number' &&
+    activity.billableHours != null &&
+    Math.abs(line.qty - activity.billableHours) <= 0.25
+  ) {
+    score += 3;
+    reasons.push(`hours match (${activity.billableHours}h ≈ ${line.qty}h)`);
+  }
+
+  // Token-overlap bonus
+  const activityText = `${activity.notes || ''} ${activity.tasks || ''}`.trim();
+  if (line.description && hasTokenOverlap(line.description, activityText)) {
+    score += 2;
+    reasons.push('description tokens overlap');
+  }
+
+  // Proximity bonus (float, max +1)
+  const daysAway = daysBetween(invoiceDate, activity.date);
+  const proximity = Math.max(0, 1 - daysAway / CANDIDATE_WINDOW_DAYS);
+  if (proximity > 0) {
+    score += proximity;
+    if (daysAway === 0) {
+      reasons.push('same day');
+    } else {
+      reasons.push(`${Math.round(daysAway)}d away`);
+    }
+  }
+
+  // WorkType-to-QBO-Item bonus
+  if (workTypeMatchesQBOItem(activity.workType, line.qboItemName)) {
+    score += 2;
+    reasons.push(`workType "${activity.workType}" matches item`);
+  }
+
+  return { score, reason: reasons.join(', ') || 'no signals' };
+}
+
+/**
+ * Build a MatchCandidate JSON entry from a scored activity. Includes a
+ * 200-char snippet of notes/tasks so the review UI can render context
+ * without joining back to work_activities.
+ */
+export function toMatchCandidate(
+  activity: ScoringActivity,
+  scored: { score: number; reason: string }
+): MatchCandidate {
+  const rawNotes = (activity.notes || activity.tasks || '').trim();
+  return {
+    workActivityId: activity.id,
+    score: Number(scored.score.toFixed(3)),
+    reason: scored.reason,
+    date: activity.date,
+    workType: activity.workType,
+    billableHours: activity.billableHours,
+    notesSnippet: rawNotes.length > 200 ? rawNotes.slice(0, 200) : rawNotes
+  };
+}
+
+/**
+ * Classify a set of scored candidates for a single labor line.
+ *
+ * Caller is responsible for upstream filtering (e.g., removing already-claimed
+ * activities for within-invoice dedup). This function just applies the
+ * threshold rules on whatever it's given.
+ */
+export function classifyLine(
+  scored: Array<{ activity: ScoringActivity; score: number; reason: string }>
+): {
+  status: 'auto' | 'needs_review' | 'unmatched';
+  workActivityId: number | null;
+  matchScore: number | null;
+  matchCandidates: MatchCandidate[] | null;
+} {
+  if (scored.length === 0) {
+    return { status: 'unmatched', workActivityId: null, matchScore: null, matchCandidates: null };
+  }
+  // Sort descending by score; ties are broken by activity id ASC (deterministic).
+  const sorted = [...scored].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.activity.id - b.activity.id;
+  });
+  const top = sorted[0];
+
+  if (top.score >= HIGH_THRESHOLD) {
+    return {
+      status: 'auto',
+      workActivityId: top.activity.id,
+      matchScore: Number(top.score.toFixed(3)),
+      matchCandidates: null
+    };
+  }
+
+  if (top.score >= MIN_THRESHOLD) {
+    const candidates = sorted.slice(0, 3).map((s) => toMatchCandidate(s.activity, s));
+    return {
+      status: 'needs_review',
+      workActivityId: null,
+      matchScore: Number(top.score.toFixed(3)),
+      matchCandidates: candidates
+    };
+  }
+
+  return { status: 'unmatched', workActivityId: null, matchScore: null, matchCandidates: null };
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+type LabororMatch = {
+  lineIndex: number;
+  qboLine: QBOInvoice['Line'][number];
+  status: 'auto' | 'needs_review' | 'unmatched';
+  workActivityId: number | null;
+  matchScore: number | null;
+  matchCandidates: MatchCandidate[] | null;
+};
+
+type MaterialMatch = {
+  lineIndex: number;
+  qboLine: QBOInvoice['Line'][number];
+  status: 'auto' | 'unmatched';
+  otherChargeId: number | null;
+};
+
+export class InvoiceImportService extends DatabaseService {
+  // -----------------------------------------------------------------------
+  // Public: syncAllInvoices
+  // -----------------------------------------------------------------------
+
+  /**
+   * Pull all QBO invoices, persist them locally, and run the matcher against
+   * line items on freshly-inserted invoices. Existing invoices have their
+   * status/totals refreshed but their line items are NOT rewritten (preserves
+   * 'manual' relinks).
+   *
+   * Errors on a single invoice never abort the whole sync — they get pushed
+   * into `result.errors` and processing continues.
+   */
+  async syncAllInvoices(opts?: { since?: string }): Promise<SyncResult> {
+    const result: SyncResult = {
+      imported: 0,
+      updated: 0,
+      autoMatched: 0,
+      needsReview: 0,
+      unmatched: 0,
+      errors: []
+    };
+
+    let qboInvoices: QBOInvoice[];
+    try {
+      qboInvoices = await services.quickBooksService.getAllInvoices();
+    } catch (error) {
+      result.errors.push({
+        type: 'qbo_fetch_failed',
+        message: error instanceof Error ? error.message : String(error)
+      });
+      return result;
+    }
+
+    if (opts?.since) {
+      const since = opts.since;
+      qboInvoices = qboInvoices.filter((inv) => inv.TxnDate && inv.TxnDate >= since);
+    }
+
+    // Sort by TxnDate ASC so older invoices claim older work activities first.
+    // Without this, matcher results vary with QBO's response order.
+    qboInvoices.sort((a, b) => (a.TxnDate || '').localeCompare(b.TxnDate || ''));
+
+    for (const qboInvoice of qboInvoices) {
+      try {
+        await this.processInvoice(qboInvoice, result);
+      } catch (error) {
+        result.errors.push({
+          type: 'invoice_persist_failed',
+          qboInvoiceId: qboInvoice.Id,
+          message: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Process one QBO invoice: resolve client, upsert invoice, run matcher for
+   * inserts, flip activity statuses inside the same transaction.
+   */
+  private async processInvoice(qboInvoice: QBOInvoice, result: SyncResult): Promise<void> {
+    const clientId = await this.resolveClientId(qboInvoice, result);
+    if (clientId == null) return;
+
+    const existing = await this.db
+      .select()
+      .from(invoices)
+      .where(eq(invoices.qboInvoiceId, qboInvoice.Id))
+      .limit(1);
+
+    if (existing[0]) {
+      // UPDATE path: refresh metadata only; do NOT rewrite line items so we
+      // don't blow away 'manual' relinks the user has made since import.
+      await this.db
+        .update(invoices)
+        .set({
+          status: services.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+          totalAmount: qboInvoice.TotalAmt,
+          dueDate: qboInvoice.DueDate || null,
+          qboSyncAt: new Date(),
+          updatedAt: new Date()
+        })
+        .where(eq(invoices.id, existing[0].id));
+      result.updated++;
+      return;
+    }
+
+    // INSERT path: persist invoice + line items + run matcher.
+    let matcherResult: {
+      laborMatches: LabororMatch[];
+      materialMatches: MaterialMatch[];
+    };
+    try {
+      matcherResult = await this.matchInvoiceLines(qboInvoice, clientId);
+    } catch (error) {
+      result.errors.push({
+        type: 'matcher_failed',
+        qboInvoiceId: qboInvoice.Id,
+        message: error instanceof Error ? error.message : String(error)
+      });
+      // Still insert the invoice with unmatched lines so the user has a record.
+      matcherResult = {
+        laborMatches: qboInvoice.Line.map((line, lineIndex) => ({
+          lineIndex,
+          qboLine: line,
+          status: 'unmatched' as const,
+          workActivityId: null,
+          matchScore: null,
+          matchCandidates: null
+        })),
+        materialMatches: []
+      };
+    }
+
+    await this.db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(invoices)
+        .values({
+          qboInvoiceId: qboInvoice.Id,
+          qboCustomerId: qboInvoice.CustomerRef.value,
+          clientId,
+          invoiceNumber: qboInvoice.DocNumber,
+          status: services.invoiceService.mapQBOInvoiceStatus(qboInvoice),
+          totalAmount: qboInvoice.TotalAmt,
+          invoiceDate: qboInvoice.TxnDate,
+          dueDate: qboInvoice.DueDate || null,
+          qboSyncAt: new Date()
+        })
+        .returning();
+      const localInvoiceId = inserted[0].id;
+
+      // Build line item rows from the QBO invoice. We index by lineIndex so
+      // we can layer matcher results on top regardless of whether each line
+      // was treated as labor or material.
+      const laborByIndex = new Map(matcherResult.laborMatches.map((m) => [m.lineIndex, m]));
+      const materialByIndex = new Map(matcherResult.materialMatches.map((m) => [m.lineIndex, m]));
+
+      const lineRows = qboInvoice.Line.map((line, lineIndex) => {
+        const labor = laborByIndex.get(lineIndex);
+        const material = materialByIndex.get(lineIndex);
+        const qboItemId = line.SalesItemLineDetail?.ItemRef?.value || null;
+        const qty = line.SalesItemLineDetail?.Qty ?? 0;
+        const rate = line.SalesItemLineDetail?.UnitPrice ?? 0;
+
+        let matchStatus: string = 'unmatched';
+        let workActivityId: number | null = null;
+        let otherChargeId: number | null = null;
+        let matchScore: number | null = null;
+        let matchCandidates: MatchCandidate[] | null = null;
+
+        if (labor) {
+          matchStatus = labor.status;
+          workActivityId = labor.workActivityId;
+          matchScore = labor.matchScore;
+          matchCandidates = labor.matchCandidates;
+        } else if (material) {
+          matchStatus = material.status;
+          otherChargeId = material.otherChargeId;
+        }
+
+        return {
+          invoiceId: localInvoiceId,
+          workActivityId,
+          otherChargeId,
+          qboItemId,
+          description: line.Description || '',
+          quantity: qty,
+          rate,
+          amount: line.Amount,
+          matchStatus,
+          matchScore,
+          matchCandidates: matchCandidates as any
+        };
+      });
+
+      if (lineRows.length > 0) {
+        await tx.insert(invoiceLineItems).values(lineRows);
+      }
+
+      // Flip status for any 'auto'-matched labor activities (materials don't
+      // flip activity status — they live on already-completed activities).
+      const autoActivityIds = matcherResult.laborMatches
+        .filter((m) => m.status === 'auto' && m.workActivityId != null)
+        .map((m) => m.workActivityId as number);
+      if (autoActivityIds.length > 0) {
+        await services.workActivityService.setStatus(autoActivityIds, 'invoiced', tx);
+      }
+    });
+
+    result.imported++;
+
+    for (const m of matcherResult.laborMatches) {
+      if (m.status === 'auto') result.autoMatched++;
+      else if (m.status === 'needs_review') result.needsReview++;
+      else result.unmatched++;
+    }
+    for (const m of matcherResult.materialMatches) {
+      if (m.status === 'auto') result.autoMatched++;
+      else result.unmatched++;
+    }
+  }
+
+  /**
+   * Resolve a local client for a QBO invoice. Tries qboCustomerId, then a
+   * case-insensitive name match (with opportunistic backfill). Returns null
+   * and writes an `unmatched_client` notification when no match is found.
+   */
+  private async resolveClientId(qboInvoice: QBOInvoice, result: SyncResult): Promise<number | null> {
+    const qboCustomerId = qboInvoice.CustomerRef.value;
+    const customerName = qboInvoice.CustomerRef.name || '';
+
+    // 1) Primary lookup by qboCustomerId.
+    const byQboId = await this.db
+      .select({ id: clients.id })
+      .from(clients)
+      .where(eq(clients.qboCustomerId, qboCustomerId))
+      .limit(1);
+    if (byQboId[0]) return byQboId[0].id;
+
+    // 2) Fallback by name (case-insensitive). If found, backfill qboCustomerId.
+    if (customerName.trim()) {
+      const byName = await this.db
+        .select({ id: clients.id, qboCustomerId: clients.qboCustomerId })
+        .from(clients)
+        .where(ilike(clients.name, customerName.trim()))
+        .limit(1);
+      if (byName[0]) {
+        if (!byName[0].qboCustomerId) {
+          await this.db
+            .update(clients)
+            .set({ qboCustomerId, updatedAt: new Date() })
+            .where(eq(clients.id, byName[0].id));
+        }
+        return byName[0].id;
+      }
+    }
+
+    // 3) No match — record an error + notification.
+    const message = `No local client matches "${customerName}"`;
+    result.errors.push({
+      type: 'unmatched_client',
+      qboInvoiceId: qboInvoice.Id,
+      message
+    });
+    try {
+      await this.db.insert(notifications).values({
+        type: 'qbo_invoice_unmatched_client',
+        severity: 'warn',
+        title: `Unmatched QBO customer: ${customerName || qboCustomerId}`,
+        body:
+          `QBO invoice #${qboInvoice.DocNumber || qboInvoice.Id} for customer "${customerName}" ` +
+          `could not be linked to a local client. Add a matching client or set qboCustomerId, then re-run sync.`,
+        entityType: null,
+        metadata: { qboInvoiceId: qboInvoice.Id, qboCustomerId, customerName } as any
+      });
+    } catch (notifError) {
+      // Notification failure shouldn't crash the sync.
+      console.warn('Failed to insert unmatched_client notification:', notifError);
+    }
+    return null;
+  }
+
+  // -----------------------------------------------------------------------
+  // Matching
+  // -----------------------------------------------------------------------
+
+  /**
+   * Load candidate work activities + their charges and run the matcher for
+   * every line on the invoice. Implements within-invoice dedup for labor.
+   */
+  private async matchInvoiceLines(
+    qboInvoice: QBOInvoice,
+    clientId: number
+  ): Promise<{ laborMatches: LabororMatch[]; materialMatches: MaterialMatch[] }> {
+    const invoiceDate = qboInvoice.TxnDate;
+    const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
+
+    // Candidate activities: same client, completed, within 90d window.
+    const candidateActivities = (await this.db
+      .select()
+      .from(workActivities)
+      .where(
+        and(
+          eq(workActivities.clientId, clientId),
+          eq(workActivities.status, 'completed'),
+          gte(workActivities.date, windowStart),
+          lte(workActivities.date, invoiceDate)
+        )
+      )) as WorkActivity[];
+
+    // Classify lines into labor vs material using qbo_items.type.
+    const qboItemIds = Array.from(
+      new Set(
+        qboInvoice.Line
+          .map((l) => l.SalesItemLineDetail?.ItemRef?.value)
+          .filter((v): v is string => !!v)
+      )
+    );
+    const itemRows = qboItemIds.length
+      ? await this.db.select().from(qboItems).where(inArray(qboItems.qboId, qboItemIds))
+      : [];
+    const itemTypeById = new Map(itemRows.map((it) => [it.qboId, it.type]));
+    const itemNameById = new Map(itemRows.map((it) => [it.qboId, it.name]));
+
+    // Score every line ↔ candidate pair for labor lines.
+    const laborLines: Array<{
+      lineIndex: number;
+      qboLine: QBOInvoice['Line'][number];
+      scored: Array<{ activity: ScoringActivity; score: number; reason: string }>;
+    }> = [];
+    const materialLines: Array<{
+      lineIndex: number;
+      qboLine: QBOInvoice['Line'][number];
+    }> = [];
+
+    qboInvoice.Line.forEach((line, lineIndex) => {
+      const qboItemId = line.SalesItemLineDetail?.ItemRef?.value;
+      const itemType = qboItemId ? itemTypeById.get(qboItemId) : undefined;
+      const itemName = qboItemId ? itemNameById.get(qboItemId) : undefined;
+
+      if (itemType === 'Inventory' || itemType === 'NonInventory') {
+        materialLines.push({ lineIndex, qboLine: line });
+        return;
+      }
+      // Default to labor (Service or unknown).
+      const scoringLine: ScoringLine = {
+        description: line.Description || '',
+        qty: line.SalesItemLineDetail?.Qty ?? null,
+        qboItemName: itemName ?? null
+      };
+      const scored = candidateActivities.map((activity) => ({
+        activity: toScoringActivity(activity),
+        ...scoreCandidate(toScoringActivity(activity), scoringLine, invoiceDate)
+      }));
+      laborLines.push({ lineIndex, qboLine: line, scored });
+    });
+
+    // Within-invoice dedup: process labor lines in descending top-score order
+    // so the strongest match wins ties, and remove claimed activities from the
+    // candidate pool of subsequent lines.
+    const claimedActivityIds = new Set<number>();
+    const laborMatches: LabororMatch[] = [];
+
+    // First, compute each line's current top score (before dedup) for ordering.
+    const orderedByTopScore = [...laborLines].sort((a, b) => {
+      const ta = a.scored.length ? Math.max(...a.scored.map((s) => s.score)) : 0;
+      const tb = b.scored.length ? Math.max(...b.scored.map((s) => s.score)) : 0;
+      return tb - ta;
+    });
+
+    for (const { lineIndex, qboLine, scored } of orderedByTopScore) {
+      const filtered = scored.filter((s) => !claimedActivityIds.has(s.activity.id));
+      const classification = classifyLine(filtered);
+      if (classification.status === 'auto' && classification.workActivityId != null) {
+        claimedActivityIds.add(classification.workActivityId);
+      }
+      laborMatches.push({
+        lineIndex,
+        qboLine,
+        status: classification.status,
+        workActivityId: classification.workActivityId,
+        matchScore: classification.matchScore,
+        matchCandidates: classification.matchCandidates
+      });
+    }
+
+    // Material matching: for each material line, look for an other_charges row
+    // among candidate activities' charges whose description matches and whose
+    // totalCost is within $0.01. Auto-match only when exactly one such row exists.
+    const candidateActivityIds = candidateActivities.map((a) => a.id);
+    const candidateCharges: OtherCharge[] = candidateActivityIds.length
+      ? ((await this.db
+          .select()
+          .from(otherCharges)
+          .where(inArray(otherCharges.workActivityId, candidateActivityIds))) as OtherCharge[])
+      : [];
+
+    const materialMatches: MaterialMatch[] = [];
+    for (const { lineIndex, qboLine } of materialLines) {
+      const desc = (qboLine.Description || '').trim();
+      const amount = qboLine.Amount;
+      const matchesDesc = (charge: OtherCharge) => {
+        if (!desc) return false;
+        const cd = charge.description?.toLowerCase() || '';
+        const ld = desc.toLowerCase();
+        // ILIKE-ish: exact, contains, or contained-by.
+        return cd === ld || cd.includes(ld) || ld.includes(cd);
+      };
+      const amountMatches = (charge: OtherCharge) =>
+        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - amount) < 0.01;
+      const hits = candidateCharges.filter((c) => matchesDesc(c) && amountMatches(c));
+      if (hits.length === 1) {
+        materialMatches.push({
+          lineIndex,
+          qboLine,
+          status: 'auto',
+          otherChargeId: hits[0].id
+        });
+      } else {
+        materialMatches.push({
+          lineIndex,
+          qboLine,
+          status: 'unmatched',
+          otherChargeId: null
+        });
+      }
+    }
+
+    return { laborMatches, materialMatches };
+  }
+
+  // -----------------------------------------------------------------------
+  // Public: rematchInvoice
+  // -----------------------------------------------------------------------
+
+  /**
+   * Re-run the matcher for a single invoice's line items, preserving any
+   * 'manual' user decisions. Cleared activities are reverted from 'invoiced'
+   * back to 'completed' iff they're no longer referenced by any invoice line.
+   */
+  async rematchInvoice(invoiceId: number): Promise<{
+    autoMatched: number;
+    needsReview: number;
+    unmatched: number;
+  }> {
+    const invoiceRow = await this.db
+      .select()
+      .from(invoices)
+      .where(eq(invoices.id, invoiceId))
+      .limit(1);
+    if (!invoiceRow[0]) throw new Error(`Invoice ${invoiceId} not found`);
+    const invoice = invoiceRow[0];
+
+    // Build a minimal QBOInvoice shape from the local invoice + lines so we
+    // can reuse the matcher. We don't fetch from QBO here — rematch is a
+    // local-only operation that re-applies scoring to today's candidates.
+    const allLines = await this.db
+      .select()
+      .from(invoiceLineItems)
+      .where(eq(invoiceLineItems.invoiceId, invoiceId))
+      .orderBy(asc(invoiceLineItems.id));
+
+    const linesToRematch = allLines.filter((l) => l.matchStatus !== 'manual');
+    if (linesToRematch.length === 0) {
+      return { autoMatched: 0, needsReview: 0, unmatched: 0 };
+    }
+
+    // Collect activity ids that are about to be cleared so we can revert
+    // any that end up orphaned.
+    const clearedActivityIds = Array.from(
+      new Set(
+        linesToRematch
+          .map((l) => l.workActivityId)
+          .filter((id): id is number => id != null)
+      )
+    );
+
+    // Build a synthetic QBOInvoice purely to feed the matcher.
+    const itemQboIds = Array.from(
+      new Set(
+        linesToRematch
+          .map((l) => l.qboItemId)
+          .filter((v): v is string => !!v)
+      )
+    );
+    const itemRows = itemQboIds.length
+      ? await this.db.select().from(qboItems).where(inArray(qboItems.qboId, itemQboIds))
+      : [];
+    const itemTypeById = new Map(itemRows.map((it) => [it.qboId, it.type]));
+    const itemNameById = new Map(itemRows.map((it) => [it.qboId, it.name]));
+
+    // Re-score: candidate window from invoice date.
+    const invoiceDate = invoice.invoiceDate;
+    const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
+    const candidateActivities = (await this.db
+      .select()
+      .from(workActivities)
+      .where(
+        and(
+          eq(workActivities.clientId, invoice.clientId),
+          eq(workActivities.status, 'completed'),
+          gte(workActivities.date, windowStart),
+          lte(workActivities.date, invoiceDate)
+        )
+      )) as WorkActivity[];
+
+    // Partition lines into labor vs material based on item type.
+    const laborLines: Array<{
+      lineId: number;
+      qboItemId: string | null;
+      description: string;
+      qty: number | null;
+      scored: Array<{ activity: ScoringActivity; score: number; reason: string }>;
+    }> = [];
+    const materialLines: Array<{
+      lineId: number;
+      description: string;
+      amount: number;
+    }> = [];
+
+    for (const line of linesToRematch) {
+      const itemType = line.qboItemId ? itemTypeById.get(line.qboItemId) : undefined;
+      const itemName = line.qboItemId ? itemNameById.get(line.qboItemId) : undefined;
+      if (itemType === 'Inventory' || itemType === 'NonInventory') {
+        materialLines.push({
+          lineId: line.id,
+          description: line.description,
+          amount: line.amount
+        });
+        continue;
+      }
+      const sLine: ScoringLine = {
+        description: line.description,
+        qty: line.quantity ?? null,
+        qboItemName: itemName ?? null
+      };
+      const scored = candidateActivities.map((activity) => {
+        const sa = toScoringActivity(activity);
+        return { activity: sa, ...scoreCandidate(sa, sLine, invoiceDate) };
+      });
+      laborLines.push({
+        lineId: line.id,
+        qboItemId: line.qboItemId,
+        description: line.description,
+        qty: line.quantity ?? null,
+        scored
+      });
+    }
+
+    // Within-invoice dedup for the rematch — same algorithm as the initial sync.
+    const claimed = new Set<number>();
+    const ordered = [...laborLines].sort((a, b) => {
+      const ta = a.scored.length ? Math.max(...a.scored.map((s) => s.score)) : 0;
+      const tb = b.scored.length ? Math.max(...b.scored.map((s) => s.score)) : 0;
+      return tb - ta;
+    });
+    const laborDecisions = new Map<
+      number,
+      ReturnType<typeof classifyLine>
+    >();
+    for (const ll of ordered) {
+      const filtered = ll.scored.filter((s) => !claimed.has(s.activity.id));
+      const decision = classifyLine(filtered);
+      if (decision.status === 'auto' && decision.workActivityId != null) {
+        claimed.add(decision.workActivityId);
+      }
+      laborDecisions.set(ll.lineId, decision);
+    }
+
+    // Material rematch.
+    const candidateActivityIds = candidateActivities.map((a) => a.id);
+    const candidateCharges: OtherCharge[] = candidateActivityIds.length
+      ? ((await this.db
+          .select()
+          .from(otherCharges)
+          .where(inArray(otherCharges.workActivityId, candidateActivityIds))) as OtherCharge[])
+      : [];
+
+    const materialDecisions = new Map<
+      number,
+      { status: 'auto' | 'unmatched'; otherChargeId: number | null }
+    >();
+    for (const ml of materialLines) {
+      const desc = ml.description.trim();
+      const matchesDesc = (charge: OtherCharge) => {
+        if (!desc) return false;
+        const cd = charge.description?.toLowerCase() || '';
+        const ld = desc.toLowerCase();
+        return cd === ld || cd.includes(ld) || ld.includes(cd);
+      };
+      const amountMatches = (charge: OtherCharge) =>
+        typeof charge.totalCost === 'number' && Math.abs(charge.totalCost - ml.amount) < 0.01;
+      const hits = candidateCharges.filter((c) => matchesDesc(c) && amountMatches(c));
+      if (hits.length === 1) {
+        materialDecisions.set(ml.lineId, { status: 'auto', otherChargeId: hits[0].id });
+      } else {
+        materialDecisions.set(ml.lineId, { status: 'unmatched', otherChargeId: null });
+      }
+    }
+
+    // Apply decisions in a single transaction: clear the old lines, write
+    // new state, flip activity statuses.
+    let autoMatched = 0;
+    let needsReview = 0;
+    let unmatched = 0;
+
+    await this.db.transaction(async (tx) => {
+      // 1) Clear the lines we're rematching.
+      for (const line of linesToRematch) {
+        await tx
+          .update(invoiceLineItems)
+          .set({
+            workActivityId: null,
+            otherChargeId: null,
+            matchStatus: 'unmatched',
+            matchScore: null,
+            matchCandidates: null,
+            updatedAt: new Date()
+          })
+          .where(eq(invoiceLineItems.id, line.id));
+      }
+
+      // 2) Revert orphaned activities to 'completed'.
+      await this.revertOrphanedActivities(clearedActivityIds, tx);
+
+      // 3) Apply labor decisions.
+      const newAutoActivityIds: number[] = [];
+      for (const [lineId, decision] of laborDecisions) {
+        await tx
+          .update(invoiceLineItems)
+          .set({
+            workActivityId: decision.workActivityId,
+            matchStatus: decision.status,
+            matchScore: decision.matchScore,
+            matchCandidates: (decision.matchCandidates ?? null) as any,
+            updatedAt: new Date()
+          })
+          .where(eq(invoiceLineItems.id, lineId));
+        if (decision.status === 'auto' && decision.workActivityId != null) {
+          newAutoActivityIds.push(decision.workActivityId);
+          autoMatched++;
+        } else if (decision.status === 'needs_review') {
+          needsReview++;
+        } else {
+          unmatched++;
+        }
+      }
+
+      // 4) Apply material decisions.
+      for (const [lineId, decision] of materialDecisions) {
+        await tx
+          .update(invoiceLineItems)
+          .set({
+            otherChargeId: decision.otherChargeId,
+            matchStatus: decision.status,
+            updatedAt: new Date()
+          })
+          .where(eq(invoiceLineItems.id, lineId));
+        if (decision.status === 'auto') {
+          autoMatched++;
+        } else {
+          unmatched++;
+        }
+      }
+
+      // 5) Flip newly auto-matched activities to 'invoiced'.
+      if (newAutoActivityIds.length > 0) {
+        await services.workActivityService.setStatus(newAutoActivityIds, 'invoiced', tx);
+      }
+    });
+
+    return { autoMatched, needsReview, unmatched };
+  }
+
+  // -----------------------------------------------------------------------
+  // Public: relinkLineItem
+  // -----------------------------------------------------------------------
+
+  /**
+   * The user-correction primitive. Sets `workActivityId` on a line (or clears
+   * it). Detects cross-invoice double-links unless `force: true` is passed.
+   * Manages activity status flips on both sides of the move.
+   */
+  async relinkLineItem(
+    lineItemId: number,
+    workActivityId: number | null,
+    opts?: { source?: 'review' | 'detail'; force?: boolean }
+  ): Promise<RelinkResult> {
+    const rows = await this.db
+      .select()
+      .from(invoiceLineItems)
+      .where(eq(invoiceLineItems.id, lineItemId))
+      .limit(1);
+    if (!rows[0]) throw new Error(`Line item ${lineItemId} not found`);
+    const line = rows[0];
+
+    // No-op short-circuit: same activity AND already 'manual'.
+    if (line.workActivityId === workActivityId && line.matchStatus === 'manual') {
+      return { ok: true };
+    }
+
+    // Double-link check: look for OTHER lines on OTHER invoices that reference
+    // the same activity. We exclude this line's own invoice and own id so
+    // moving within an invoice doesn't false-positive.
+    let crossInvoiceRefs: Array<{ invoiceId: number; invoiceNumber: string }> = [];
+    if (workActivityId != null) {
+      const refs = await this.db
+        .select({
+          invoiceId: invoices.id,
+          invoiceNumber: invoices.invoiceNumber
+        })
+        .from(invoiceLineItems)
+        .innerJoin(invoices, eq(invoiceLineItems.invoiceId, invoices.id))
+        .where(
+          and(
+            eq(invoiceLineItems.workActivityId, workActivityId),
+            ne(invoiceLineItems.invoiceId, line.invoiceId),
+            ne(invoiceLineItems.id, lineItemId)
+          )
+        );
+      crossInvoiceRefs = refs;
+      if (crossInvoiceRefs.length > 0 && !opts?.force) {
+        return {
+          warning: 'already_linked',
+          existingInvoices: crossInvoiceRefs
+        };
+      }
+    }
+
+    const oldActivityId = line.workActivityId;
+    const wasForcedDoubleLink = workActivityId != null && crossInvoiceRefs.length > 0 && !!opts?.force;
+
+    await this.db.transaction(async (tx) => {
+      // 1) Write the line.
+      await tx
+        .update(invoiceLineItems)
+        .set({
+          workActivityId,
+          matchStatus: 'manual',
+          matchScore: null,
+          matchCandidates: null,
+          updatedAt: new Date()
+        })
+        .where(eq(invoiceLineItems.id, lineItemId));
+
+      // 2) Revert old activity if orphaned.
+      if (oldActivityId != null) {
+        await this.revertOrphanedActivities([oldActivityId], tx);
+      }
+
+      // 3) Flip new activity to 'invoiced' if it isn't already.
+      if (workActivityId != null) {
+        const current = await tx
+          .select({ status: workActivities.status })
+          .from(workActivities)
+          .where(eq(workActivities.id, workActivityId))
+          .limit(1);
+        if (current[0] && current[0].status !== 'invoiced') {
+          await services.workActivityService.setStatus([workActivityId], 'invoiced', tx);
+        }
+      }
+
+      // 4) For forced double-links, log a notification. Best-effort inside tx;
+      // if it fails the tx will roll back which is acceptable.
+      if (wasForcedDoubleLink && workActivityId != null) {
+        const allInvoiceIds = [line.invoiceId, ...crossInvoiceRefs.map((r) => r.invoiceId)];
+        const allInvoiceNumbers = crossInvoiceRefs.map((r) => r.invoiceNumber);
+        // Include this invoice's number too for the body.
+        const thisInvoice = await tx
+          .select({ invoiceNumber: invoices.invoiceNumber })
+          .from(invoices)
+          .where(eq(invoices.id, line.invoiceId))
+          .limit(1);
+        if (thisInvoice[0]) allInvoiceNumbers.unshift(thisInvoice[0].invoiceNumber);
+
+        await tx.insert(notifications).values({
+          type: 'work_activity_double_linked',
+          severity: 'warn',
+          title: 'Work activity linked to multiple invoices',
+          body:
+            `Work activity ${workActivityId} is now linked to multiple invoices: ` +
+            `${allInvoiceNumbers.join(', ')}. This was a forced override.`,
+          entityType: 'work_activity',
+          entityId: workActivityId,
+          metadata: {
+            workActivityId,
+            lineItemId,
+            invoiceIds: allInvoiceIds
+          } as any
+        });
+      }
+    });
+
+    return { ok: true };
+  }
+
+  // -----------------------------------------------------------------------
+  // Public: getReviewQueue
+  // -----------------------------------------------------------------------
+
+  /**
+   * Return all line items needing user review, enriched with invoice +
+   * client info and the persisted candidate list. Self-contained so the
+   * frontend doesn't need extra joins.
+   */
+  async getReviewQueue(): Promise<ReviewQueueEntry[]> {
+    const rows = await this.db
+      .select({
+        lineItemId: invoiceLineItems.id,
+        invoiceId: invoices.id,
+        invoiceNumber: invoices.invoiceNumber,
+        invoiceDate: invoices.invoiceDate,
+        clientName: clients.name,
+        description: invoiceLineItems.description,
+        quantity: invoiceLineItems.quantity,
+        rate: invoiceLineItems.rate,
+        amount: invoiceLineItems.amount,
+        candidates: invoiceLineItems.matchCandidates
+      })
+      .from(invoiceLineItems)
+      .innerJoin(invoices, eq(invoiceLineItems.invoiceId, invoices.id))
+      .leftJoin(clients, eq(invoices.clientId, clients.id))
+      .where(eq(invoiceLineItems.matchStatus, 'needs_review'))
+      .orderBy(asc(invoices.invoiceDate), asc(invoiceLineItems.id));
+
+    return rows.map((r) => ({
+      lineItemId: r.lineItemId,
+      invoiceId: r.invoiceId,
+      invoiceNumber: r.invoiceNumber,
+      invoiceDate: r.invoiceDate,
+      clientName: r.clientName,
+      description: r.description,
+      quantity: r.quantity,
+      rate: r.rate,
+      amount: r.amount,
+      candidates: (r.candidates as MatchCandidate[] | null) ?? null
+    }));
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * For each activity id, if no invoice_line_items row references it anymore,
+   * flip it back to 'completed'. Used by rematch and relink to keep activity
+   * status consistent with line-item ownership.
+   */
+  private async revertOrphanedActivities(activityIds: number[], tx: DbOrTx): Promise<void> {
+    if (activityIds.length === 0) return;
+    const unique = Array.from(new Set(activityIds));
+    const stillReferenced = await tx
+      .select({ workActivityId: invoiceLineItems.workActivityId })
+      .from(invoiceLineItems)
+      .where(
+        and(
+          inArray(invoiceLineItems.workActivityId, unique),
+          isNotNull(invoiceLineItems.workActivityId)
+        )
+      );
+    const referenced = new Set(
+      stillReferenced
+        .map((r) => r.workActivityId)
+        .filter((id): id is number => id != null)
+    );
+    const orphaned = unique.filter((id) => !referenced.has(id));
+    if (orphaned.length > 0) {
+      await services.workActivityService.setStatus(orphaned, 'completed', tx);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small pure helpers used internally and in tests.
+// ---------------------------------------------------------------------------
+
+/**
+ * Add `days` to a YYYY-MM-DD string (UTC, no DST shenanigans) and return
+ * the same format. Used for building the candidate-date window.
+ */
+export function shiftDate(isoDate: string, days: number): string {
+  const t = Date.parse(isoDate);
+  if (Number.isNaN(t)) return isoDate;
+  const d = new Date(t + days * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Narrow a full WorkActivity row to the subset the matcher needs.
+ */
+function toScoringActivity(activity: WorkActivity): ScoringActivity {
+  return {
+    id: activity.id,
+    date: activity.date,
+    workType: activity.workType,
+    billableHours: activity.billableHours ?? null,
+    notes: activity.notes ?? null,
+    tasks: activity.tasks ?? null
+  };
+}

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -296,9 +296,7 @@ export class InvoiceService extends DatabaseService {
       // be re-offered for invoicing.
       const localInvoice = await this.db.transaction(async (tx) => {
         const inv = await this.saveInvoiceToLocal(qboInvoice, client.id, normalizedLineItems, tx);
-        if (invoicedWorkActivityIds.length > 0) {
-          await this.updateWorkActivitiesStatus(invoicedWorkActivityIds, 'invoiced', tx);
-        }
+        await this.workActivityService.setStatus(invoicedWorkActivityIds, 'invoiced', tx);
         return inv;
       });
 
@@ -715,17 +713,6 @@ export class InvoiceService extends DatabaseService {
     return tx ? run(tx) : this.db.transaction(run);
   }
 
-  private async updateWorkActivitiesStatus(workActivityIds: number[], status: string, tx?: DbOrTx): Promise<void> {
-    const conn = tx ?? this.db;
-    await conn
-      .update(workActivities)
-      .set({
-        status: status,
-        updatedAt: new Date()
-      })
-      .where(inArray(workActivities.id, workActivityIds));
-  }
-
   private mapQBOInvoiceStatus(qboInvoice: any): string {
     // Map QuickBooks invoice status to our local status
     if (qboInvoice.Balance === 0) return 'paid';
@@ -778,8 +765,8 @@ export class InvoiceService extends DatabaseService {
         console.log('Deleted invoice record');
 
         // 5. Revert work activities status back to 'completed'
+        await this.workActivityService.setStatus(workActivityIds, 'completed', tx);
         if (workActivityIds.length > 0) {
-          await this.updateWorkActivitiesStatus(workActivityIds, 'completed', tx);
           console.log(`Reverted ${workActivityIds.length} work activities to 'completed' status`);
         }
       });

--- a/server/src/services/InvoiceService.ts
+++ b/server/src/services/InvoiceService.ts
@@ -555,15 +555,6 @@ export class InvoiceService extends DatabaseService {
   }
 
   private async findQBOItemForWorkType(workType: string): Promise<any> {
-    // Map work types to QBO items based on common naming
-    const workTypeMapping: { [key: string]: string[] } = {
-      'maintenance': ['Specialized garden care', 'Garden maintenance', 'Maintenance'],
-      'pruning': ['Specialized pruning', 'Pruning'],
-      'design': ['Design Consultation', 'Design'],
-      'consultation': ['Design Consultation', 'Garden coaching'],
-      'project': ['Project management']
-    };
-
     const possibleNames = workTypeMapping[workType.toLowerCase()] || [workType];
     
     for (const name of possibleNames) {
@@ -713,7 +704,12 @@ export class InvoiceService extends DatabaseService {
     return tx ? run(tx) : this.db.transaction(run);
   }
 
-  private mapQBOInvoiceStatus(qboInvoice: any): string {
+  /**
+   * Map a raw QBO invoice response to our local status enum.
+   * Public so InvoiceImportService can reuse the same status mapping when
+   * upserting imported invoices.
+   */
+  public mapQBOInvoiceStatus(qboInvoice: any): string {
     // Map QuickBooks invoice status to our local status
     if (qboInvoice.Balance === 0) return 'paid';
     if (qboInvoice.EmailStatus === 'EmailSent') return 'sent';
@@ -824,6 +820,21 @@ export class InvoiceService extends DatabaseService {
     }
   }
 }
+
+/**
+ * Mapping from local `work_activities.workType` (lowercased) to the QBO Item
+ * names that typically represent that kind of labor. Exported so both the
+ * outbound `InvoiceService.findQBOItemForWorkType` and the inbound
+ * `InvoiceImportService` matcher (workType scoring bonus) share one source
+ * of truth.
+ */
+export const workTypeMapping: { [key: string]: string[] } = {
+  'maintenance': ['Specialized garden care', 'Garden maintenance', 'Maintenance'],
+  'pruning': ['Specialized pruning', 'Pruning'],
+  'design': ['Design Consultation', 'Design'],
+  'consultation': ['Design Consultation', 'Garden coaching'],
+  'project': ['Project management']
+};
 
 /**
  * Validate user-submitted line items and recompute `amount` server-side.

--- a/server/src/services/NotificationService.ts
+++ b/server/src/services/NotificationService.ts
@@ -123,4 +123,26 @@ export class NotificationService extends BaseCrudService<typeof notifications, N
       metadata: { jobName, error: message }
     });
   }
+
+  async notifyQBOUnmatchedClient(params: {
+    qboInvoiceId: string;
+    qboInvoiceNumber: string;
+    qboCustomerId: string;
+    customerName: string;
+  }): Promise<void> {
+    try {
+      await this.create({
+        type: 'qbo_invoice_unmatched_client',
+        severity: 'warn',
+        title: `Unmatched QBO customer: ${params.customerName || params.qboCustomerId}`,
+        body:
+          `QBO invoice #${params.qboInvoiceNumber || params.qboInvoiceId} for customer "${params.customerName}" ` +
+          `could not be linked to a local client. Add a matching client or set qboCustomerId, then re-run sync.`,
+        entityType: null,
+        metadata: { qboInvoiceId: params.qboInvoiceId, qboCustomerId: params.qboCustomerId, customerName: params.customerName }
+      });
+    } catch (err) {
+      console.error('Failed to write qbo_invoice_unmatched_client notification', err);
+    }
+  }
 }

--- a/server/src/services/ProductionPullService.ts
+++ b/server/src/services/ProductionPullService.ts
@@ -9,6 +9,7 @@ import {
   type Employee,
   type NewClient,
   type NewEmployee,
+  type WorkActivityStatus,
 } from '../db';
 import { eq, and, ilike } from 'drizzle-orm';
 
@@ -468,7 +469,7 @@ export class ProductionPullService extends DatabaseService {
       workActivity: {
         workType: activity.workType,
         date: activity.date,
-        status: activity.status,
+        status: activity.status as WorkActivityStatus,
         startTime: activity.startTime,
         endTime: activity.endTime,
         billableHours: activity.billableHours,

--- a/server/src/services/QuickBooksService.ts
+++ b/server/src/services/QuickBooksService.ts
@@ -3,7 +3,7 @@
 import QuickBooksLib from 'node-quickbooks';
 import OAuthClientLib from 'intuit-oauth';
 import { DatabaseService } from './DatabaseService';
-import { qboItems, qboCredentials, invoices, invoiceLineItems } from '../db';
+import { qboItems, qboCredentials, invoices, invoiceLineItems, clients } from '../db';
 import { eq } from 'drizzle-orm';
 import { encryptToken, decryptToken } from '../utils/encryption';
 
@@ -47,6 +47,7 @@ export interface QBOInvoice {
     LineNum: number;
     Amount: number;
     DetailType: string;
+    Description?: string; // Per-line description returned by QBO at the line level
     SalesItemLineDetail?: {
       ItemRef: { value: string; name: string };
       Qty: number;
@@ -388,6 +389,20 @@ export class QuickBooksService extends DatabaseService {
     });
   }
 
+  /**
+   * Fetch all invoices from QuickBooks. Uses fetchAll: true so the library
+   * handles pagination automatically — no explicit page/offset needed.
+   */
+  async getAllInvoices(): Promise<QBOInvoice[]> {
+    await this.ensureClient();
+    return new Promise((resolve, reject) => {
+      this.qbo.findInvoices({ fetchAll: true }, (err: any, response: any) => {
+        if (err) return reject(err);
+        resolve(response.QueryResponse?.Invoice || []);
+      });
+    });
+  }
+
   async createCustomer(customerData: any): Promise<any> {
     await this.ensureClient();
     return new Promise((resolve, reject) => {
@@ -481,11 +496,30 @@ export class QuickBooksService extends DatabaseService {
           geoZone: '',
           isRecurringMaintenance: false,
           activeStatus: qboCustomer.Active ? 'active' : 'inactive',
+          qboCustomerId: qboCustomer.Id,
         };
         await clientService.createClient(newClient);
-        console.log(`Created local client from QuickBooks: ${qboCustomer.DisplayName}`);
+        console.log(`Created local client from QuickBooks: ${qboCustomer.DisplayName} (qboCustomerId=${qboCustomer.Id})`);
       } else {
-        console.log(`Customer already exists locally: ${qboCustomer.DisplayName}`);
+        // Backfill qboCustomerId on the existing local client if not already set.
+        // If a different non-null qboCustomerId is already present, log a warning
+        // rather than overwriting — two QBO customers mapping to one local client
+        // is a data-quality issue that needs manual review.
+        if (!existingClient.qboCustomerId) {
+          await this.db
+            .update(clients)
+            .set({ qboCustomerId: qboCustomer.Id, updatedAt: new Date() })
+            .where(eq(clients.id, existingClient.id));
+          console.log(`Backfilled qboCustomerId=${qboCustomer.Id} for existing client: ${qboCustomer.DisplayName}`);
+        } else if (existingClient.qboCustomerId !== qboCustomer.Id) {
+          console.warn(
+            `Data quality warning: local client "${qboCustomer.DisplayName}" (id=${existingClient.id}) ` +
+            `already has qboCustomerId="${existingClient.qboCustomerId}" but QBO customer has Id="${qboCustomer.Id}". ` +
+            `Skipping update — manual review required.`
+          );
+        } else {
+          console.log(`Customer already exists locally with matching qboCustomerId: ${qboCustomer.DisplayName}`);
+        }
       }
     } catch (error) {
       console.error(`Error upserting customer ${qboCustomer.DisplayName}:`, error);

--- a/server/src/services/WorkActivityService.ts
+++ b/server/src/services/WorkActivityService.ts
@@ -9,12 +9,13 @@ import {
   clients,
   projects,
   employees,
-  type WorkActivity, 
+  type WorkActivity,
   type NewWorkActivity,
   type OtherCharge,
   type NewOtherCharge,
   type PlantListItem,
-  type NewPlantListItem
+  type NewPlantListItem,
+  type WorkActivityStatus
 } from '../db';
 import { eq, desc, like, and, gte, lte, between, inArray, exists } from 'drizzle-orm';
 
@@ -112,7 +113,7 @@ export class WorkActivityService extends DatabaseService {
     }
     
     if (filters?.status) {
-      whereConditions.push(eq(workActivities.status, filters.status));
+      whereConditions.push(eq(workActivities.status, filters.status as WorkActivityStatus));
     }
     
     if (filters?.clientId) {
@@ -638,7 +639,7 @@ export class WorkActivityService extends DatabaseService {
    * transaction handle so callers can compose this with other writes atomically.
    * Returns early when ids is empty to avoid a no-op SQL error.
    */
-  async setStatus(ids: number[], status: string, tx?: DbOrTx): Promise<void> {
+  async setStatus(ids: number[], status: WorkActivityStatus, tx?: DbOrTx): Promise<void> {
     if (ids.length === 0) return;
     const conn = tx ?? this.db;
     await conn

--- a/server/src/services/WorkActivityService.ts
+++ b/server/src/services/WorkActivityService.ts
@@ -634,6 +634,20 @@ export class WorkActivityService extends DatabaseService {
   }
 
   /**
+   * Bulk-update the status of a set of work activities. Accepts an optional
+   * transaction handle so callers can compose this with other writes atomically.
+   * Returns early when ids is empty to avoid a no-op SQL error.
+   */
+  async setStatus(ids: number[], status: string, tx?: DbOrTx): Promise<void> {
+    if (ids.length === 0) return;
+    const conn = tx ?? this.db;
+    await conn
+      .update(workActivities)
+      .set({ status, updatedAt: new Date() })
+      .where(inArray(workActivities.id, ids));
+  }
+
+  /**
    * Get a work activity by Notion page ID
    */
   async getWorkActivityByNotionPageId(notionPageId: string): Promise<WorkActivityWithDetails | undefined> {

--- a/server/src/services/container.ts
+++ b/server/src/services/container.ts
@@ -124,7 +124,12 @@ class ServiceContainer {
   }
 
   get invoiceImportService(): InvoiceImportService {
-    return this._invoiceImportService ??= new InvoiceImportService();
+    return this._invoiceImportService ??= new InvoiceImportService(
+      this.quickBooksService,
+      this.invoiceService,
+      this.workActivityService,
+      this.notificationService
+    );
   }
 
   // Google services

--- a/server/src/services/container.ts
+++ b/server/src/services/container.ts
@@ -24,6 +24,7 @@ import { TravelTimeAllocationService } from './TravelTimeAllocationService';
 import { SettingsService } from './SettingsService';
 import { QuickBooksService } from './QuickBooksService';
 import { InvoiceService } from './InvoiceService';
+import { InvoiceImportService } from './InvoiceImportService';
 import { DataMigrationService } from './DataMigrationService';
 import { GoogleSheetsService } from './GoogleSheetsService';
 import { GoogleCalendarService } from './GoogleCalendarService';
@@ -50,6 +51,7 @@ class ServiceContainer {
   private _notionSyncService?: NotionSyncService;
   private _quickBooksService?: QuickBooksService;
   private _invoiceService?: InvoiceService;
+  private _invoiceImportService?: InvoiceImportService;
 
   // Google services
   private _googleSheetsService?: GoogleSheetsService;
@@ -119,6 +121,10 @@ class ServiceContainer {
 
   get invoiceService(): InvoiceService {
     return this._invoiceService ??= new InvoiceService();
+  }
+
+  get invoiceImportService(): InvoiceImportService {
+    return this._invoiceImportService ??= new InvoiceImportService();
   }
 
   // Google services

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import Login from './components/Login';
 import NotionEmbedPage from './components/NotionEmbedPage';
 import QuickBooksIntegration from './components/QuickBooksIntegration';
 import Invoices from './components/Invoices';
+import InvoiceReview from './components/InvoiceReview';
 import Settings from './components/Settings';
 import Reports from './components/Reports';
 import NaturalLanguageSQL from './components/NaturalLanguageSQL';
@@ -61,6 +62,7 @@ function App() {
                         <Route path="/notifications" element={<Notifications />} />
                         <Route path="/quickbooks" element={<QuickBooksIntegration />} />
                         <Route path="/invoices" element={<Invoices />} />
+                        <Route path="/invoices/review" element={<InvoiceReview />} />
                         <Route path="/reports" element={<Reports />} />
                         <Route path="/ask-data" element={<NaturalLanguageSQL />} />
                         <Route path="/debug" element={<Debug />} />

--- a/src/components/InvoiceReview.tsx
+++ b/src/components/InvoiceReview.tsx
@@ -453,6 +453,8 @@ const InvoiceReview: React.FC = () => {
 
   useEffect(() => {
     fetchQueue();
+    // fetchQueue is a stable closure over component state setters; safe to omit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleConfirmed = (lineItemId: number) => {

--- a/src/components/InvoiceReview.tsx
+++ b/src/components/InvoiceReview.tsx
@@ -24,6 +24,7 @@ import {
 } from '../icons';
 import { useNavigate } from 'react-router-dom';
 import { formatDateBriefPacific } from '../utils/dateUtils';
+import { secureFetch } from '../services/csrf';
 
 // ---------------------------------------------------------------------------
 // Local types — mirror exactly what getReviewQueue() returns.
@@ -190,12 +191,11 @@ const EntryCard: React.FC<EntryCardProps> = ({
       };
       if (force) body.force = true;
 
-      const resp = await fetch(
+      const resp = await secureFetch(
         `/api/qbo/invoices/${entry.invoiceId}/line-items/${entry.lineItemId}`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
           body: JSON.stringify(body),
         }
       );

--- a/src/components/InvoiceReview.tsx
+++ b/src/components/InvoiceReview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Box,
   Container,
@@ -150,14 +150,12 @@ interface EntryCardProps {
   entry: ReviewQueueEntry;
   isActive: boolean;
   onConfirmed: (lineItemId: number) => void;
-  onQueueEmpty: () => void;
 }
 
 const EntryCard: React.FC<EntryCardProps> = ({
   entry,
   isActive,
   onConfirmed,
-  onQueueEmpty,
 }) => {
   const candidates = entry.candidates ?? [];
   const defaultValue = candidates.length > 0
@@ -180,70 +178,70 @@ const EntryCard: React.FC<EntryCardProps> = ({
     }
   }, [isActive]);
 
-  const doConfirm = useCallback(
-    async (force?: boolean) => {
-      setConfirming(true);
-      setCardError(null);
-      try {
-        const workActivityId =
-          selected === 'unmatched' ? null : Number(selected);
-        const body: Record<string, unknown> = {
-          workActivityId,
-          source: 'review',
-        };
-        if (force) body.force = true;
+  const doConfirm = async (force?: boolean) => {
+    setConfirming(true);
+    setCardError(null);
+    try {
+      const workActivityId =
+        selected === 'unmatched' ? null : Number(selected);
+      const body: Record<string, unknown> = {
+        workActivityId,
+        source: 'review',
+      };
+      if (force) body.force = true;
 
-        const resp = await fetch(
-          `/api/qbo/invoices/${entry.invoiceId}/line-items/${entry.lineItemId}`,
-          {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify(body),
-          }
-        );
+      const resp = await fetch(
+        `/api/qbo/invoices/${entry.invoiceId}/line-items/${entry.lineItemId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(body),
+        }
+      );
 
-        if (resp.ok) {
-          onConfirmed(entry.lineItemId);
+      if (resp.ok) {
+        onConfirmed(entry.lineItemId);
+        return;
+      }
+
+      if (resp.status === 409) {
+        const data = await resp.json();
+        if (data.warning === 'already_linked') {
+          setPendingLink(data as DoubleLink409);
+          setModalOpen(true);
           return;
         }
-
-        if (resp.status === 409) {
-          const data = await resp.json();
-          if (data.warning === 'already_linked') {
-            setPendingLink(data as DoubleLink409);
-            setModalOpen(true);
-            return;
-          }
-        }
-
-        // Other non-2xx error
-        let errMsg = `Request failed (${resp.status})`;
-        try {
-          const errData = await resp.json();
-          if (errData.error || errData.message) {
-            errMsg = errData.error ?? errData.message;
-          }
-        } catch {
-          // ignore parse errors
-        }
-        setCardError(errMsg);
-      } catch (err) {
-        setCardError(err instanceof Error ? err.message : 'Network error');
-      } finally {
-        setConfirming(false);
       }
-    },
-    [entry.invoiceId, entry.lineItemId, selected, onConfirmed]
-  );
+
+      // Other non-2xx error
+      let errMsg = `Request failed (${resp.status})`;
+      try {
+        const errData = await resp.json();
+        if (errData.error || errData.message) {
+          errMsg = errData.error ?? errData.message;
+        }
+      } catch {
+        // ignore parse errors
+      }
+      setCardError(errMsg);
+    } catch (err) {
+      setCardError(err instanceof Error ? err.message : 'Network error');
+    } finally {
+      setConfirming(false);
+    }
+  };
 
   const handleLinkAnyway = async () => {
     setModalLinking(true);
-    setModalOpen(false);
-    // Re-issue with force=true; doConfirm handles removal on success.
-    await doConfirm(true);
-    setModalLinking(false);
-    setPendingLink(null);
+    // Keep the modal open so the spinner is visible while the request is in flight.
+    try {
+      await doConfirm(true);
+    } finally {
+      setModalLinking(false);
+      setModalOpen(false);
+      setPendingLink(null);
+    }
   };
 
   const handleModalCancel = () => {
@@ -455,7 +453,6 @@ const InvoiceReview: React.FC = () => {
 
   useEffect(() => {
     fetchQueue();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleConfirmed = (lineItemId: number) => {
@@ -533,7 +530,6 @@ const InvoiceReview: React.FC = () => {
           entry={entry}
           isActive={idx === 0}
           onConfirmed={handleConfirmed}
-          onQueueEmpty={() => navigate('/invoices', { replace: true })}
         />
       ))}
     </Container>

--- a/src/components/InvoiceReview.tsx
+++ b/src/components/InvoiceReview.tsx
@@ -1,0 +1,543 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  Box,
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  CardActions,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Button,
+  Alert,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@mui/material';
+import {
+  ArrowLeft,
+  CheckCircle,
+  AlertTriangle,
+} from '../icons';
+import { useNavigate } from 'react-router-dom';
+import { formatDateBriefPacific } from '../utils/dateUtils';
+
+// ---------------------------------------------------------------------------
+// Local types — mirror exactly what getReviewQueue() returns.
+// clientName can be null if the join finds no client row.
+// billableHours can be null if not set on the activity.
+// ---------------------------------------------------------------------------
+
+type MatchCandidate = {
+  workActivityId: number;
+  score: number;
+  reason: string;
+  date: string;
+  workType: string;
+  billableHours: number | null;
+  notesSnippet: string;
+};
+
+type ReviewQueueEntry = {
+  lineItemId: number;
+  invoiceId: number;
+  invoiceNumber: string;
+  invoiceDate: string;
+  clientName: string | null;
+  description: string;
+  quantity: number;
+  rate: number;
+  amount: number;
+  candidates: MatchCandidate[] | null;
+};
+
+// ---------------------------------------------------------------------------
+// Small formatting helpers
+// ---------------------------------------------------------------------------
+
+const formatMoney = (n: number): string => '$' + n.toFixed(2);
+
+// ---------------------------------------------------------------------------
+// Double-link warning modal
+// ---------------------------------------------------------------------------
+
+interface DoubleLink409 {
+  warning: 'already_linked';
+  existingInvoices: Array<{ invoiceId: number; invoiceNumber: string }>;
+}
+
+interface DoubleLinkModalProps {
+  open: boolean;
+  data: DoubleLink409 | null;
+  onCancel: () => void;
+  onLinkAnyway: () => void;
+  linking: boolean;
+}
+
+const DoubleLinkModal: React.FC<DoubleLinkModalProps> = ({
+  open,
+  data,
+  onCancel,
+  onLinkAnyway,
+  linking,
+}) => {
+  const totalCount = (data?.existingInvoices.length ?? 0) + 1;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth="sm"
+      fullWidth
+      // Default focus goes to the first focusable element — Cancel is first
+      // in DialogActions so it receives focus automatically.
+    >
+      <DialogTitle>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AlertTriangle size={20} />
+          Activity already linked to another invoice
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body1" gutterBottom>
+          This work activity is already linked to:
+        </Typography>
+        <Box component="ul" sx={{ mt: 1, mb: 2, pl: 2 }}>
+          {data?.existingInvoices.map((inv) => (
+            <li key={inv.invoiceId}>
+              <Typography variant="body2">
+                Invoice #{inv.invoiceNumber}
+              </Typography>
+            </li>
+          ))}
+        </Box>
+        <Typography variant="body2" color="warning.main">
+          Linking it here will result in this activity being counted on{' '}
+          {totalCount} invoice{totalCount !== 1 ? 's' : ''}.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        {/* Cancel is listed first so it receives default focus */}
+        <Button
+          onClick={onCancel}
+          variant="contained"
+          disabled={linking}
+          autoFocus
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={onLinkAnyway}
+          variant="text"
+          color="warning"
+          disabled={linking}
+        >
+          {linking ? <CircularProgress size={16} /> : 'Link anyway'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Per-entry card
+// ---------------------------------------------------------------------------
+
+interface EntryCardProps {
+  entry: ReviewQueueEntry;
+  isActive: boolean;
+  onConfirmed: (lineItemId: number) => void;
+  onQueueEmpty: () => void;
+}
+
+const EntryCard: React.FC<EntryCardProps> = ({
+  entry,
+  isActive,
+  onConfirmed,
+  onQueueEmpty,
+}) => {
+  const candidates = entry.candidates ?? [];
+  const defaultValue = candidates.length > 0
+    ? String(candidates[0].workActivityId)
+    : 'unmatched';
+
+  const [selected, setSelected] = useState<string>(defaultValue);
+  const [confirming, setConfirming] = useState(false);
+  const [cardError, setCardError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalLinking, setModalLinking] = useState(false);
+  const [pendingLink, setPendingLink] = useState<DoubleLink409 | null>(null);
+
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  // Auto-focus when this card becomes active
+  useEffect(() => {
+    if (isActive && cardRef.current) {
+      cardRef.current.focus();
+    }
+  }, [isActive]);
+
+  const doConfirm = useCallback(
+    async (force?: boolean) => {
+      setConfirming(true);
+      setCardError(null);
+      try {
+        const workActivityId =
+          selected === 'unmatched' ? null : Number(selected);
+        const body: Record<string, unknown> = {
+          workActivityId,
+          source: 'review',
+        };
+        if (force) body.force = true;
+
+        const resp = await fetch(
+          `/api/qbo/invoices/${entry.invoiceId}/line-items/${entry.lineItemId}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (resp.ok) {
+          onConfirmed(entry.lineItemId);
+          return;
+        }
+
+        if (resp.status === 409) {
+          const data = await resp.json();
+          if (data.warning === 'already_linked') {
+            setPendingLink(data as DoubleLink409);
+            setModalOpen(true);
+            return;
+          }
+        }
+
+        // Other non-2xx error
+        let errMsg = `Request failed (${resp.status})`;
+        try {
+          const errData = await resp.json();
+          if (errData.error || errData.message) {
+            errMsg = errData.error ?? errData.message;
+          }
+        } catch {
+          // ignore parse errors
+        }
+        setCardError(errMsg);
+      } catch (err) {
+        setCardError(err instanceof Error ? err.message : 'Network error');
+      } finally {
+        setConfirming(false);
+      }
+    },
+    [entry.invoiceId, entry.lineItemId, selected, onConfirmed]
+  );
+
+  const handleLinkAnyway = async () => {
+    setModalLinking(true);
+    setModalOpen(false);
+    // Re-issue with force=true; doConfirm handles removal on success.
+    await doConfirm(true);
+    setModalLinking(false);
+    setPendingLink(null);
+  };
+
+  const handleModalCancel = () => {
+    setModalOpen(false);
+    setPendingLink(null);
+  };
+
+  // Keyboard shortcuts on the focused card
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!isActive) return;
+    // Ignore key events that originated from inside interactive elements
+    // (radio, button) so we don't conflict with their native behaviour.
+    const tag = (e.target as HTMLElement).tagName.toLowerCase();
+    if (tag === 'input' || tag === 'button') return;
+
+    switch (e.key) {
+      case '1':
+        if (candidates.length >= 1) setSelected(String(candidates[0].workActivityId));
+        break;
+      case '2':
+        if (candidates.length >= 2) setSelected(String(candidates[1].workActivityId));
+        break;
+      case '3':
+        if (candidates.length >= 3) setSelected(String(candidates[2].workActivityId));
+        break;
+      case '0':
+        setSelected('unmatched');
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (!confirming) doConfirm();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const headerLine = [
+    `Invoice #${entry.invoiceNumber}`,
+    entry.clientName ?? '(unknown client)',
+    formatDateBriefPacific(entry.invoiceDate),
+  ].join(' · ');
+
+  const amountLine = [
+    entry.description || '(no description)',
+    `Qty ${entry.quantity} × ${formatMoney(entry.rate)} = ${formatMoney(entry.amount)}`,
+  ].join(' · ');
+
+  return (
+    <>
+      <Card
+        ref={cardRef}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        sx={{
+          mb: 2,
+          outline: isActive ? '2px solid' : 'none',
+          outlineColor: isActive ? 'primary.main' : 'transparent',
+          outlineOffset: 2,
+          '&:focus': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: 2 },
+        }}
+      >
+        <CardContent>
+          {/* Header */}
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              mb: 2,
+              flexWrap: 'wrap',
+              gap: 1,
+            }}
+          >
+            <Typography variant="subtitle1" fontWeight="medium">
+              {headerLine}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {amountLine}
+            </Typography>
+          </Box>
+
+          {/* Candidate radio group */}
+          <RadioGroup
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            {candidates.map((c, idx) => (
+              <Box key={c.workActivityId} sx={{ mb: 1 }}>
+                <FormControlLabel
+                  value={String(c.workActivityId)}
+                  control={<Radio size="small" />}
+                  label={
+                    <Box>
+                      <Typography variant="body2">
+                        {[
+                          formatDateBriefPacific(c.date),
+                          c.workType,
+                          c.billableHours != null ? `${c.billableHours}h` : null,
+                        ]
+                          .filter(Boolean)
+                          .join(' · ')}
+                        {' '}
+                        <Typography
+                          component="span"
+                          variant="caption"
+                          color="text.secondary"
+                        >
+                          score {c.score.toFixed(2)}
+                        </Typography>
+                      </Typography>
+                      {c.notesSnippet && (
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ ml: 0, mt: 0.25, fontStyle: 'italic' }}
+                        >
+                          {c.notesSnippet}
+                        </Typography>
+                      )}
+                      <Typography variant="caption" color="text.disabled">
+                        [{idx + 1}] {c.reason}
+                      </Typography>
+                    </Box>
+                  }
+                />
+              </Box>
+            ))}
+
+            {/* Leave unmatched option */}
+            <FormControlLabel
+              value="unmatched"
+              control={<Radio size="small" />}
+              label={
+                <Typography variant="body2" color="text.secondary">
+                  Leave unmatched{' '}
+                  <Typography component="span" variant="caption" color="text.disabled">
+                    [0]
+                  </Typography>
+                </Typography>
+              }
+            />
+          </RadioGroup>
+
+          {cardError && (
+            <Alert severity="error" sx={{ mt: 1 }} onClose={() => setCardError(null)}>
+              {cardError}
+            </Alert>
+          )}
+        </CardContent>
+
+        <CardActions sx={{ justifyContent: 'flex-end', px: 2, pb: 2 }}>
+          <Button
+            variant="contained"
+            startIcon={
+              confirming ? <CircularProgress size={16} /> : <CheckCircle size={16} />
+            }
+            disabled={confirming}
+            onClick={() => doConfirm()}
+          >
+            {confirming ? 'Confirming…' : 'Confirm'}
+          </Button>
+        </CardActions>
+      </Card>
+
+      <DoubleLinkModal
+        open={modalOpen}
+        data={pendingLink}
+        onCancel={handleModalCancel}
+        onLinkAnyway={handleLinkAnyway}
+        linking={modalLinking}
+      />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+const InvoiceReview: React.FC = () => {
+  const navigate = useNavigate();
+  const [queue, setQueue] = useState<ReviewQueueEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchQueue = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await fetch('/api/qbo/invoices/review-queue', {
+        credentials: 'include',
+      });
+      if (!resp.ok) {
+        throw new Error(`Failed to load review queue (${resp.status})`);
+      }
+      const data: ReviewQueueEntry[] = await resp.json();
+      setQueue(data);
+      if (data.length === 0) {
+        // Empty on load — navigate immediately; no flash needed.
+        navigate('/invoices', { replace: true });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load review queue');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchQueue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleConfirmed = (lineItemId: number) => {
+    setQueue((prev) => {
+      const next = prev.filter((e) => e.lineItemId !== lineItemId);
+      if (next.length === 0) {
+        navigate('/invoices', { replace: true });
+      }
+      return next;
+    });
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render states
+  // ---------------------------------------------------------------------------
+
+  if (loading) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <CircularProgress />
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={fetchQueue}>
+              Retry
+            </Button>
+          }
+        >
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      {/* Back link + title */}
+      <Box sx={{ mb: 3 }}>
+        <Button
+          variant="text"
+          startIcon={<ArrowLeft size={16} />}
+          onClick={() => navigate('/invoices')}
+          sx={{ mb: 1, pl: 0 }}
+        >
+          Back to Invoices
+        </Button>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
+          <Typography variant="h5" component="h1">
+            Review matches
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {queue.length} remaining
+          </Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          Pick the best work activity for each line item, or leave it unmatched.
+          Keyboard: <strong>1 / 2 / 3</strong> to pick, <strong>0</strong> to leave
+          unmatched, <strong>Enter</strong> to confirm.
+        </Typography>
+      </Box>
+
+      {/* Cards */}
+      {queue.map((entry, idx) => (
+        <EntryCard
+          key={entry.lineItemId}
+          entry={entry}
+          isActive={idx === 0}
+          onConfirmed={handleConfirmed}
+          onQueueEmpty={() => navigate('/invoices', { replace: true })}
+        />
+      ))}
+    </Container>
+  );
+};
+
+export default InvoiceReview;

--- a/src/components/Invoices.tsx
+++ b/src/components/Invoices.tsx
@@ -55,6 +55,7 @@ import {
 } from '../icons';
 import { useNavigate } from 'react-router-dom';
 import { formatDateBriefPacific } from '../utils/dateUtils';
+import { secureFetch } from '../services/csrf';
 
 interface Invoice {
   id: number;
@@ -171,7 +172,7 @@ const Invoices: React.FC = () => {
     try {
       setError(null);
       
-      const response = await fetch(`/api/qbo/invoices/${invoiceId}/sync`, {
+      const response = await secureFetch(`/api/qbo/invoices/${invoiceId}/sync`, {
         method: 'POST',
       });
       
@@ -193,7 +194,7 @@ const Invoices: React.FC = () => {
       setError(null);
       
       console.log('Making DELETE request to:', `/api/qbo/invoices/${invoiceId}`);
-      const response = await fetch(`/api/qbo/invoices/${invoiceId}`, {
+      const response = await secureFetch(`/api/qbo/invoices/${invoiceId}`, {
         method: 'DELETE',
       });
       
@@ -226,10 +227,9 @@ const Invoices: React.FC = () => {
       setSyncing(true);
       setError(null);
 
-      const response = await fetch('/api/qbo/invoices/sync-all', {
+      const response = await secureFetch('/api/qbo/invoices/sync-all', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
         body: JSON.stringify({}),
       });
 

--- a/src/components/Invoices.tsx
+++ b/src/components/Invoices.tsx
@@ -93,6 +93,7 @@ interface SyncPreviewLine {
   status: 'auto' | 'needs_review' | 'unmatched';
   matchedActivityId: number | null;
   matchScore: number | null;
+  duplicateOf?: string;
 }
 
 interface SyncPreviewInvoice {
@@ -101,6 +102,13 @@ interface SyncPreviewInvoice {
   customerName: string;
   action: 'import' | 'update' | 'skip';
   lines: SyncPreviewLine[];
+}
+
+interface DuplicateMatch {
+  activityId: number;
+  lineDescription: string;
+  invoiceNumber: string;
+  claimedByInvoiceNumber: string;
 }
 
 interface SyncResult {
@@ -112,6 +120,7 @@ interface SyncResult {
   errors: SyncResultError[];
   dryRun?: boolean;
   preview?: SyncPreviewInvoice[];
+  duplicateMatches?: DuplicateMatch[];
 }
 
 const Invoices: React.FC = () => {
@@ -134,6 +143,7 @@ const Invoices: React.FC = () => {
   const [syncModalOpen, setSyncModalOpen] = useState(false);
   const [errorsExpanded, setErrorsExpanded] = useState(false);
   const [previewExpanded, setPreviewExpanded] = useState(false);
+  const [duplicatesExpanded, setDuplicatesExpanded] = useState(false);
 
   useEffect(() => {
     fetchInvoices();
@@ -264,6 +274,7 @@ const Invoices: React.FC = () => {
       setSyncModalOpen(true);
       setErrorsExpanded(false);
       setPreviewExpanded(false);
+      setDuplicatesExpanded(false);
       // A dry run writes nothing, so the invoice list is unchanged.
       if (!dryRun) {
         await fetchInvoices();
@@ -298,6 +309,7 @@ const Invoices: React.FC = () => {
     setSyncResult(null);
     setErrorsExpanded(false);
     setPreviewExpanded(false);
+    setDuplicatesExpanded(false);
   };
 
   const handleSort = (property: keyof Invoice) => {
@@ -854,6 +866,18 @@ const Invoices: React.FC = () => {
                   </Typography>
                 </Box>
               </Grid>
+              {syncResult?.dryRun && (
+                <Grid item xs={6} sm={4}>
+                  <Box sx={{ textAlign: 'center' }}>
+                    <Typography variant="h4" color={(syncResult?.duplicateMatches?.length ?? 0) > 0 ? 'warning.main' : 'text.primary'}>
+                      {syncResult?.duplicateMatches?.length ?? 0}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Duplicate matches
+                    </Typography>
+                  </Box>
+                </Grid>
+              )}
             </Grid>
 
             {(syncResult?.errors?.length ?? 0) > 0 && (
@@ -892,6 +916,52 @@ const Invoices: React.FC = () => {
                         </Typography>
                         <Typography variant="body2" color="text.secondary">
                           {err.message}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </Collapse>
+              </Box>
+            )}
+
+            {syncResult?.dryRun && (syncResult.duplicateMatches?.length ?? 0) > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Alert severity="warning" sx={{ mb: 1 }}>
+                  The same work activity strongly matched more than one invoice. In a
+                  real run the <strong>older</strong> invoice keeps the activity and the
+                  newer one is left for manual review — confirm that's the right call.
+                </Alert>
+                <Button
+                  size="small"
+                  variant="text"
+                  color="warning"
+                  startIcon={<AlertTriangle size={16} />}
+                  endIcon={duplicatesExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                  onClick={() => setDuplicatesExpanded(prev => !prev)}
+                >
+                  {duplicatesExpanded ? 'Hide' : 'Show'} duplicate matches ({syncResult.duplicateMatches!.length})
+                </Button>
+                <Collapse in={duplicatesExpanded}>
+                  <Box sx={{ mt: 1, maxHeight: 240, overflowY: 'auto' }}>
+                    {syncResult.duplicateMatches!.map((dup, idx) => (
+                      <Box
+                        key={idx}
+                        sx={{
+                          mb: 1,
+                          p: 1.5,
+                          borderRadius: 1,
+                          bgcolor: 'warning.50',
+                          border: '1px solid',
+                          borderColor: 'warning.200',
+                        }}
+                      >
+                        <Typography variant="body2" fontWeight="medium" color="warning.main">
+                          Activity #{dup.activityId} contested
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          Invoice #{dup.invoiceNumber} would match it, but invoice{' '}
+                          #{dup.claimedByInvoiceNumber} (older) claims it first.
+                          {dup.lineDescription && ` — "${dup.lineDescription}"`}
                         </Typography>
                       </Box>
                     ))}
@@ -941,7 +1011,8 @@ const Invoices: React.FC = () => {
                             <Typography
                               variant="caption"
                               color={
-                                ln.status === 'auto' ? 'success.main'
+                                ln.duplicateOf ? 'warning.main'
+                                  : ln.status === 'auto' ? 'success.main'
                                   : ln.status === 'needs_review' ? 'warning.main'
                                   : 'text.disabled'
                               }
@@ -949,6 +1020,7 @@ const Invoices: React.FC = () => {
                               {ln.status}
                               {ln.matchedActivityId != null && ` → #${ln.matchedActivityId}`}
                               {ln.matchScore != null && ` (${ln.matchScore.toFixed(1)})`}
+                              {ln.duplicateOf && ` ⚠ dup of #${ln.duplicateOf}`}
                             </Typography>
                           </Box>
                         ))}

--- a/src/components/Invoices.tsx
+++ b/src/components/Invoices.tsx
@@ -34,6 +34,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
+  Collapse,
 } from '@mui/material';
 import {
   Receipt,
@@ -48,6 +49,9 @@ import {
   CalendarDays as Schedule,
   ExternalLink as OpenInNew,
   Trash2 as Delete,
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
 } from '../icons';
 import { useNavigate } from 'react-router-dom';
 import { formatDateBriefPacific } from '../utils/dateUtils';
@@ -75,6 +79,21 @@ interface InvoiceStats {
   overdueCount: number;
 }
 
+interface SyncResultError {
+  type: 'unmatched_client' | 'qbo_fetch_failed' | 'invoice_persist_failed' | 'matcher_failed';
+  qboInvoiceId?: string;
+  message: string;
+}
+
+interface SyncResult {
+  imported: number;
+  updated: number;
+  autoMatched: number;
+  needsReview: number;
+  unmatched: number;
+  errors: SyncResultError[];
+}
+
 const Invoices: React.FC = () => {
   const navigate = useNavigate();
   const [invoices, setInvoices] = useState<Invoice[]>([]);
@@ -89,6 +108,10 @@ const Invoices: React.FC = () => {
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<SyncResult | null>(null);
+  const [syncModalOpen, setSyncModalOpen] = useState(false);
+  const [errorsExpanded, setErrorsExpanded] = useState(false);
 
   useEffect(() => {
     fetchInvoices();
@@ -198,6 +221,51 @@ const Invoices: React.FC = () => {
     }
   };
 
+  const syncAllInvoices = async () => {
+    try {
+      setSyncing(true);
+      setError(null);
+
+      const response = await fetch('/api/qbo/invoices/sync-all', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Sync failed: ${response.status}`);
+      }
+
+      const result: SyncResult = await response.json();
+      setSyncResult(result);
+      setSyncModalOpen(true);
+      setErrorsExpanded(false);
+      await fetchInvoices();
+    } catch (err) {
+      console.error('Error syncing invoices:', err);
+      setError(err instanceof Error ? err.message : 'Failed to sync invoices from QuickBooks');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const humanizeErrorType = (type: SyncResultError['type']): string => {
+    switch (type) {
+      case 'unmatched_client': return 'Unmatched client';
+      case 'qbo_fetch_failed': return 'QuickBooks fetch failed';
+      case 'invoice_persist_failed': return 'Invoice save failed';
+      case 'matcher_failed': return 'Matcher failed';
+      default: return type;
+    }
+  };
+
+  const handleSyncModalClose = () => {
+    setSyncModalOpen(false);
+    setSyncResult(null);
+    setErrorsExpanded(false);
+  };
+
   const handleSort = (property: keyof Invoice) => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');
@@ -302,13 +370,23 @@ const Invoices: React.FC = () => {
               Manage and track your QuickBooks invoices
             </Typography>
           </Box>
-          <Button
-            variant="contained"
-            startIcon={<Add />}
-            onClick={() => navigate('/clients')}
-          >
-            Create Invoice
-          </Button>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              variant="outlined"
+              startIcon={syncing ? <CircularProgress size={16} /> : <Sync />}
+              onClick={syncAllInvoices}
+              disabled={syncing}
+            >
+              {syncing ? 'Syncing...' : 'Sync from QuickBooks'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<Add />}
+              onClick={() => navigate('/clients')}
+            >
+              Create Invoice
+            </Button>
+          </Box>
         </Box>
 
         {error && (
@@ -664,6 +742,129 @@ const Invoices: React.FC = () => {
             >
               {deleting ? 'Deleting...' : 'Delete Invoice'}
             </Button>
+          </DialogActions>
+        </Dialog>
+        {/* Sync Results Modal */}
+        <Dialog
+          open={syncModalOpen}
+          onClose={handleSyncModalClose}
+          maxWidth="sm"
+          fullWidth
+        >
+          <DialogTitle>QuickBooks sync complete</DialogTitle>
+          <DialogContent>
+            <Grid container spacing={2} sx={{ mb: 2 }}>
+              <Grid item xs={6} sm={4}>
+                <Box sx={{ textAlign: 'center' }}>
+                  <Typography variant="h4" color="success.main">
+                    {syncResult?.imported ?? 0}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Imported
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={6} sm={4}>
+                <Box sx={{ textAlign: 'center' }}>
+                  <Typography variant="h4">
+                    {syncResult?.updated ?? 0}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Updated
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={6} sm={4}>
+                <Box sx={{ textAlign: 'center' }}>
+                  <Typography variant="h4" color="success.main">
+                    {syncResult?.autoMatched ?? 0}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Auto-matched
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={6} sm={4}>
+                <Box sx={{ textAlign: 'center' }}>
+                  <Typography variant="h4" color={(syncResult?.needsReview ?? 0) > 0 ? 'warning.main' : 'text.primary'}>
+                    {syncResult?.needsReview ?? 0}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Needs review
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={6} sm={4}>
+                <Box sx={{ textAlign: 'center' }}>
+                  <Typography variant="h4" color={(syncResult?.errors?.length ?? 0) > 0 ? 'error.main' : 'text.primary'}>
+                    {syncResult?.errors?.length ?? 0}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Errors
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+
+            {(syncResult?.errors?.length ?? 0) > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Button
+                  size="small"
+                  variant="text"
+                  color="error"
+                  startIcon={<AlertTriangle size={16} />}
+                  endIcon={errorsExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                  onClick={() => setErrorsExpanded(prev => !prev)}
+                >
+                  {errorsExpanded ? 'Hide' : 'Show'} errors ({syncResult!.errors.length})
+                </Button>
+                <Collapse in={errorsExpanded}>
+                  <Box sx={{ mt: 1, maxHeight: 240, overflowY: 'auto' }}>
+                    {syncResult!.errors.map((err, idx) => (
+                      <Box
+                        key={idx}
+                        sx={{
+                          mb: 1,
+                          p: 1.5,
+                          borderRadius: 1,
+                          bgcolor: 'error.50',
+                          border: '1px solid',
+                          borderColor: 'error.200',
+                        }}
+                      >
+                        <Typography variant="body2" fontWeight="medium" color="error.main">
+                          {humanizeErrorType(err.type)}
+                          {err.qboInvoiceId && (
+                            <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+                              (QBO #{err.qboInvoiceId})
+                            </Typography>
+                          )}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {err.message}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </Collapse>
+              </Box>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleSyncModalClose}>
+              Close
+            </Button>
+            {(syncResult?.needsReview ?? 0) > 0 && (
+              <Button
+                variant="contained"
+                onClick={() => {
+                  handleSyncModalClose();
+                  navigate('/invoices/review');
+                }}
+              >
+                Review {syncResult!.needsReview} match{syncResult!.needsReview === 1 ? '' : 'es'}
+              </Button>
+            )}
           </DialogActions>
         </Dialog>
       </Box>

--- a/src/components/Invoices.tsx
+++ b/src/components/Invoices.tsx
@@ -86,6 +86,23 @@ interface SyncResultError {
   message: string;
 }
 
+interface SyncPreviewLine {
+  description: string;
+  amount: number;
+  kind: 'labor' | 'material';
+  status: 'auto' | 'needs_review' | 'unmatched';
+  matchedActivityId: number | null;
+  matchScore: number | null;
+}
+
+interface SyncPreviewInvoice {
+  qboInvoiceId: string;
+  invoiceNumber: string;
+  customerName: string;
+  action: 'import' | 'update' | 'skip';
+  lines: SyncPreviewLine[];
+}
+
 interface SyncResult {
   imported: number;
   updated: number;
@@ -93,6 +110,8 @@ interface SyncResult {
   needsReview: number;
   unmatched: number;
   errors: SyncResultError[];
+  dryRun?: boolean;
+  preview?: SyncPreviewInvoice[];
 }
 
 const Invoices: React.FC = () => {
@@ -110,9 +129,11 @@ const Invoices: React.FC = () => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
   const [syncResult, setSyncResult] = useState<SyncResult | null>(null);
   const [syncModalOpen, setSyncModalOpen] = useState(false);
   const [errorsExpanded, setErrorsExpanded] = useState(false);
+  const [previewExpanded, setPreviewExpanded] = useState(false);
 
   useEffect(() => {
     fetchInvoices();
@@ -222,33 +243,45 @@ const Invoices: React.FC = () => {
     }
   };
 
-  const syncAllInvoices = async () => {
+  const runSync = async (dryRun: boolean) => {
+    const setBusy = dryRun ? setPreviewing : setSyncing;
     try {
-      setSyncing(true);
+      setBusy(true);
       setError(null);
 
       const response = await secureFetch('/api/qbo/invoices/sync-all', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ dryRun }),
       });
 
       if (!response.ok) {
-        throw new Error(`Sync failed: ${response.status}`);
+        throw new Error(`${dryRun ? 'Preview' : 'Sync'} failed: ${response.status}`);
       }
 
       const result: SyncResult = await response.json();
       setSyncResult(result);
       setSyncModalOpen(true);
       setErrorsExpanded(false);
-      await fetchInvoices();
+      setPreviewExpanded(false);
+      // A dry run writes nothing, so the invoice list is unchanged.
+      if (!dryRun) {
+        await fetchInvoices();
+      }
     } catch (err) {
       console.error('Error syncing invoices:', err);
-      setError(err instanceof Error ? err.message : 'Failed to sync invoices from QuickBooks');
+      setError(
+        err instanceof Error
+          ? err.message
+          : `Failed to ${dryRun ? 'preview' : 'sync'} invoices from QuickBooks`
+      );
     } finally {
-      setSyncing(false);
+      setBusy(false);
     }
   };
+
+  const syncAllInvoices = () => runSync(false);
+  const previewSync = () => runSync(true);
 
   const humanizeErrorType = (type: SyncResultError['type']): string => {
     switch (type) {
@@ -264,6 +297,7 @@ const Invoices: React.FC = () => {
     setSyncModalOpen(false);
     setSyncResult(null);
     setErrorsExpanded(false);
+    setPreviewExpanded(false);
   };
 
   const handleSort = (property: keyof Invoice) => {
@@ -372,10 +406,18 @@ const Invoices: React.FC = () => {
           </Box>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Button
+              variant="text"
+              startIcon={previewing ? <CircularProgress size={16} /> : <Visibility size={16} />}
+              onClick={previewSync}
+              disabled={syncing || previewing}
+            >
+              {previewing ? 'Previewing...' : 'Preview sync'}
+            </Button>
+            <Button
               variant="outlined"
               startIcon={syncing ? <CircularProgress size={16} /> : <Sync />}
               onClick={syncAllInvoices}
-              disabled={syncing}
+              disabled={syncing || previewing}
             >
               {syncing ? 'Syncing...' : 'Sync from QuickBooks'}
             </Button>
@@ -751,8 +793,16 @@ const Invoices: React.FC = () => {
           maxWidth="sm"
           fullWidth
         >
-          <DialogTitle>QuickBooks sync complete</DialogTitle>
+          <DialogTitle>
+            {syncResult?.dryRun ? 'QuickBooks sync preview' : 'QuickBooks sync complete'}
+          </DialogTitle>
           <DialogContent>
+            {syncResult?.dryRun && (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                This is a preview — <strong>no changes were made</strong>. The numbers
+                below show what a real sync would do.
+              </Alert>
+            )}
             <Grid container spacing={2} sx={{ mb: 2 }}>
               <Grid item xs={6} sm={4}>
                 <Box sx={{ textAlign: 'center' }}>
@@ -760,7 +810,7 @@ const Invoices: React.FC = () => {
                     {syncResult?.imported ?? 0}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
-                    Imported
+                    {syncResult?.dryRun ? 'Would import' : 'Imported'}
                   </Typography>
                 </Box>
               </Grid>
@@ -770,7 +820,7 @@ const Invoices: React.FC = () => {
                     {syncResult?.updated ?? 0}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
-                    Updated
+                    {syncResult?.dryRun ? 'Would update' : 'Updated'}
                   </Typography>
                 </Box>
               </Grid>
@@ -849,21 +899,94 @@ const Invoices: React.FC = () => {
                 </Collapse>
               </Box>
             )}
+
+            {syncResult?.dryRun && (syncResult.preview?.length ?? 0) > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Button
+                  size="small"
+                  variant="text"
+                  endIcon={previewExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                  onClick={() => setPreviewExpanded(prev => !prev)}
+                >
+                  {previewExpanded ? 'Hide' : 'Show'} per-invoice breakdown ({syncResult.preview!.length})
+                </Button>
+                <Collapse in={previewExpanded}>
+                  <Box sx={{ mt: 1, maxHeight: 320, overflowY: 'auto' }}>
+                    {syncResult.preview!.map((inv) => (
+                      <Box
+                        key={inv.qboInvoiceId}
+                        sx={{
+                          mb: 1,
+                          p: 1.5,
+                          borderRadius: 1,
+                          bgcolor: 'grey.50',
+                          border: '1px solid',
+                          borderColor: 'grey.200',
+                        }}
+                      >
+                        <Typography variant="body2" fontWeight="medium">
+                          #{inv.invoiceNumber} · {inv.customerName || '(unknown customer)'}
+                          <Chip
+                            label={inv.action}
+                            size="small"
+                            sx={{ ml: 1 }}
+                            color={inv.action === 'skip' ? 'error' : inv.action === 'update' ? 'default' : 'success'}
+                          />
+                        </Typography>
+                        {inv.lines.map((ln, lIdx) => (
+                          <Box key={lIdx} sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, mt: 0.5 }}>
+                            <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+                              {ln.description || '(no description)'} · ${ln.amount.toFixed(2)}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              color={
+                                ln.status === 'auto' ? 'success.main'
+                                  : ln.status === 'needs_review' ? 'warning.main'
+                                  : 'text.disabled'
+                              }
+                            >
+                              {ln.status}
+                              {ln.matchedActivityId != null && ` → #${ln.matchedActivityId}`}
+                              {ln.matchScore != null && ` (${ln.matchScore.toFixed(1)})`}
+                            </Typography>
+                          </Box>
+                        ))}
+                      </Box>
+                    ))}
+                  </Box>
+                </Collapse>
+              </Box>
+            )}
           </DialogContent>
           <DialogActions>
             <Button onClick={handleSyncModalClose}>
               Close
             </Button>
-            {(syncResult?.needsReview ?? 0) > 0 && (
+            {syncResult?.dryRun ? (
               <Button
                 variant="contained"
+                disabled={syncing}
+                startIcon={syncing ? <CircularProgress size={16} /> : <Sync />}
                 onClick={() => {
                   handleSyncModalClose();
-                  navigate('/invoices/review');
+                  syncAllInvoices();
                 }}
               >
-                Review {syncResult!.needsReview} match{syncResult!.needsReview === 1 ? '' : 'es'}
+                Run sync for real
               </Button>
+            ) : (
+              (syncResult?.needsReview ?? 0) > 0 && (
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    handleSyncModalClose();
+                    navigate('/invoices/review');
+                  }}
+                >
+                  Review {syncResult!.needsReview} match{syncResult!.needsReview === 1 ? '' : 'es'}
+                </Button>
+              )
             )}
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
## Summary

Adds a pull/import direction to the QBO integration so invoices created in QuickBooks (or pre-dating this integration) can be brought into the local DB and associated with the work activities they were billing for. Today the integration is push-only.

- **Sync**: `POST /api/qbo/invoices/sync-all` pulls all QBO invoices in `TxnDate ASC` order, upserts them locally, and auto-matches each line item to a candidate work activity using a confidence-scored matcher (hours / token overlap / proximity / workType→QBO item).
- **Triage**: low-confidence matches stay unlinked with `match_status='needs_review'` and persisted top-3 candidates; the new `/invoices/review` page surfaces them as cards (radio + Confirm, keyboard 1/2/3/0/Enter).
- **High-confidence matches** auto-apply and flip the work activity from `completed` → `invoiced` in the same per-invoice transaction. Per-invoice errors are isolated (one bad invoice doesn't abort the sync) and surfaced in the post-sync results modal.
- **Correction primitive**: `PATCH /api/qbo/invoices/:id/line-items/:lineItemId` (also reused by the review queue). Detects cross-invoice double-links and returns `409 { warning: 'already_linked', existingInvoices }`; the UI shows a loud Cancel-default modal, and a confirmed force-link writes a `notifications` row for the audit trail.
- **Rematch**: `POST /api/qbo/invoices/:id/rematch` re-runs the matcher on an invoice while preserving any line marked `'manual'` (confirmed user decisions, including explicit "leave unmatched").

The per-invoice detail page is intentionally deferred; the review queue covers the main triage flow and the PATCH endpoint exists for one-off corrections.

## Implementation notes

- New `InvoiceImportService` keeps import-direction logic out of the existing push-only `InvoiceService`.
- Lifted `updateWorkActivitiesStatus` from `InvoiceService` (private) to `WorkActivityService.setStatus` (public) so both flows share one status-flip primitive.
- `QBOInvoice.Line` type extended with `Description?: string` (QBO returns it; the local type didn't model it).
- Matcher uses thresholds `HIGH_THRESHOLD = 5` and `MIN_THRESHOLD = 2` — tune after a real dry-run import.
- Materials are auto-only for v1 (no `needs_review` state); the review queue is labor-focused.
- Within-invoice dedup: lines processed in descending top-score order, claimed activities removed from the candidate pool so the same activity can't auto-link to two lines on the same invoice.

## Test Plan

- [x] Migration `0014_magenta_rogue.sql` applied to local DB; columns visible in `\d clients` / `\d invoice_line_items`
- [x] 23/23 matcher unit tests pass (`server/src/__tests__/invoiceImportService.test.ts`)
- [x] Server type-check clean
- [x] Frontend type-check clean
- [x] Frontend production build clean (no new warnings)
- [ ] **Dry-run on real QBO data**: hit `POST /api/qbo/invoices/sync-all` against a sandbox or production account. Confirm the response counts add up (`autoMatched + needsReview + unmatched` equals total imported line items). Inspect a few `'auto'` and `'needs_review'` lines for false positives / candidate quality.
- [ ] Open `/invoices/review`, confirm a few candidates and pick "Leave unmatched" on at least one. Verify the queue drains, `match_status` flips to `'manual'`, and the relevant work activities update to `'invoiced'` (or stay `'completed'` for the unmatched pick).
- [ ] Trigger the double-link path (link an activity that's already linked to another invoice via DB or a second sync). Verify the 409 → modal flow, Cancel default-focus, "Link anyway" force path, and the resulting `work_activity_double_linked` notification.
- [ ] Idempotency: re-run `sync-all`; counts stable, no duplicate line items, prior `'manual'` lines preserved.
- [ ] Rematch on an invoice: cleared lines revert; orphaned activities go back to `'completed'`; `'manual'` lines untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)