### PR TITLE
ClientDetail: surface Create Invoice button in the header

### DIFF
--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -37,6 +37,7 @@ import {
   TableCell,
   IconButton,
   Autocomplete,
+  Tooltip,
 } from '@mui/material';
 import {
   ArrowLeft as ArrowBackIcon,
@@ -717,9 +718,30 @@ const ClientDetail: React.FC = () => {
             />
           </h1>
         </div>
-        <Button startIcon={<EditIcon />} variant="contained" onClick={handleEdit}>
-          Edit client
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+          <Tooltip
+            title={
+              readyToInvoiceActivities.length === 0
+                ? 'No completed work activities with billable hours to invoice'
+                : ''
+            }
+          >
+            {/* span wrapper so the tooltip works while the button is disabled */}
+            <span>
+              <Button
+                startIcon={<AttachMoneyIcon />}
+                variant="outlined"
+                onClick={() => setShowInvoiceDialog(true)}
+                disabled={readyToInvoiceActivities.length === 0}
+              >
+                Create Invoice
+              </Button>
+            </span>
+          </Tooltip>
+          <Button startIcon={<EditIcon />} variant="contained" onClick={handleEdit}>
+            Edit client
+          </Button>
+        </Box>
       </div>
 
       {/* Client Information */}


### PR DESCRIPTION
## Why

The **Create Invoice** button only lived in the "Ready to Invoice" card, which renders *below* the full Work Activities list. On a client with many activities (e.g. Silver, 11), it's pushed well down the page and is easy to miss — it looked like the button was gone.

## What

Add a second **Create Invoice** button to the header, next to **Edit client** — always visible without scrolling.

- Same action as the existing button (`setShowInvoiceDialog(true)`)
- Same enabled condition (`readyToInvoiceActivities.length > 0` → completed activities with billable hours)
- Tooltip explains the disabled state ("No completed work activities with billable hours to invoice")
- `outlined` variant so it reads as secondary to the primary `Edit client`

Single-file change. Frontend `tsc` clean.

## Still open (your call)

The enabled condition counts only `status === 'completed'` activities — same as before. We recently widened the QBO invoice *matcher* to also consider `needs_review` (#71). If you want the invoice UI to agree with the matcher, I can include `needs_review` in "ready to invoice" too — say the word and I'll do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)