### PR TITLE
QBO: surname matching + client↔customer mapping UI

### DIFF
--- a/server/src/__tests__/clientMatching.test.ts
+++ b/server/src/__tests__/clientMatching.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@jest/globals';
+import { nameTokens, matchClientsByName } from '../services/clientMatching';
+
+const clients = (names: string[]) => names.map((name, i) => ({ id: i + 1, name }));
+
+describe('nameTokens', () => {
+  it('lowercases, splits on non-alphanumerics, drops joiners', () => {
+    expect(nameTokens('Steve and Jackie Thomas')).toEqual(['steve', 'jackie', 'thomas']);
+    expect(nameTokens('St. Clair')).toEqual(['st', 'clair']);
+    expect(nameTokens('Erickson Realty')).toEqual(['erickson', 'realty']);
+  });
+
+  it('returns empty for null/empty', () => {
+    expect(nameTokens(null)).toEqual([]);
+    expect(nameTokens('')).toEqual([]);
+  });
+});
+
+describe('matchClientsByName', () => {
+  it('matches a single surname inside a couple name', () => {
+    const out = matchClientsByName('Steve and Jackie Thomas', clients(['Thomas', 'Foley', 'Erickson']));
+    expect(out.map((c) => c.name)).toEqual(['Thomas']);
+  });
+
+  it('returns BOTH surnames for a two-surname couple (ambiguous)', () => {
+    const out = matchClientsByName('Matt Leid and Kourtney Foley', clients(['Leid', 'Foley', 'Thomas']));
+    expect(out.map((c) => c.name).sort()).toEqual(['Foley', 'Leid']);
+  });
+
+  it('matches a business name by its distinctive token', () => {
+    const out = matchClientsByName('Erickson Realty', clients(['Erickson', 'Thomas']));
+    expect(out.map((c) => c.name)).toEqual(['Erickson']);
+  });
+
+  it('is whole-token, not substring', () => {
+    // "Smith" must NOT match "Blacksmith".
+    const out = matchClientsByName('Blacksmith Landscaping', clients(['Smith']));
+    expect(out).toEqual([]);
+  });
+
+  it('flags two CRM clients sharing a surname as ambiguous', () => {
+    const out = matchClientsByName('John Thomas', clients(['Thomas', 'Thomas']));
+    expect(out).toHaveLength(2);
+  });
+
+  it('returns nothing when no surname appears', () => {
+    expect(matchClientsByName('Erickson Realty', clients(['Thomas', 'Foley']))).toEqual([]);
+  });
+
+  it('matches multi-word client names only when all tokens are present', () => {
+    expect(matchClientsByName('Jane St Clair', clients(['St Clair'])).map((c) => c.name)).toEqual(['St Clair']);
+    expect(matchClientsByName('Jane Clair', clients(['St Clair']))).toEqual([]);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchClientsByName('STEVE AND JACKIE THOMAS', clients(['thomas'])).map((c) => c.name)).toEqual(['thomas']);
+  });
+
+  it('ignores empty client names', () => {
+    expect(matchClientsByName('Steve Thomas', clients(['', 'Thomas'])).map((c) => c.name)).toEqual(['Thomas']);
+  });
+});

--- a/server/src/routes/quickbooks.ts
+++ b/server/src/routes/quickbooks.ts
@@ -151,6 +151,49 @@ router.post('/customers/sync', async (req, res) => {
   }
 });
 
+/**
+ * Mapping table for linking QBO customers to local clients: every QBO customer
+ * with its current link + a suggested client (confident surname match).
+ */
+router.get('/customers/mapping', async (req, res) => {
+  try {
+    const state = await services.clientLinkService.getMappingState();
+    res.json(state);
+  } catch (error) {
+    console.error('Error building client mapping:', error);
+    res.status(500).json({ error: 'Failed to load client mapping' });
+  }
+});
+
+/**
+ * Persist client↔QBO-customer mappings. Body: { mappings: [{ qboCustomerId,
+ * clientId }] } where clientId null clears the link.
+ */
+router.post('/customers/mapping', async (req, res) => {
+  try {
+    const { mappings } = req.body ?? {};
+    if (!Array.isArray(mappings)) {
+      return res.status(400).json({ error: 'mappings (array) is required' });
+    }
+    for (const m of mappings) {
+      if (!m || typeof m.qboCustomerId !== 'string') {
+        return res.status(400).json({ error: 'each mapping needs a string qboCustomerId' });
+      }
+      if (m.clientId !== null && !Number.isInteger(m.clientId)) {
+        return res.status(400).json({ error: 'clientId must be an integer or null' });
+      }
+    }
+    const result = await services.clientLinkService.applyMappings(mappings);
+    res.json(result);
+  } catch (error) {
+    console.error('Error applying client mapping:', error);
+    res.status(500).json({
+      error: 'Failed to apply client mapping',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
 router.get('/items', async (req, res) => {
   try {
     const items = await invoiceService.getQBOItems();

--- a/server/src/services/ClientLinkService.ts
+++ b/server/src/services/ClientLinkService.ts
@@ -1,0 +1,145 @@
+import { DatabaseService } from './DatabaseService';
+import { clients } from '../db';
+import { eq } from 'drizzle-orm';
+import type { QuickBooksService } from './QuickBooksService';
+import { matchClientsByName } from './clientMatching';
+
+// A CRM client as exposed to the mapping UI.
+export type MappingClient = {
+  id: number;
+  name: string;
+  qboCustomerId: string | null;
+};
+
+// One QBO customer row in the mapping table.
+export type CustomerMappingRow = {
+  qboCustomerId: string;
+  qboName: string;
+  // Client currently linked to this QBO customer (qbo_customer_id == this id).
+  linkedClientId: number | null;
+  // Confident single surname match among currently-unlinked clients, if any.
+  suggestedClientId: number | null;
+  // All surname matches (>1 means ambiguous — e.g. a two-surname couple).
+  candidateClientIds: number[];
+};
+
+export type MappingState = {
+  clients: MappingClient[];
+  customers: CustomerMappingRow[];
+};
+
+// One change the operator wants to persist. clientId null clears the link.
+export type MappingChange = { qboCustomerId: string; clientId: number | null };
+
+export class ClientLinkService extends DatabaseService {
+  constructor(private readonly quickBooksService: QuickBooksService) {
+    super();
+  }
+
+  /**
+   * Build the mapping table: every QBO customer, its current local link, and a
+   * suggested client (confident single surname match among unlinked clients).
+   *
+   * Suggestion guard: a client suggested for two different customers, or a
+   * customer matching two clients, yields NO suggestion — those are left for
+   * manual resolution so we never auto-pick an ambiguous link.
+   */
+  async getMappingState(): Promise<MappingState> {
+    const [qboCustomers, clientRows] = await Promise.all([
+      this.quickBooksService.getAllCustomers(),
+      this.db
+        .select({ id: clients.id, name: clients.name, qboCustomerId: clients.qboCustomerId })
+        .from(clients)
+    ]);
+
+    const linkedByQboId = new Map<string, number>();
+    for (const c of clientRows) {
+      if (c.qboCustomerId) linkedByQboId.set(c.qboCustomerId, c.id);
+    }
+    const unlinkedClients = clientRows.filter((c) => !c.qboCustomerId);
+
+    // First pass: raw single-match suggestions.
+    const rows: CustomerMappingRow[] = qboCustomers.map((cust) => {
+      const matches = matchClientsByName(cust.DisplayName || '', unlinkedClients);
+      const linkedClientId = linkedByQboId.get(cust.Id) ?? null;
+      return {
+        qboCustomerId: cust.Id,
+        qboName: cust.DisplayName || '',
+        linkedClientId,
+        suggestedClientId: !linkedClientId && matches.length === 1 ? matches[0].id : null,
+        candidateClientIds: matches.map((m) => m.id)
+      };
+    });
+
+    // Second pass: drop suggestions that collide — the same client suggested to
+    // more than one customer can't be auto-applied to all of them.
+    const suggestCount = new Map<number, number>();
+    for (const r of rows) {
+      if (r.suggestedClientId != null) {
+        suggestCount.set(r.suggestedClientId, (suggestCount.get(r.suggestedClientId) ?? 0) + 1);
+      }
+    }
+    for (const r of rows) {
+      if (r.suggestedClientId != null && (suggestCount.get(r.suggestedClientId) ?? 0) > 1) {
+        r.suggestedClientId = null;
+      }
+    }
+
+    return { clients: clientRows, customers: rows };
+  }
+
+  /**
+   * Persist mapping changes. Each change sets (or clears) the qbo_customer_id on
+   * the chosen client. Runs in two phases inside one transaction — clear every
+   * affected QBO id / client first, then set — so the unique qbo_customer_id
+   * constraint never trips on a transient state mid-batch.
+   *
+   * Validates that no QBO customer and no client appears twice, since either
+   * would be a contradictory instruction.
+   */
+  async applyMappings(changes: MappingChange[]): Promise<{ applied: number }> {
+    const seenQbo = new Set<string>();
+    const seenClient = new Set<number>();
+    for (const ch of changes) {
+      if (seenQbo.has(ch.qboCustomerId)) {
+        throw new Error(`Duplicate QBO customer in request: ${ch.qboCustomerId}`);
+      }
+      seenQbo.add(ch.qboCustomerId);
+      if (ch.clientId != null) {
+        if (seenClient.has(ch.clientId)) {
+          throw new Error(`Client ${ch.clientId} mapped to more than one QBO customer`);
+        }
+        seenClient.add(ch.clientId);
+      }
+    }
+
+    await this.db.transaction(async (tx) => {
+      // Phase 1: free every QBO id and target client involved. Clearing both
+      // sides first means Phase 2 can never hit the unique qbo_customer_id
+      // constraint on a transient mid-batch state.
+      for (const ch of changes) {
+        await tx
+          .update(clients)
+          .set({ qboCustomerId: null, updatedAt: new Date() })
+          .where(eq(clients.qboCustomerId, ch.qboCustomerId));
+        if (ch.clientId != null) {
+          await tx
+            .update(clients)
+            .set({ qboCustomerId: null, updatedAt: new Date() })
+            .where(eq(clients.id, ch.clientId));
+        }
+      }
+      // Phase 2: apply the new links.
+      for (const ch of changes) {
+        if (ch.clientId != null) {
+          await tx
+            .update(clients)
+            .set({ qboCustomerId: ch.qboCustomerId, updatedAt: new Date() })
+            .where(eq(clients.id, ch.clientId));
+        }
+      }
+    });
+
+    return { applied: changes.length };
+  }
+}

--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -11,11 +11,12 @@ import {
   type OtherCharge,
   type MatchCandidateJSON
 } from '../db';
-import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne } from 'drizzle-orm';
+import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne, sql } from 'drizzle-orm';
 import type { QBOInvoice, QuickBooksService } from './QuickBooksService';
 import { workTypeMapping, type InvoiceService } from './InvoiceService';
 import type { WorkActivityService } from './WorkActivityService';
 import type { NotificationService } from './NotificationService';
+import { matchClientsByName } from './clientMatching';
 
 // ---------------------------------------------------------------------------
 // Scoring thresholds — top of file so they're easy to tune.
@@ -654,6 +655,31 @@ export class InvoiceImportService extends DatabaseService {
           );
         }
         return byName[0].id;
+      }
+    }
+
+    // 2.5) Surname fallback: CRM clients are stored by surname while QBO carries
+    // full names. Match the client name as a whole token inside the QBO name,
+    // considering only UNLINKED clients so explicit mappings are never
+    // overridden. Auto-link only on a unique match — a couple with two surnames,
+    // or two clients sharing a surname, is left for the client-mapping UI.
+    if (customerName.trim()) {
+      const candidates = (
+        await this.db
+          .select({ id: clients.id, name: clients.name, qboCustomerId: clients.qboCustomerId })
+          .from(clients)
+          .where(sql`lower(${customerName}) like '%' || lower(${clients.name}) || '%'`)
+      ).filter((c) => !c.qboCustomerId);
+      const matched = matchClientsByName(customerName, candidates);
+      if (matched.length === 1) {
+        // Backfill the link on a real run so future invoices match by id.
+        if (!dryRun) {
+          await this.db
+            .update(clients)
+            .set({ qboCustomerId, updatedAt: new Date() })
+            .where(eq(clients.id, matched[0].id));
+        }
+        return matched[0].id;
       }
     }
 

--- a/server/src/services/QuickBooksService.ts
+++ b/server/src/services/QuickBooksService.ts
@@ -32,6 +32,13 @@ export interface QBOItem {
   Active: boolean;
 }
 
+export interface QBOCustomer {
+  Id: string;
+  DisplayName: string;
+  Active?: boolean;
+  BillAddr?: { Line1?: string };
+}
+
 export interface QBOInvoice {
   Id: string;
   DocNumber: string;
@@ -433,12 +440,13 @@ export class QuickBooksService extends DatabaseService {
     });
   }
 
-  async getAllCustomers(): Promise<any[]> {
+  async getAllCustomers(): Promise<QBOCustomer[]> {
     await this.ensureClient();
     return new Promise((resolve, reject) => {
-      this.qbo.findCustomers({}, (err: any, customers: any) => {
+      // fetchAll so we page past QBO's default result cap.
+      this.qbo.findCustomers({ fetchAll: true }, (err: any, customers: any) => {
         if (err) return reject(err);
-        const customerList = customers.QueryResponse?.Customer || [];
+        const customerList = (customers.QueryResponse?.Customer || []) as QBOCustomer[];
         console.log(`getAllCustomers: Found ${customerList.length} customers`);
         resolve(customerList);
       });

--- a/server/src/services/clientMatching.ts
+++ b/server/src/services/clientMatching.ts
@@ -1,0 +1,47 @@
+// Pure helpers for matching QBO customers to local CRM clients.
+//
+// Context: CRM clients are stored by surname only (e.g. "Thomas"), while QBO
+// customers carry full display names ("Steve and Jackie Thomas", "Erickson
+// Realty", "Matt Leid and Kourtney Foley"). Exact-name matching therefore never
+// works. These helpers match a client's name as a whole *token* inside the QBO
+// display name, and return ALL matches so callers can apply a single-candidate
+// guard (a couple with two surnames, or two clients sharing a surname, is
+// ambiguous and must not be auto-linked).
+
+export type ClientNameRecord = { id: number; name: string };
+
+// Joiner words that should never count as a surname token.
+const JOINERS = new Set(['and', 'or', 'the', 'of']);
+
+/**
+ * Split a name into lowercased alphanumeric tokens, dropping joiner words.
+ * "Steve and Jackie Thomas" -> ["steve", "jackie", "thomas"]
+ * "St. Clair"               -> ["st", "clair"]
+ */
+export function nameTokens(s: string | null | undefined): string[] {
+  if (!s) return [];
+  return s
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .filter((t) => t.length > 0 && !JOINERS.has(t));
+}
+
+/**
+ * Return every client whose name appears as a whole token (or, for multi-word
+ * names, all of whose tokens appear) inside the QBO display name. Whole-token,
+ * not substring — "Smith" does NOT match "Blacksmith".
+ *
+ * Callers apply the single-candidate guard: exactly one match -> link; zero or
+ * more than one -> leave for manual mapping.
+ */
+export function matchClientsByName<T extends ClientNameRecord>(
+  qboName: string,
+  clients: T[]
+): T[] {
+  const tokens = new Set(nameTokens(qboName));
+  if (tokens.size === 0) return [];
+  return clients.filter((c) => {
+    const ct = nameTokens(c.name);
+    return ct.length > 0 && ct.every((t) => tokens.has(t));
+  });
+}

--- a/server/src/services/container.ts
+++ b/server/src/services/container.ts
@@ -25,6 +25,7 @@ import { SettingsService } from './SettingsService';
 import { QuickBooksService } from './QuickBooksService';
 import { InvoiceService } from './InvoiceService';
 import { InvoiceImportService } from './InvoiceImportService';
+import { ClientLinkService } from './ClientLinkService';
 import { DataMigrationService } from './DataMigrationService';
 import { GoogleSheetsService } from './GoogleSheetsService';
 import { GoogleCalendarService } from './GoogleCalendarService';
@@ -52,6 +53,7 @@ class ServiceContainer {
   private _quickBooksService?: QuickBooksService;
   private _invoiceService?: InvoiceService;
   private _invoiceImportService?: InvoiceImportService;
+  private _clientLinkService?: ClientLinkService;
 
   // Google services
   private _googleSheetsService?: GoogleSheetsService;
@@ -130,6 +132,10 @@ class ServiceContainer {
       this.workActivityService,
       this.notificationService
     );
+  }
+
+  get clientLinkService(): ClientLinkService {
+    return this._clientLinkService ??= new ClientLinkService(this.quickBooksService);
   }
 
   // Google services

--- a/src/components/ClientMappingDialog.tsx
+++ b/src/components/ClientMappingDialog.tsx
@@ -1,0 +1,317 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Alert,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  FormControlLabel,
+  Switch,
+  Autocomplete,
+} from '@mui/material';
+import { secureFetch } from '../services/csrf';
+
+// Mirror of server/src/services/ClientLinkService types.
+interface MappingClient {
+  id: number;
+  name: string;
+  qboCustomerId: string | null;
+}
+
+interface CustomerMappingRow {
+  qboCustomerId: string;
+  qboName: string;
+  linkedClientId: number | null;
+  suggestedClientId: number | null;
+  candidateClientIds: number[];
+}
+
+interface MappingState {
+  clients: MappingClient[];
+  customers: CustomerMappingRow[];
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ClientMappingDialog: React.FC<Props> = ({ open, onClose }) => {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedNote, setSavedNote] = useState<string | null>(null);
+  const [clients, setClients] = useState<MappingClient[]>([]);
+  const [customers, setCustomers] = useState<CustomerMappingRow[]>([]);
+  // qboCustomerId -> chosen clientId (null = unmapped)
+  const [selection, setSelection] = useState<Record<string, number | null>>({});
+  const [filterText, setFilterText] = useState('');
+  const [onlyAttention, setOnlyAttention] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSavedNote(null);
+    try {
+      const resp = await fetch('/api/qbo/customers/mapping', { credentials: 'include' });
+      if (!resp.ok) throw new Error(`Failed to load mapping (${resp.status})`);
+      const data: MappingState = await resp.json();
+      setClients(data.clients);
+      setCustomers(data.customers);
+      // Pre-fill with the current link, or a confident suggestion.
+      const init: Record<string, number | null> = {};
+      for (const c of data.customers) {
+        init[c.qboCustomerId] = c.linkedClientId ?? c.suggestedClientId ?? null;
+      }
+      setSelection(init);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load client mapping');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) load();
+  }, [open, load]);
+
+  const clientById = useMemo(() => {
+    const m: Record<number, MappingClient> = {};
+    for (const c of clients) m[c.id] = c;
+    return m;
+  }, [clients]);
+
+  // Clients currently chosen in any row — used to prevent picking one client
+  // for two customers (which the server would reject).
+  const selectedClientIds = useMemo(() => {
+    const s = new Set<number>();
+    for (const id of Object.values(selection)) if (id != null) s.add(id);
+    return s;
+  }, [selection]);
+
+  const setRow = (qboCustomerId: string, clientId: number | null) => {
+    setSelection((prev) => ({ ...prev, [qboCustomerId]: clientId }));
+    setSavedNote(null);
+  };
+
+  const acceptAllSuggestions = () => {
+    setSelection((prev) => {
+      const next = { ...prev };
+      const taken = new Set(selectedClientIds);
+      for (const c of customers) {
+        if (
+          c.linkedClientId == null &&
+          c.suggestedClientId != null &&
+          next[c.qboCustomerId] == null &&
+          !taken.has(c.suggestedClientId)
+        ) {
+          next[c.qboCustomerId] = c.suggestedClientId;
+          taken.add(c.suggestedClientId);
+        }
+      }
+      return next;
+    });
+    setSavedNote(null);
+  };
+
+  const dirtyChanges = useMemo(
+    () =>
+      customers
+        .filter((c) => (selection[c.qboCustomerId] ?? null) !== (c.linkedClientId ?? null))
+        .map((c) => ({ qboCustomerId: c.qboCustomerId, clientId: selection[c.qboCustomerId] ?? null })),
+    [customers, selection]
+  );
+
+  const save = async () => {
+    if (dirtyChanges.length === 0) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const resp = await secureFetch('/api/qbo/customers/mapping', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mappings: dirtyChanges }),
+      });
+      if (!resp.ok) {
+        let msg = `Save failed (${resp.status})`;
+        try {
+          const d = await resp.json();
+          msg = d.details || d.error || msg;
+        } catch {
+          /* ignore */
+        }
+        throw new Error(msg);
+      }
+      const note = `Saved ${dirtyChanges.length} mapping${dirtyChanges.length === 1 ? '' : 's'}.`;
+      await load(); // refresh linked state
+      setSavedNote(note);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save mappings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const rowStatus = (c: CustomerMappingRow) => {
+    const sel = selection[c.qboCustomerId] ?? null;
+    const orig = c.linkedClientId ?? null;
+    if (sel !== orig) {
+      return sel != null
+        ? { label: 'will link', color: 'primary' as const }
+        : { label: 'will unlink', color: 'warning' as const };
+    }
+    if (sel != null) return { label: 'linked', color: 'success' as const };
+    if (c.candidateClientIds.length > 1) return { label: 'ambiguous', color: 'warning' as const };
+    return { label: 'no match', color: 'default' as const };
+  };
+
+  const visibleCustomers = useMemo(() => {
+    const ft = filterText.trim().toLowerCase();
+    return customers.filter((c) => {
+      if (ft && !c.qboName.toLowerCase().includes(ft)) return false;
+      if (onlyAttention) {
+        const sel = selection[c.qboCustomerId] ?? null;
+        if (sel != null) return false; // already handled
+      }
+      return true;
+    });
+  }, [customers, filterText, onlyAttention, selection]);
+
+  const counts = useMemo(() => {
+    let linked = 0;
+    let attention = 0;
+    for (const c of customers) {
+      const sel = selection[c.qboCustomerId] ?? null;
+      if (sel != null) linked++;
+      else attention++;
+    }
+    return { linked, attention, total: customers.length };
+  }, [customers, selection]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Map clients to QuickBooks</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Each QuickBooks customer links to one CRM client. Confident surname matches are
+          pre-filled as suggestions — review them, resolve couples/businesses by hand, then save.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {savedNote && (
+          <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSavedNote(null)}>
+            {savedNote}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap', mb: 2 }}>
+              <Typography variant="body2">
+                {counts.linked}/{counts.total} mapped · {counts.attention} need attention
+              </Typography>
+              <Box sx={{ flex: 1 }} />
+              <TextField
+                size="small"
+                placeholder="Filter by customer…"
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                sx={{ width: 220 }}
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={onlyAttention}
+                    onChange={(e) => setOnlyAttention(e.target.checked)}
+                  />
+                }
+                label="Only unmapped"
+              />
+              <Button size="small" onClick={acceptAllSuggestions}>
+                Accept all suggestions
+              </Button>
+            </Box>
+
+            <Box sx={{ maxHeight: 440, overflowY: 'auto' }}>
+              {visibleCustomers.map((c) => {
+                const status = rowStatus(c);
+                const selId = selection[c.qboCustomerId] ?? null;
+                return (
+                  <Box
+                    key={c.qboCustomerId}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'divider',
+                    }}
+                  >
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="body2" noWrap title={c.qboName}>
+                        {c.qboName || '(unnamed)'}
+                      </Typography>
+                      <Typography variant="caption" color="text.disabled">
+                        QBO #{c.qboCustomerId}
+                      </Typography>
+                    </Box>
+                    <Chip label={status.label} size="small" color={status.color} sx={{ flexShrink: 0 }} />
+                    <Autocomplete
+                      size="small"
+                      options={clients}
+                      getOptionLabel={(o) => o.name}
+                      value={selId != null ? clientById[selId] ?? null : null}
+                      onChange={(_, val) => setRow(c.qboCustomerId, val ? val.id : null)}
+                      isOptionEqualToValue={(o, v) => o.id === v.id}
+                      getOptionDisabled={(o) => selectedClientIds.has(o.id) && o.id !== selId}
+                      renderInput={(params) => (
+                        <TextField {...params} placeholder="Choose client…" />
+                      )}
+                      sx={{ width: 260, flexShrink: 0 }}
+                    />
+                  </Box>
+                );
+              })}
+              {visibleCustomers.length === 0 && (
+                <Typography variant="body2" color="text.secondary" sx={{ py: 3, textAlign: 'center' }}>
+                  No customers match the current filter.
+                </Typography>
+              )}
+            </Box>
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          onClick={save}
+          disabled={saving || loading || dirtyChanges.length === 0}
+          startIcon={saving ? <CircularProgress size={16} /> : undefined}
+        >
+          {saving ? 'Saving…' : `Save${dirtyChanges.length ? ` (${dirtyChanges.length})` : ''}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ClientMappingDialog;

--- a/src/components/Invoices.tsx
+++ b/src/components/Invoices.tsx
@@ -56,6 +56,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { formatDateBriefPacific } from '../utils/dateUtils';
 import { secureFetch } from '../services/csrf';
+import ClientMappingDialog from './ClientMappingDialog';
 
 interface Invoice {
   id: number;
@@ -139,6 +140,7 @@ const Invoices: React.FC = () => {
   const [deleting, setDeleting] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [previewing, setPreviewing] = useState(false);
+  const [mappingOpen, setMappingOpen] = useState(false);
   const [syncResult, setSyncResult] = useState<SyncResult | null>(null);
   const [syncModalOpen, setSyncModalOpen] = useState(false);
   const [errorsExpanded, setErrorsExpanded] = useState(false);
@@ -434,6 +436,13 @@ const Invoices: React.FC = () => {
               {syncing ? 'Syncing...' : 'Sync from QuickBooks'}
             </Button>
             <Button
+              variant="text"
+              startIcon={<Business size={16} />}
+              onClick={() => setMappingOpen(true)}
+            >
+              Map clients
+            </Button>
+            <Button
               variant="contained"
               startIcon={<Add />}
               onClick={() => navigate('/clients')}
@@ -442,6 +451,8 @@ const Invoices: React.FC = () => {
             </Button>
           </Box>
         </Box>
+
+        <ClientMappingDialog open={mappingOpen} onClose={() => setMappingOpen(false)} />
 
         {error && (
           <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>


### PR DESCRIPTION
## Why

CRM clients are stored by **surname** (`Smith`), but QBO customers carry **full names** (`Steve and Jackie Thomas`, `Erickson Realty`, `Matt Leid and Kourtney Foley`). The importer only matched on exact name, so almost nothing linked → a wall of `unmatched_client` errors on sync.

## What

**Automatic surname matching (A)**
- `clientMatching.ts` — pure surname-token matcher. Whole-token, not substring (`Smith` ≠ `Blacksmith`); returns *all* matches so the caller applies a single-candidate guard. Unit-tested against the real shapes from the data: single surname, two-surname couple, business name, shared surname.
- `resolveClientId` gets a surname fallback that considers **only unlinked clients** (so it never overrides an explicit mapping), auto-links on a unique match, and backfills `qbo_customer_id` on real runs. Couples (two surnames) and shared surnames stay unmatched for manual mapping.

**Manual mapping UI (B)**
- New **"Map clients"** dialog on the Invoices page: every QBO customer in a row with a searchable client picker, confident suggestions pre-filled, status chips (`linked` / `will link` / `ambiguous` / `no match`), *Accept all suggestions*, and *Save* (changed rows only). This is how you resolve the couples and businesses by hand.
- `ClientLinkService`: `getMappingState()` builds the table with collision-guarded suggestions; `applyMappings()` persists in a **two-phase transaction** (clear, then set) so the unique `qbo_customer_id` index never trips mid-batch. Rejects duplicate customer/client instructions.
- Routes: `GET` / `POST /api/qbo/customers/mapping`.
- `QuickBooksService.getAllCustomers` now pages with `fetchAll` and has a `QBOCustomer` type.

## How they fit together

Map once via the UI (or let the surname fallback auto-link the clean ones on a sync) → from then on invoices match by **ID**, exact and permanent. The fallback handles stragglers; the UI handles everything ambiguous.

## Safeguards
- Auto-link only on a **unique** surname match; couples/duplicates never guessed.
- Surname fallback ignores already-linked clients, so manual mappings win.
- Apply is transactional and respects the unique index; won't create duplicate links.

## Testing
- `clientMatching` unit tests: 11/11 (incl. the couple/business/shared-surname cases). Full server + frontend `tsc` clean.
- `ClientLinkService` / mapping routes have no DB-backed integration test yet (same orchestration-coverage gap noted on prior PRs) — verify against a real QBO connection.

> Recommended first run: open **Map clients**, hit *Accept all suggestions*, eyeball, save; then resolve the couples/businesses by hand; then dry-run the invoice sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)