### PR TITLE
QBO invoice import: add invoice-date window to sync

### DIFF
--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -229,17 +229,27 @@ router.get('/invoices', async (req, res) => {
  */
 router.post('/invoices/sync-all', async (req, res) => {
   try {
-    const { since, dryRun } = req.body ?? {};
+    const { since, until, dryRun } = req.body ?? {};
+    const isoDate = /^\d{4}-\d{2}-\d{2}$/;
     if (since !== undefined) {
-      if (typeof since !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(since)) {
+      if (typeof since !== 'string' || !isoDate.test(since)) {
         return res.status(400).json({ error: 'since must be a date string in YYYY-MM-DD format' });
       }
+    }
+    if (until !== undefined) {
+      if (typeof until !== 'string' || !isoDate.test(until)) {
+        return res.status(400).json({ error: 'until must be a date string in YYYY-MM-DD format' });
+      }
+    }
+    if (typeof since === 'string' && typeof until === 'string' && since > until) {
+      return res.status(400).json({ error: 'since must be on or before until' });
     }
     if (dryRun !== undefined && typeof dryRun !== 'boolean') {
       return res.status(400).json({ error: 'dryRun must be a boolean' });
     }
     const result = await services.invoiceImportService.syncAllInvoices({
       since,
+      until,
       dryRun: dryRun === true
     });
     res.json(result);

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -379,8 +379,13 @@ export class InvoiceImportService extends DatabaseService {
    * When `dryRun` is true, NO database writes happen: the matcher still runs
    * and the same counts are returned, plus a per-invoice `preview`, so the
    * operator can evaluate match quality before committing.
+   *
+   * `since` / `until` bound the run to invoices whose QBO TxnDate falls in
+   * [since, until] (either end optional). Both are 'YYYY-MM-DD'. NOTE: the
+   * window is applied after fetching all invoices from QBO, so it bounds what
+   * gets written locally — not the QBO API pull.
    */
-  async syncAllInvoices(opts?: { since?: string; dryRun?: boolean }): Promise<SyncResult> {
+  async syncAllInvoices(opts?: { since?: string; until?: string; dryRun?: boolean }): Promise<SyncResult> {
     const dryRun = opts?.dryRun ?? false;
     const result: SyncResult = {
       imported: 0,
@@ -406,6 +411,10 @@ export class InvoiceImportService extends DatabaseService {
     if (opts?.since) {
       const since = opts.since;
       qboInvoices = qboInvoices.filter((inv) => inv.TxnDate && inv.TxnDate >= since);
+    }
+    if (opts?.until) {
+      const until = opts.until;
+      qboInvoices = qboInvoices.filter((inv) => inv.TxnDate && inv.TxnDate <= until);
     }
 
     // Sort by TxnDate ASC so older invoices claim older work activities first.

--- a/src/components/Invoices.tsx
+++ b/src/components/Invoices.tsx
@@ -139,11 +139,15 @@ const Invoices: React.FC = () => {
   const [deleting, setDeleting] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [previewing, setPreviewing] = useState(false);
+  const [sinceDate, setSinceDate] = useState('');
+  const [untilDate, setUntilDate] = useState('');
   const [syncResult, setSyncResult] = useState<SyncResult | null>(null);
   const [syncModalOpen, setSyncModalOpen] = useState(false);
   const [errorsExpanded, setErrorsExpanded] = useState(false);
   const [previewExpanded, setPreviewExpanded] = useState(false);
   const [duplicatesExpanded, setDuplicatesExpanded] = useState(false);
+  // The date window in effect when the last sync/preview ran (for the modal).
+  const [syncWindowLabel, setSyncWindowLabel] = useState('');
 
   useEffect(() => {
     fetchInvoices();
@@ -253,16 +257,23 @@ const Invoices: React.FC = () => {
     }
   };
 
+  // Both dates are optional; an inverted range is blocked client-side too.
+  const rangeInvalid = !!sinceDate && !!untilDate && sinceDate > untilDate;
+
   const runSync = async (dryRun: boolean) => {
     const setBusy = dryRun ? setPreviewing : setSyncing;
     try {
       setBusy(true);
       setError(null);
 
+      const body: { dryRun: boolean; since?: string; until?: string } = { dryRun };
+      if (sinceDate) body.since = sinceDate;
+      if (untilDate) body.until = untilDate;
+
       const response = await secureFetch('/api/qbo/invoices/sync-all', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ dryRun }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
@@ -271,6 +282,11 @@ const Invoices: React.FC = () => {
 
       const result: SyncResult = await response.json();
       setSyncResult(result);
+      setSyncWindowLabel(
+        sinceDate || untilDate
+          ? `Invoice date ${sinceDate || 'start'} → ${untilDate || 'today'}`
+          : 'All invoices'
+      );
       setSyncModalOpen(true);
       setErrorsExpanded(false);
       setPreviewExpanded(false);
@@ -416,30 +432,59 @@ const Invoices: React.FC = () => {
               Manage and track your QuickBooks invoices
             </Typography>
           </Box>
-          <Box sx={{ display: 'flex', gap: 1 }}>
-            <Button
-              variant="text"
-              startIcon={previewing ? <CircularProgress size={16} /> : <Visibility size={16} />}
-              onClick={previewSync}
-              disabled={syncing || previewing}
-            >
-              {previewing ? 'Previewing...' : 'Preview sync'}
-            </Button>
-            <Button
-              variant="outlined"
-              startIcon={syncing ? <CircularProgress size={16} /> : <Sync />}
-              onClick={syncAllInvoices}
-              disabled={syncing || previewing}
-            >
-              {syncing ? 'Syncing...' : 'Sync from QuickBooks'}
-            </Button>
-            <Button
-              variant="contained"
-              startIcon={<Add />}
-              onClick={() => navigate('/clients')}
-            >
-              Create Invoice
-            </Button>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.5 }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+              <TextField
+                label="From"
+                type="date"
+                size="small"
+                value={sinceDate}
+                onChange={(e) => setSinceDate(e.target.value)}
+                disabled={syncing || previewing}
+                error={rangeInvalid}
+                InputLabelProps={{ shrink: true }}
+                sx={{ width: 160 }}
+              />
+              <TextField
+                label="To"
+                type="date"
+                size="small"
+                value={untilDate}
+                onChange={(e) => setUntilDate(e.target.value)}
+                disabled={syncing || previewing}
+                error={rangeInvalid}
+                InputLabelProps={{ shrink: true }}
+                sx={{ width: 160 }}
+              />
+              <Button
+                variant="text"
+                startIcon={previewing ? <CircularProgress size={16} /> : <Visibility size={16} />}
+                onClick={previewSync}
+                disabled={syncing || previewing || rangeInvalid}
+              >
+                {previewing ? 'Previewing...' : 'Preview sync'}
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={syncing ? <CircularProgress size={16} /> : <Sync />}
+                onClick={syncAllInvoices}
+                disabled={syncing || previewing || rangeInvalid}
+              >
+                {syncing ? 'Syncing...' : 'Sync from QuickBooks'}
+              </Button>
+              <Button
+                variant="contained"
+                startIcon={<Add />}
+                onClick={() => navigate('/clients')}
+              >
+                Create Invoice
+              </Button>
+            </Box>
+            <Typography variant="caption" color={rangeInvalid ? 'error' : 'text.secondary'}>
+              {rangeInvalid
+                ? '“From” must be on or before “To”.'
+                : 'Optional: limit sync to an invoice-date window. Leave blank to sync all.'}
+            </Typography>
           </Box>
         </Box>
 
@@ -809,6 +854,9 @@ const Invoices: React.FC = () => {
             {syncResult?.dryRun ? 'QuickBooks sync preview' : 'QuickBooks sync complete'}
           </DialogTitle>
           <DialogContent>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Scope: <strong>{syncWindowLabel}</strong>
+            </Typography>
             {syncResult?.dryRun && (
               <Alert severity="info" sx={{ mb: 2 }}>
                 This is a preview — <strong>no changes were made</strong>. The numbers


### PR DESCRIPTION
## What

Adds an optional **From / To invoice-date window** to the QuickBooks sync, so a sync can be bounded to a slice of invoices instead of always pulling everything.

Pairs with the existing dry-run preview to make the safe first-run workflow first-class: **narrow the window → preview → commit just that slice.**

## Changes

- **`InvoiceImportService.syncAllInvoices`** now accepts `until` alongside the existing `since`, applied as a second `TxnDate` filter (`since <= TxnDate <= until`). Both ends optional.
- **Route `/api/qbo/invoices/sync-all`** validates `until` as `YYYY-MM-DD` and rejects `since > until` with a 400.
- **Invoices page UI**: two `date` inputs next to the Preview / Sync buttons, wired into both the preview and the real sync. An inverted range is blocked client-side (buttons disabled + inline hint), and the results modal shows the scope that actually ran.

## Notes / caveats

- The window bounds **what gets written locally**, not the QBO API pull — `getAllInvoices()` still fetches the full list, then the window filters it. Good for limiting blast radius; doesn't reduce QBO quota. (A server-side QBO query filter would be a separate follow-up.)
- Leaving both fields blank preserves the prior "sync everything" behavior.

## Testing

- `server` + frontend `tsc --noEmit`: clean
- `invoiceImportService` unit tests: 23/23 pass
- The sync orchestration itself remains without DB-backed integration coverage (pre-existing gap noted on the prior PR) — manual verification recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)