### PR TITLE
QBO invoice matcher: include needs_review activities as candidates

### DIFF
--- a/server/src/services/InvoiceImportService.ts
+++ b/server/src/services/InvoiceImportService.ts
@@ -9,7 +9,8 @@ import {
   notifications,
   type WorkActivity,
   type OtherCharge,
-  type MatchCandidateJSON
+  type MatchCandidateJSON,
+  type WorkActivityStatus
 } from '../db';
 import { and, asc, eq, gte, ilike, inArray, isNotNull, lte, ne } from 'drizzle-orm';
 import type { QBOInvoice, QuickBooksService } from './QuickBooksService';
@@ -26,6 +27,14 @@ const MIN_THRESHOLD = 2;
 
 // 90-day candidate window around the invoice date.
 const CANDIDATE_WINDOW_DAYS = 90;
+
+// Work-activity statuses the matcher will consider as invoice candidates.
+// 'completed' = finished work; 'needs_review' = work logged but pending approval
+// (e.g. fresh Notion imports) — both represent work that actually happened.
+// Deliberately excludes 'invoiced' (already billed, must not re-match),
+// 'planned' and 'in_progress' (not done — billing those, and flipping them to
+// 'invoiced' on a match, would be wrong).
+const MATCHABLE_ACTIVITY_STATUSES: WorkActivityStatus[] = ['completed', 'needs_review'];
 
 // Stopwords used by the token-overlap scorer. Tiny on purpose — the matcher
 // needs to ignore noise words, not be a full NLP stack.
@@ -712,14 +721,14 @@ export class InvoiceImportService extends DatabaseService {
   ): Promise<MatcherOutput<K>> {
     const windowStart = shiftDate(invoiceDate, -CANDIDATE_WINDOW_DAYS);
 
-    // Candidate activities: same client, completed, within window.
+    // Candidate activities: same client, matchable status, within window.
     const candidateActivities = (await this.db
       .select()
       .from(workActivities)
       .where(
         and(
           eq(workActivities.clientId, clientId),
-          eq(workActivities.status, 'completed'),
+          inArray(workActivities.status, MATCHABLE_ACTIVITY_STATUSES),
           gte(workActivities.date, windowStart),
           lte(workActivities.date, invoiceDate)
         )


### PR DESCRIPTION
## Why

The invoice matcher only considered work activities with `status = 'completed'`. But Notion-synced activities are imported as **`needs_review`** and stay there until approved — so they were invisible to the matcher, and their invoice lines all came back **`unmatched`**.

## What

Widen the candidate query from a single status to:

```ts
const MATCHABLE_ACTIVITY_STATUSES = ['completed', 'needs_review'];
```

Both represent **work that actually happened**. Deliberately still excludes:
- `invoiced` — already billed; must not re-match
- `planned` / `in_progress` — not done; billing those (and flipping them to `invoiced` on a match) would be wrong

One-line change to the `runMatcher` candidate query (used by both initial sync and rematch), plus the named constant + a comment explaining the choice.

## Behaviour note

A `needs_review` activity that auto-matches now flips to `invoiced` — i.e. matching it to an invoice effectively bypasses the manual review step. On a later unmatch, `revertOrphanedActivities` returns it to `completed` (not back to `needs_review`). Both are reasonable, but flagging them since they're subtle.

## Testing
- Server `tsc` clean; 23 `invoiceImportService` unit tests pass.
- The candidate query lives in `runMatcher`, which has no DB-backed integration test (existing orchestration-coverage gap) — verify via a dry-run **Preview sync** that previously-unmatched invoices now match.

> After this lands: re-run a dry-run sync (or per-invoice rematch) on a client whose work was stuck in `needs_review` and confirm the lines now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)