### PR TITLE
Add CI guard against bare fetch() writes (CSRF regression)

### DIFF
--- a/.eslintrc.csrf.json
+++ b/.eslintrc.csrf.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "ignorePatterns": ["src/config/api.ts", "src/services/csrf.ts", "src/services/api.ts"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "module",
+    "ecmaFeatures": { "jsx": true }
+  },
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name='fetch'] > ObjectExpression > Property[key.name='method']",
+        "message": "Use secureFetch from src/services/csrf.ts for state-changing requests. A bare fetch() with a method sends no X-CSRF-Token header and returns 403 (EBADCSRFTOKEN) in production."
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
         
     - name: Install frontend dependencies
       run: npm ci
-      
+
+    - name: CSRF guard — no bare fetch() writes (must use secureFetch)
+      run: npm run lint:csrf
+
     - name: Run frontend tests
       run: npm test -- --watchAll=false --coverage --passWithNoTests
       

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dev": "concurrently \"npm run server\" \"npm start\"",
     "server": "cd server && npm run dev",
     "type-check": "tsc --noEmit",
+    "lint:csrf": "eslint --no-eslintrc --no-inline-config -c .eslintrc.csrf.json --ext .ts,.tsx src",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Why

Bare `fetch()` with a method sends no `X-CSRF-Token` and 403s (`EBADCSRFTOKEN`) in production. This bug has now surfaced **three times** (QBO buttons → invoice review → all the edit forms in #72). A lint guard makes it un-reintroducible.

## What

- **`.eslintrc.csrf.json`** — isolated, single-rule config:
  ```
  CallExpression[callee.name='fetch'] > ObjectExpression > Property[key.name='method']
  ```
  Flags any `fetch(url, { method: ... })` (and the shorthand `{ method }` form). Ignores the sanctioned wrappers that legitimately attach the token: `config/api.ts`, `services/csrf.ts`, `services/api.ts`.
- **`lint:csrf`** npm script — runs with `--no-inline-config` so the guard can't be silenced with an inline `eslint-disable`.
- **CI** — runs `npm run lint:csrf` in the frontend job, so a violating PR fails.

Kept deliberately **separate from the CRA `eslintConfig`** — adding it there would make the build itself flag the legitimate `apiClient` wrapper in `config/api.ts` and require override juggling. The dedicated config is cleaner and the CI step is the real enforcement.

Verified: flags a bare `fetch(x, {method})`, passes `secureFetch(x, {method})` and bare GETs, and runs clean against current `src`.

## ⚠️ Stacked on #72

This is based on **`mynock/csrf-secure-writes` (#72)**, not `main`, because the guard would (correctly) fail on plain `main` — main still contains the bare-fetch writes that #72 fixes. Merge #72 first; GitHub will then auto-retarget this PR to `main` and its diff stays just these 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)